### PR TITLE
Create coin stake

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -277,9 +277,7 @@ libunite_wallet_a_CPPFLAGS = $(AM_CPPFLAGS) $(UNITE_INCLUDES)
 libunite_wallet_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libunite_wallet_a_SOURCES = \
   address/address.cpp \
-  esperanza/config.cpp \
   esperanza/kernel.cpp \
-  esperanza/params.cpp \
   esperanza/validation.cpp \
   esperanza/miner.cpp \
   esperanza/init.cpp \
@@ -375,6 +373,7 @@ libunite_common_a_SOURCES = \
   core_read.cpp \
   core_write.cpp \
   esperanza/config.cpp \
+  esperanza/params.cpp \
   key.cpp \
   keystore.cpp \
   netaddress.cpp \

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -91,11 +91,13 @@ public:
     //! Esperanza Proof-of-Stake parameters
     const esperanza::Params& EsperanzaParams() const;
 
+
+
 protected:
     CChainParams() {}
 
     Consensus::Params consensus;
-    esperanza::Params m_esperanzaParams;
+    esperanza::Params m_esperanzaParams = esperanza::Params(this);
     CMessageHeader::MessageStartChars pchMessageStart;
     int nDefaultPort;
     uint64_t nPruneAfterHeight;

--- a/src/esperanza/params.cpp
+++ b/src/esperanza/params.cpp
@@ -2,33 +2,62 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-
 #include <esperanza/params.h>
