### PR TITLE
temporarily move esperanza functional tests to --extended set

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -67,7 +67,6 @@ BASE_SCRIPTS= [
     'wallet_accounts.py',
     'p2p_segwit.py',
     'wallet_dump.py',
-    'esperanza_vote.py',
     'rpc_listtransactions.py',
     # vv Tests less than 60s vv
     'p2p_sendheaders.py',
@@ -108,7 +107,6 @@ BASE_SCRIPTS= [
     'rpc_net.py',
     'wallet_keypool.py',
     'p2p_mempool.py',
-    'esperanza_deposit.py',
     'mining_prioritisetransaction.py',
     'p2p_invalid_block.py',
     'p2p_invalid_tx.py',
@@ -147,6 +145,9 @@ BASE_SCRIPTS= [
 ]
 
 EXTENDED_SCRIPTS = [
+    # temporarily moved these two tests here, to be moved back when fixed
+    'esperanza_vote.py',
+    'esperanza_deposit.py',
     # These tests are not run by the travis build process.
     # Longest test should go first, to favor running tests in parallel
     'feature_pruning.py',


### PR DESCRIPTION
As discussed in #81