+
+#include <chainparams.h>
+#include <util.h>
+#include <utilmoneystr.h>
 
 namespace esperanza {
 
-uint32_t Params::GetModifierInterval() const {
-  return m_modifierInterval;
+Params::Params(const CChainParams *chainParams) : m_chainParams(chainParams) {
+  assert(chainParams != nullptr);
 }
+
+uint32_t Params::GetModifierInterval() const { return m_modifierInterval; }
 
 uint32_t Params::GetStakeMinConfirmations() const {
   return m_stakeMinConfirmations;
 }
 
-uint32_t Params::GetTargetSpacing() const {
-  return m_targetSpacing;
-}
+uint32_t Params::GetTargetSpacing() const { return m_targetSpacing; }
 
-uint32_t Params::GetTargetTimespan() const {
-  return m_targetTimespan;
-}
+uint32_t Params::GetTargetTimespan() const { return m_targetTimespan; }
 
 uint32_t Params::GetStakeTimestampMask(int nHeight) const {
   return m_stakeTimestampMask;
 }
 
-uint32_t Params::GetLastImportHeight() const {
-  return m_lastImportHeight;
+int64_t Params::GetCoinYearReward(int64_t nTime) const {
+  static const int64_t nSecondsInYear = 365 * 24 * 60 * 60;
+
+  if (m_chainParams->NetworkIDString() != "regtest") {
+    // Y1 5%, Y2 4%, Y3 3%, Y4 2%, ... YN 2%
+    int64_t nYearsSinceGenesis =
+        (nTime - m_chainParams->GenesisBlock().nTime) / nSecondsInYear;
+
+    if (nYearsSinceGenesis >= 0 && nYearsSinceGenesis < 3) {
+      return (5 - nYearsSinceGenesis) * EEES;
+    }
+  }
+
+  return m_coinYearReward;
 }
 
-} // namespace esperanza
+int64_t Params::GetProofOfStakeReward(const CBlockIndex *pindexPrev,
+                                      int64_t nFees) const {
+  int64_t nSubsidy;
+
+  nSubsidy = (pindexPrev->nMoneySupply / UNIT) *
+             GetCoinYearReward(pindexPrev->nTime) /
+             (365 * 24 * (60 * 60 / m_targetSpacing));
+
+  if (LogAcceptCategory(BCLog::POS) &&
+      gArgs.GetBoolArg("-printcreation", false))
+    LogPrintf("GetProofOfStakeReward(): create=%s\n",
+              FormatMoney(nSubsidy).c_str());
+
+  return nSubsidy + nFees;
+}
+
+}  // namespace esperanza

--- a/src/esperanza/params.h
+++ b/src/esperanza/params.h
@@ -7,6 +7,9 @@
 #define UNITE_ESPERANZA_PARAMS_H
 
 #include <stdint.h>
+#include <chain.h>
+
+class CChainParams;
 
 namespace esperanza {
 
@@ -16,6 +19,9 @@ namespace esperanza {
 class Params final {
 
  private:
+
+  //! chain params these params are embedded in
+  const ::CChainParams *m_chainParams;
 
   //! seconds to elapse before new modifier is computed
   uint32_t m_modifierInterval;
@@ -33,7 +39,11 @@ class Params final {
 
   uint32_t m_lastImportHeight;
 
+  int64_t m_coinYearReward = 2 * EEES; // 2% per year
+
  public:
+
+  Params(const CChainParams *chainParams);
 
   uint32_t GetModifierInterval() const;
 
@@ -46,6 +56,10 @@ class Params final {
   uint32_t GetStakeTimestampMask(int nHeight) const;
 
   uint32_t GetLastImportHeight() const;
+
+  int64_t GetCoinYearReward(int64_t nTime) const;
+
+  int64_t GetProofOfStakeReward(const CBlockIndex *pindexPrev, int64_t nFees) const;
 
 };
 

--- a/src/esperanza/stakethread.cpp
+++ b/src/esperanza/stakethread.cpp
@@ -83,8 +83,6 @@ void StakeThread::Start(size_t nThreadID, std::vector<CWallet *> &vpwallets,
   int nBestHeight;  // TODO: set from new block signal?
   int64_t nBestTime;
 
-  int nLastImportHeight = ::Params().EsperanzaParams().GetLastImportHeight();
-
   if (!esperanza::g_config.m_staking) {
     LogPrint(BCLog::POS, "%s: -staking is false.\n", __func__);
     return;
@@ -203,14 +201,6 @@ void StakeThread::Start(size_t nThreadID, std::vector<CWallet *> &vpwallets,
           m_isStaking = false;
           nWaitFor = std::min(nWaitFor, (size_t)m_minerSleep);
           LogPrint(BCLog::POS, "%s: Couldn't create new block.\n", __func__);
-          continue;
-        }
-
-        if (nBestHeight + 1 <= nLastImportHeight &&
-            !ImportOutputs(pblocktemplate.get(), nBestHeight + 1)) {
-          m_isStaking = false;
-          nWaitFor = std::min(nWaitFor, (size_t)30000);
-          LogPrint(BCLog::POS, "%s: ImportOutputs failed.\n", __func__);
           continue;
         }
       }

--- a/src/esperanza/validation.cpp
+++ b/src/esperanza/validation.cpp
@@ -15,6 +15,52 @@ static const size_t MAX_STAKE_SEEN_SIZE = 1000;
 static std::map<COutPoint, uint256> mapStakeSeen;
 static std::list<COutPoint> listStakeSeen;
 
+bool HasIsCoinstakeOp(const CScript &scriptIn) {
+  CScript::const_iterator pc = scriptIn.begin();
+
+  if (pc == scriptIn.end()) {
+    return false;
+  }
+  opcodetype opcode;
+  std::vector<unsigned char> vchPushValue;
+
+  if (!scriptIn.GetOp(pc, opcode, vchPushValue)) {
+    return false;
+  }
+  return opcode == OP_ISCOINSTAKE;
+}
+
+bool GetCoinstakeScriptPath(const CScript &scriptIn, CScript &scriptOut)
+{
+  CScript::const_iterator pc = scriptIn.begin();
+  CScript::const_iterator pend = scriptIn.end();
+  CScript::const_iterator pcStart = pc;
+
+  opcodetype opcode;
+  std::vector<unsigned char> pushValue;
+
+  bool foundOp = false;
+  while (pc < pend) {
+    if (!scriptIn.GetOp(pc, opcode, pushValue)) {
+      break;
+    }
+    if (!foundOp && opcode == OP_ISCOINSTAKE) {
+      pc++; // skip over if
+
+      pcStart = pc;
+      foundOp = true;
+      continue;
+    }
+    if (foundOp && opcode == OP_ELSE) {
+      pc--;
+      scriptOut = CScript(pcStart, pc);
+      return true;
+    }
+  }
+
+  return false;
+}
+
 bool AddToMapStakeSeen(const COutPoint &kernel, const uint256 &blockHash) {
   // Overwrites existing values
 

--- a/src/esperanza/validation.h
+++ b/src/esperanza/validation.h
@@ -11,6 +11,10 @@
 
 namespace esperanza {
 
+bool HasIsCoinstakeOp(const CScript &scriptIn);
+
+bool GetCoinstakeScriptPath(const CScript &scriptIn, CScript &scriptOut);
+
 bool CheckStakeUnused(const COutPoint &kernel);
 
 bool CheckStakeUnique(const CBlock &block, bool update);

--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -5,14 +5,19 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <esperanza/kernel.h>
 #include <esperanza/miner.h>
 #include <esperanza/validation.h>
 #include <esperanza/walletextension.h>
+#include <script/standard.h>
 #include <utilfun.h>
 #include <validation.h>
 #include <wallet/wallet.h>
 
 namespace esperanza {
+
+//! UNIT-E: check necessity of this constant
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 1000000;
 
 WalletExtension::WalletExtension(::CWallet *enclosingWallet)
     : m_enclosingWallet(enclosingWallet) {
@@ -49,8 +54,9 @@ void WalletExtension::AvailableCoinsForStaking(std::vector<::COutput> &vCoins) {
     LOCK2(cs_main, m_enclosingWallet->cs_wallet);
 
     int height = chainActive.Tip()->nHeight;
-    int requiredDepth =
-        std::min<int>(Params().GetStakeMinConfirmations() - 1, height / 2);
+    int requiredDepth = std::min<int>(
+        ::Params().EsperanzaParams().GetStakeMinConfirmations() - 1,
+        height / 2);
 
     for (const auto &it : m_enclosingWallet->mapWallet) {
       const CWalletTx &coin = it.second;
@@ -67,7 +73,7 @@ void WalletExtension::AvailableCoinsForStaking(std::vector<::COutput> &vCoins) {
         continue;
       }
       const uint256 &wtxid = it.first;
-      const int numOutputs = static_cast<const int>(tx->vout.size());
+      const auto numOutputs = static_cast<const unsigned int>(tx->vout.size());
       for (unsigned int i = 0; i < numOutputs; ++i) {
         const auto &txout = tx->vout[i];
 
@@ -95,11 +101,9 @@ void WalletExtension::AvailableCoinsForStaking(std::vector<::COutput> &vCoins) {
 }
 
 bool WalletExtension::SelectCoinsForStaking(
-    int64_t nTargetValue,
-    std::vector<::COutput>& availableCoinsForStaking,
+    int64_t nTargetValue, std::vector<::COutput> &availableCoinsForStaking,
     std::set<std::pair<const ::CWalletTx *, unsigned int>> &setCoinsRet,
     int64_t &nValueRet) {
-
   setCoinsRet.clear();
   nValueRet = 0;
 
@@ -114,7 +118,8 @@ bool WalletExtension::SelectCoinsForStaking(
 
     int64_t amount = pcoin->tx->vout[index].nValue;
 
-    std::pair<const CWalletTx *, unsigned int> coin = std::make_pair(pcoin, index);
+    std::pair<const CWalletTx *, unsigned int> coin =
+        std::make_pair(pcoin, index);
 
     if (amount >= nTargetValue) {
       // If input value is greater or equal to target then simply insert
@@ -135,12 +140,230 @@ bool WalletExtension::CreateCoinStake(unsigned int nBits, int64_t nTime,
                                       int nBlockHeight, int64_t nFees,
                                       ::CMutableTransaction &txNew,
                                       ::CKey &key) {
-  // todo
-  return false;
+  CBlockIndex *pindexPrev = chainActive.Tip();
+  arith_uint256 bnTargetPerCoinDay;
+  bnTargetPerCoinDay.SetCompact(nBits);
+
+  CAmount nBalance = GetStakeableBalance();
+  if (nBalance <= m_reserveBalance) {
+    return false;
+  }
+
+  // Choose coins to use
+  std::vector<const CWalletTx *> vwtxPrev;
+  std::set<std::pair<const CWalletTx *, unsigned int>> setCoins;
+  CAmount nValueIn = 0;
+
+  std::vector<::COutput> availableCoinsForStaking;
+  AvailableCoinsForStaking(availableCoinsForStaking);
+  if (!SelectCoinsForStaking(nBalance - m_reserveBalance,
+                             availableCoinsForStaking, setCoins, nValueIn)) {
+    return false;
+  }
+
+  CAmount nCredit = 0;
+  CScript scriptPubKeyKernel;
+
+  auto it = setCoins.begin();
+
+  for (; it != setCoins.end(); ++it) {
+    auto pcoin = *it;
+    if (StakeThread::IsStopped()) {
+      return false;
+    }
+    COutPoint prevoutStake = COutPoint(pcoin.first->GetHash(), pcoin.second);
+
+    int64_t nBlockTime;
+    if (CheckKernel(pindexPrev, nBits, nTime, prevoutStake, &nBlockTime)) {
+      LOCK(m_enclosingWallet->cs_wallet);
+      // Found a kernel
+      LogPrint(BCLog::POS, "%s: Kernel found.\n", __func__);
+
+      const CTxOut &kernelOut = pcoin.first->tx->vout[pcoin.second];
+
+      std::vector<std::vector<unsigned char>> vSolutions;
+      txnouttype whichType;
+
+      CScript pscriptPubKey = kernelOut.scriptPubKey;
+      CScript coinstakePath;
+      bool fConditionalStake = false;
+      if (HasIsCoinstakeOp(pscriptPubKey)) {
+        fConditionalStake = true;
+        if (!GetCoinstakeScriptPath(pscriptPubKey, coinstakePath)) {
+          continue;
+        }
+        pscriptPubKey = coinstakePath;
+      }
+
+      if (!Solver(pscriptPubKey, whichType, vSolutions)) {
+        LogPrint(BCLog::POS, "%s: Failed to parse kernel.\n", __func__);
+        break;
+      }
+
+      LogPrint(BCLog::POS, "%s: Parsed kernel type=%d.\n", __func__, whichType);
+      CKeyID spendId;
+      if (whichType == TX_PUBKEYHASH) {
+        spendId = CKeyID(uint160(vSolutions[0]));
+      } else {
+        LogPrint(BCLog::POS, "%s: No support for kernel type=%d.\n", __func__,
+                 whichType);
+        break;  // only support pay to address (pay to pubkey hash)
+      }
+
+      if (!m_enclosingWallet->GetKey(spendId, key)) {
+        LogPrint(BCLog::POS, "%s: Failed to get key for kernel type=%d.\n",
+                 __func__, whichType);
+        break;  // unable to find corresponding key
+      }
+
+      if (fConditionalStake) {
+        scriptPubKeyKernel = kernelOut.scriptPubKey;
+      } else {
+        scriptPubKeyKernel << OP_DUP << OP_HASH160 << ToByteVector(spendId)
+                           << OP_EQUALVERIFY << OP_CHECKSIG;
+      }
+
+      // Ensure txn is empty
+      txNew.vin.clear();
+      txNew.vout.clear();
+
+      // Mark as coin stake transaction
+      txNew.SetVersion(1);  // UNIT-E: TODO decide transaction version
+      txNew.SetType(TxType::COINSTAKE);
+
+      txNew.vin.emplace_back(CTxIn(pcoin.first->GetHash(), pcoin.second));
+
+      nCredit += kernelOut.nValue;
+      vwtxPrev.push_back(pcoin.first);
+
+      CTxOut out(0, scriptPubKeyKernel);
+      txNew.vout.emplace_back(out);
+
+      LogPrint(BCLog::POS, "%s: Added kernel.\n", __func__);
+
+      setCoins.erase(it);
+      break;
+    }
+  }
+
+  if (nCredit == 0 || nCredit > nBalance - m_reserveBalance) {
+    return false;
+  }
+
+  // Attempt to add more inputs
+  // Only advantage here is to setup the next stake using this output as a
+  // kernel to have a higher chance of staking
+  size_t nStakesCombined = 0;
+  it = setCoins.begin();
+  while (it != setCoins.end()) {
+    if (nStakesCombined >= m_maxStakeCombine) {
+      break;
+    }
+
+    // Stop adding more inputs if already too many inputs
+    if (txNew.vin.size() >= 100) {
+      break;
+    }
+
+    // Stop adding more inputs if value is already pretty significant
+    if (nCredit >= m_stakeCombineThreshold) {
+      break;
+    }
+
+    auto itc = it++;  // copy the current iterator then increment it
+    auto pcoin = *itc;
+
+    const CTxOut &prevOut = pcoin.first->tx->vout[pcoin.second];
+
+    // Only add coins of the same key/address as kernel
+    if (prevOut.scriptPubKey != scriptPubKeyKernel) {
+      continue;
+    }
+    // Stop adding inputs if reached reserve limit
+    if (nCredit + prevOut.nValue > nBalance - m_reserveBalance) {
+      break;
+    }
+    // Do not add additional significant input
+    if (prevOut.nValue >= m_stakeCombineThreshold) {
+      continue;
+    }
+
+    txNew.vin.emplace_back(pcoin.first->GetHash(), pcoin.second);
+    nCredit += prevOut.nValue;
+    vwtxPrev.push_back(pcoin.first);
+
+    LogPrint(BCLog::POS, "%s: Combining kernel %s, %d.\n", __func__,
+             pcoin.first->GetHash().ToString(), pcoin.second);
+    nStakesCombined++;
+    setCoins.erase(itc);
+  }
+
+  // Get block reward
+  CAmount nReward =
+      ::Params().EsperanzaParams().GetProofOfStakeReward(pindexPrev, nFees);
+  if (nReward < 0) {
+    return false;
+  }
+
+  // Process development fund
+  CAmount nRewardOut = nReward;
+
+  // UNIT-E: Creating a reward to a rewardAddress has not been ported,
+  // presumably belongs to coldstaking
+  nCredit += nRewardOut;
+
+  // Set output amount, split outputs if > nStakeSplitThreshold
+  if (nCredit >= m_stakeSplitThreshold) {
+    CTxOut outSplit(0, scriptPubKeyKernel);
+
+    txNew.vout.back().nValue = nCredit / 2;
+    outSplit.nValue = nCredit - txNew.vout.back().nValue;
+    txNew.vout.emplace_back(outSplit);
+  } else {
+    txNew.vout.back().nValue = nCredit;
+  }
+
+  // Create output for reward
+  // UNIT-E: Creating a reward to a rewardAddress has not been ported,
+  // presumably belongs to coldstaking
+
+  // Sign
+  int nIn = 0;
+  for (const auto &pcoin : vwtxPrev) {
+    uint32_t nPrev = txNew.vin[nIn].prevout.n;
+
+    const CTxOut &prevOut = pcoin->tx->vout[nPrev];
+    const CScript &scriptPubKeyOut = prevOut.scriptPubKey;
+
+    SignatureData sigdata;
+    CTransaction txToConst(txNew);
+    if (!ProduceSignature(
+            TransactionSignatureCreator(m_enclosingWallet, &txToConst, nIn,
+                                        prevOut.nValue, SIGHASH_ALL),
+            scriptPubKeyOut, sigdata)) {
+      return error("%s: ProduceSignature failed.", __func__);
+    }
+
+    UpdateTransaction(txNew, nIn, sigdata);
+    nIn++;
+  }
+
+  // Limit size
+  auto nBytes = static_cast<unsigned int>(
+      ::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION));
+  if (nBytes >= DEFAULT_BLOCK_MAX_SIZE / 5) {
+    return error("%s: Exceeded coinstake size limit.", __func__);
+  }
+
+  // Successfully generated coinstake
+  return true;
 }
+
+const int32_t BLOCK_VERSION = 1;
 
 bool WalletExtension::SignBlock(::CBlockTemplate *pblocktemplate, int nHeight,
                                 int64_t nSearchTime) {
+  // todo
   return false;
 }
 

--- a/src/esperanza/walletextension.h
+++ b/src/esperanza/walletextension.h
@@ -58,13 +58,30 @@ class WalletExtension {
 
   CAmount m_stakeSplitThreshold = 2000 * UNIT;
 
-  size_t m_MaxStakeCombine = 3;
+  size_t m_maxStakeCombine = 3;
 
   std::string m_rewardAddress;
 
  public:
+  //! \brief non-intrusive extension of the bitcoin-core wallet.
+  //!
+  //! A WalletExtension requires an enclosing wallet which it extends.
+  //! The esperanza::WalletExtension is befriended by CWallet so that it
+  //! can access CWallet's guts.
+  //!
+  //! @param enclosingWallet The CWallet that this WalletExtension extends (must
+  //! not be nullptr).
   WalletExtension(::CWallet *enclosingWallet);
 
+  //! \brief which proposer thread this wallet maps to
+  //!
+  //! Each Wallet is mapped to a proposer thread (when proposing/staking).
+  //! There is always at least one proposer thread. Multiple wallets may be
+  //! mapped to the same thread. There are never more proposer threads then
+  //! wallets.
+  //!
+  //! @return The index of the proposer thread that uses this wallet for
+  //! proposing new blocks.
   size_t GetProposerThreadIndex() const;
 
   CAmount GetStakeableBalance() const;
@@ -72,8 +89,7 @@ class WalletExtension {
   void AvailableCoinsForStaking(std::vector<::COutput> &vCoins);
 
   static bool SelectCoinsForStaking(
-      int64_t nTargetValue,
-      std::vector<::COutput>& availableCoinsForStaking,
+      int64_t nTargetValue, std::vector<::COutput> &availableCoinsForStaking,
       std::set<std::pair<const ::CWalletTx *, unsigned int>> &setCoinsRet,
       int64_t &nValueRet);
 

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -245,26 +245,6 @@ bool CScript::IsWitnessProgram(int& version, std::vector<unsigned char>& program
     return false;
 }
 
-bool CScript::HasIsCoinstakeOp() const {
-    CScript::const_iterator pc = this->begin();
-
-    if (pc == this->end()) {
-        return false;
-    }
-
-    opcodetype opcode;
-    std::vector<unsigned char> vchPushValue;
-
-    if (!this->GetOp(pc, opcode, vchPushValue)) {
-        return false;
-    }
-
-    if (opcode == OP_ISCOINSTAKE) {
-        return true;
-    }
-        return false;
-};
-
 bool CScript::IsPushOnly(const_iterator pc) const
 {
     while (pc < end())

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -646,9 +646,6 @@ public:
     bool IsPayToWitnessScriptHash() const;
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
 
-    //! Proof-of-Stake: Checks whether the script has an IS_COINSTAKE_OP
-    bool HasIsCoinstakeOp() const;
-
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */
     bool IsPushOnly(const_iterator pc) const;
     bool IsPushOnly() const;


### PR DESCRIPTION
This ports the functions for selecting coins for proposing from the particl wallet. Some of these functions IMHO are not strictly wallet functions, but proposer capabilities. I will send a follow up pull request which moves some things around. For now I am just interested in getting this additional piece merged.

Unfortunately there's no tests for this. I wanted to write unit tests, but it's next to impossible (or too costly in my mind) to mock the required objects (go ahead an try creating a `COutput` fixture). So this will have to wait for the next iteration which checks the proposing as part of the stake thread as a functional test. Also in particl there are no tests to port which would cover these functions exclusively.

`kernel.cpp` experienced very little changes but looks like a lot as I ran our google formatter on it...

The essence of this PR are the filled out blanks in `WalletExtension`. Additionally I moved some stuff out of bitcoin territory into `esperanza::` land, like from `script.h` to `esperanza/validation.h`. No logic has been touched though.

---

The most interesting introduction in this PR is the Reward function on esperanza params. This is something we are *so* surely gonna touch.