### PR TITLE
WIP: add hash witness merkle root in block header

### DIFF
--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -24,6 +24,7 @@ public:
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;
+    uint256 hashWitnessMerkleRoot;
     uint32_t nTime;
     uint32_t nBits;
     uint32_t nNonce;
@@ -40,6 +41,7 @@ public:
         READWRITE(this->nVersion);
         READWRITE(hashPrevBlock);
         READWRITE(hashMerkleRoot);
+        READWRITE(hashWitnessMerkleRoot);
         READWRITE(nTime);
         READWRITE(nBits);
         READWRITE(nNonce);
@@ -50,6 +52,7 @@ public:
         nVersion = 0;
         hashPrevBlock.SetNull();
         hashMerkleRoot.SetNull();
+        hashWitnessMerkleRoot.SetNull();
         nTime = 0;
         nBits = 0;
         nNonce = 0;
@@ -112,12 +115,13 @@ public:
     CBlockHeader GetBlockHeader() const
     {
         CBlockHeader block;
-        block.nVersion       = nVersion;
-        block.hashPrevBlock  = hashPrevBlock;
-        block.hashMerkleRoot = hashMerkleRoot;
-        block.nTime          = nTime;
-        block.nBits          = nBits;
-        block.nNonce         = nNonce;
+        block.nVersion              = nVersion;
+        block.hashPrevBlock         = hashPrevBlock;
+        block.hashMerkleRoot        = hashMerkleRoot;
+        block.hashWitnessMerkleRoot = hashWitnessMerkleRoot;
+        block.nTime                 = nTime;
+        block.nBits                 = nBits;
+        block.nNonce                = nNonce;
         return block;
     }
 


### PR DESCRIPTION
- <strike>Hey, not too rough</strike>
- <strike>Hurt me plenty</strike>
- Ultra-Violence

## Separate PRs

- [x] https://github.com/dtr-org/unit-e/pull/89 introduce ReducedTestingSetup for blockchain agnostic unit tests

## Unit Tests

- [x] arith_uint256_tests*
  - [x] basics*
  - [x] shifts*
  - [x] unaryOperators*
  - [x] bitwiseOperators*
  - [x] comparison*
  - [x] plusMinus*
  - [x] multiply*
  - [x] divide*
  - [x] methods*
  - [x] bignum_SetCompact*
  - [x] getmaxcoverage*
- [x] addrman_tests*
  - [x] addrman_simple*
  - [x] addrman_ports*
  - [x] addrman_select*
  - [x] addrman_new_collisions*
  - [x] addrman_tried_collisions*
  - [x] addrman_find*
  - [x] addrman_create*
  - [x] addrman_delete*
  - [x] addrman_getaddr*
  - [x] caddrinfo_get_tried_bucket*
  - [x] caddrinfo_get_new_bucket*
- [x] amount_tests*
  - [x] MoneyRangeTest*
  - [x] GetFeeTest*
  - [x] BinaryOperatorTest*
  - [x] ToStringTest*
- [x] allocator_tests*
  - [x] arena_tests*
  - [x] lockedpool_tests_mock*
  - [x] lockedpool_tests_live*
- [x] base16_tests*
  - [x] encode_base16*
  - [x] decode_base16*
  - [x] decode_base16_fail*
- [x] base32_tests*
  - [x] base32_testvectors*
- [ ] base58_tests*
  - [ ] base58_EncodeBase58*
  - [ ] base58_DecodeBase58*
  - [ ] base58_keys_valid_parse*
  - [ ] base58_keys_valid_gen*
  - [ ] base58_keys_invalid*
- [x] base64_tests*
  - [x] base64_testvectors*
- [x] bech32_tests*
  - [x] bip173_testvectors_valid*
  - [x] bip173_testvectors_invalid*
- [ ] bip32_tests*
  - [ ] bip32_test1*
  - [ ] bip32_test2*
  - [ ] bip32_test3*
- [x] blockchain_difficulty_tests*
  - [x] get_difficulty_for_very_low_target*
  - [x] get_difficulty_for_low_target*
  - [x] get_difficulty_for_mid_target*
  - [x] get_difficulty_for_high_target*
  - [x] get_difficulty_for_very_high_target*
  - [x] get_difficulty_for_null_tip*
  - [x] get_difficulty_for_null_block_index*
  - [x] get_difficulty_for_block_index_overrides_tip*
- [ ] blockencodings_tests*
  - [ ] SimpleRoundTripTest*
  - [ ] NonCoinbasePreforwardRTTest*
  - [ ] SufficientPreforwardRTTest*
  - [ ] EmptyBlockRoundTripTest*
  - [ ] TransactionsRequestSerializationTest*
- [ ] bloom_tests*
  - [ ] bloom_create_insert_serialize*
  - [ ] bloom_create_insert_serialize_with_tweak*
  - [ ] bloom_create_insert_key*
  - [ ] bloom_match*
  - [ ] merkle_block_1*
  - [ ] merkle_block_2*
  - [ ] merkle_block_2_with_update_none*
  - [ ] merkle_block_3_and_serialize*
  - [ ] merkle_block_4*
  - [ ] merkle_block_4_test_p2pubkey_only*
  - [ ] merkle_block_4_test_update_none*
  - [ ] rolling_bloom*
- [x] bswap_tests*
  - [x] bswap_tests*
- [ ] checkqueue_tests*
  - [ ] test_CheckQueue_Correct_Zero*
  - [ ] test_CheckQueue_Correct_One*
  - [ ] test_CheckQueue_Correct_Max*
  - [ ] test_CheckQueue_Correct_Random*
  - [ ] test_CheckQueue_Catches_Failure*
  - [ ] test_CheckQueue_Recovers_From_Failure*
  - [ ] test_CheckQueue_UniqueCheck*
  - [ ] test_CheckQueue_Memory*
  - [ ] test_CheckQueue_FrozenCleanup*
  - [ ] test_CheckQueueControl_Locks*
- [x] coins_tests*
  - [x] coins_cache_simulation_test*
  - [x] updatecoins_simulation_test*
  - [x] ccoins_serialization*
  - [x] ccoins_access*
  - [x] ccoins_spend*
  - [x] ccoins_add*
  - [x] ccoins_write*
- [x] compress_tests*
  - [x] compress_amounts*
- [x] semaphore_tests*
  - [x] barrier_example*
- [x] crypto_tests*
  - [x] ripemd160_testvectors*
  - [x] sha1_testvectors*
  - [x] sha256_testvectors*
  - [x] sha512_testvectors*
  - [x] hmac_sha256_testvectors*
  - [x] hmac_sha512_testvectors*
  - [x] aes_testvectors*
  - [x] aes_cbc_testvectors*
  - [x] chacha20_testvector*
  - [x] countbits_tests*
- [x] cuckoocache_tests*
  - [x] test_cuckoocache_no_fakes*
  - [x] cuckoocache_hit_rate_ok*
  - [x] cuckoocache_erase_ok*
  - [x] cuckoocache_erase_parallel_ok*
  - [x] cuckoocache_generations*
- [ ] DoS_tests*
  - [ ] outbound_slow_chain_eviction*
  - [ ] stale_tip_peer_management*
  - [ ] DoS_banning*
  - [ ] DoS_banscore*
  - [ ] DoS_bantime*
  - [ ] DoS_mapOrphans*
- [x] finalizationstate_tests*
  - [x] constructor*
  - [x] initialize_epcoh_wrong_height_passed*
  - [x] initialize_epcoh_insta_finalize*
  - [x] initialize_epoch_reward_factor*
  - [x] validate_deposit_tx_not_enough_deposit*
  - [x] validate_deposit_tx_double_deposit*
  - [x] process_deposit_tx*
  - [x] validate_vote_tx_no_deposit*
  - [x] validate_vote_tx_non_votable_already_voted*
  - [x] validate_vote_tx_non_votable_wrong_target_epoch*
  - [x] validate_vote_tx_non_votable_wrong_target_hash*
  - [x] validate_vote_tx_non_votable_source_epoch_not_justified*
  - [x] process_vote_tx_success*
  - [x] process_vote_tx_success_with_reward_no_consensus*
  - [x] process_vote_tx_success_with_finalization*
  - [x] validate_logout_not_a_validator*
  - [x] validate_logout_before_start_dynasty*
  - [x] validate_logout_already_logged_out*
  - [x] process_logout_end_dynasty*
  - [x] validate_withdraw_not_a_validator*
  - [x] process_withdraw_before_end_dynasty*
  - [x] process_withdraw_too_early*
  - [x] process_withdraw_completely_slashed*
  - [x] is_slashable_not_a_validator*
  - [x] is_slashable_not_the_same_validator*
  - [x] is_slashable_too_early*
  - [x] is_slashable_same_vote*
  - [x] is_slashable_already_slashed*
  - [x] process_slash_duplicate_vote*
  - [x] process_slash_surrounding_vote*
  - [x] getrecommendedvote*
  - [x] map_empty_initializer*
- [x] finalization_params_tests*
  - [x] parse_params_invalid_json*
  - [x] parse_params_param_not_a_number_fallback_default*
  - [x] parse_params_negative_unsigned_params*
  - [x] parse_params_values*
- [x] getarg_tests*
  - [x] boolarg*
  - [x] stringarg*
  - [x] intarg*
  - [x] doubledash*
  - [x] boolargno*
- [x] hash_tests*
  - [x] murmurhash3*
  - [x] siphash*
- [x] interpreter_tests*
  - [x] signaturehash_vote*
- [ ] key_tests*
  - [ ] key_test1*
- [x] limitedmap_tests*
  - [x] limitedmap_test*
- [x] dbwrapper_tests*
  - [x] dbwrapper*
  - [x] dbwrapper_batch*
  - [x] dbwrapper_iterator*
  - [x] existing_data_no_obfuscate*
  - [x] existing_data_reindex*
  - [x] iterator_ordering*
  - [x] iterator_string_ordering*
- [ ] main_tests*
  - [ ] block_subsidy_test*
  - [ ] subsidy_limit_test*
  - [ ] test_combiner_all*
- [ ] mempool_tests*
  - [ ] MempoolRemoveTest*
  - [ ] MempoolIndexingTest*
  - [ ] MempoolAncestorIndexingTest*
  - [ ] MempoolSizeLimitTest*
- [ ] merkle_tests*
  - [ ] merkle_test*
- [ ] merkleblock_tests*
  - [ ] merkleblock_construct_from_txids_found*
  - [ ] merkleblock_construct_from_txids_not_found*
- [ ] miner_tests*
  - [ ] CreateNewBlock_validity*
- [x] multisig_tests*
  - [x] multisig_verify*
  - [x] multisig_IsStandard*
  - [x] multisig_Sign*
- [ ] net_tests*
  - [ ] cnode_listen_port*
  - [ ] caddrdb_read*
  - [ ] caddrdb_read_corrupted*
  - [ ] cnode_simple_test*
- [x] netbase_tests*
  - [x] netbase_networks*
  - [x] netbase_properties*
  - [x] netbase_splithost*
  - [x] netbase_lookupnumeric*
  - [x] onioncat_test*
  - [x] subnet_test*
  - [x] netbase_getgroup*
- [x] pmt_tests*
  - [x] pmt_test1*
  - [x] pmt_malleability*
- [x] policyestimator_tests*
  - [x] BlockPolicyEstimates*
- [ ] pow_tests*
  - [ ] get_next_work*
  - [ ] get_next_work_pow_limit*
  - [ ] get_next_work_lower_limit_actual*
  - [ ] get_next_work_upper_limit_actual*
  - [ ] GetBlockProofEquivalentTime_test*
- [ ] PrevectorTests*
  - [ ] PrevectorTestInt*
- [x] raii_event_tests*
  - [x] raii_event_creation*
  - [x] raii_event_order*
- [x] random_tests*
  - [x] osrandom_tests*
  - [x] fastrandom_tests*
  - [x] fastrandom_randbits*
- [x] reverselock_tests*
  - [x] reverselock_basics*
  - [x] reverselock_errors*
- [ ] rpc_tests*
  - [ ] rpc_rawparams*
  - [ ] rpc_togglenetwork*
  - [ ] rpc_rawsign*
  - [ ] rpc_createraw_op_return*
  - [ ] rpc_format_monetary_values*
  - [ ] rpc_parse_monetary_values*
  - [ ] json_parse_errors*
  - [ ] rpc_ban*
  - [ ] rpc_convert_values_generatetoaddress*
- [x] sanity_tests*
  - [x] basic_sanity*
- [x] scheduler_tests*
  - [x] manythreads*
- [x] script_P2SH_tests*
  - [x] sign*
  - [x] norecurse*
  - [x] set*
  - [x] is*
  - [x] switchover*
  - [x] AreInputsStandard*
- [x] script_tests*
  - [x] script_build*
  - [x] script_json_test*
  - [x] script_PushData*
  - [x] script_CHECKMULTISIG12*
  - [x] script_CHECKMULTISIG23*
  - [x] script_combineSigs*
  - [x] script_standard_push*
  - [x] script_IsPushOnly_on_invalid_scripts*
  - [x] script_GetScriptAsm*
  - [x] script_FindAndDelete*
  - [x] script_HasValidOps*
  - [x] script_can_append_self*
  - [x] encode_decode_vote_data*
  - [x] extract_vote_data_from_scriptsig*
  - [x] extract_vote_data_from_witness*
- [x] script_standard_tests*
  - [x] script_standard_Solver_success*
  - [x] script_standard_Solver_failure*
  - [x] script_standard_ExtractDestination*
  - [x] script_standard_ExtractDestinations*
  - [x] script_standard_GetScriptFor_*
  - [x] script_standard_IsMine*
- [x] scriptnum_tests*
  - [x] creation*
  - [x] operators*
- [x] serialize_tests*
  - [x] sizes*
  - [x] floats_conversion*
  - [x] doubles_conversion*
  - [x] floats*
  - [x] doubles*
  - [x] varints*
  - [x] varints_bitpatterns*
  - [x] compactsize*
  - [x] noncanonical*
  - [x] insert_delete*
  - [x] class_methods*
- [x] sighash_tests*
  - [x] sighash_test*
  - [x] sighash_from_data*
- [x] sigopcount_tests*
  - [x] GetSigOpCount*
  - [x] GetTxSigOpCost*
- [x] sign_tests*
  - [x] producesignature_vote_witness*
- [x] skiplist_tests*
  - [x] skiplist_test*
  - [x] getlocator_test*
  - [x] findearliestatleast_test*
  - [x] findearliestatleast_edge_test*
- [x] streams_tests*
  - [x] streams_vector_writer*
  - [x] streams_serializedata_xor*
- [x] timedata_tests*
  - [x] util_MedianFilter*
- [x] torcontrol_tests*
  - [x] util_SplitTorReplyLine*
  - [x] util_ParseTorReplyMapping*
- [x] transaction_tests*
  - [x] tx_valid*
  - [x] tx_invalid*
  - [x] basic_transaction_tests*
  - [x] test_Get*
  - [x] test_big_witness_transaction*
  - [x] test_witness*
  - [x] test_IsStandard*
  - [x] mutabletransaction_set_type_mulitple_times*
- [ ] txvalidation_tests*
  - [ ] tx_mempool_reject_coinbase*
- [ ] tx_validationcache_tests*
  - [ ] tx_mempool_block_doublespend*
  - [ ] checkinputs_test*
- [x] uint256_tests*
  - [x] basics*
  - [x] comparison*
  - [x] methods*
  - [x] conversion*
- [x] util_tests*
  - [x] util_criticalsection*
  - [x] util_ParseHex*
  - [x] util_HexStr*
  - [x] util_DateTimeStrFormat*
  - [x] util_ParseParameters*
  - [x] util_GetArg*
  - [x] util_FormatMoney*
  - [x] util_ParseMoney*
  - [x] util_IsHex*
  - [x] util_IsHexNumber*
  - [x] util_seed_insecure_rand*
  - [x] util_TimingResistantEqual*
  - [x] strprintf_numbers*
  - [x] gettime*
  - [x] test_ParseInt32*
  - [x] test_ParseInt64*
  - [x] test_ParseUInt32*
  - [x] test_ParseUInt64*
  - [x] test_ParseDouble*
  - [x] test_FormatParagraph*
  - [x] test_FormatSubVersion*
  - [x] test_ParseFixedPoint*
  - [x] test_LockDirectory*
- [x] util_fun_tests*
  - [x] take_while_int_vector*
  - [x] take_while_char_vector*
  - [x] take_while_string*
  - [x] drop_while_int_vector_fun_ptr*
  - [x] drop_while_int_vector_lambda*
  - [x] drop_while_int_vector*
  - [x] drop_while_char_vector*
  - [x] drop_while_string*
  - [x] filter_int_vector*
  - [x] filter_not_int_vector*
  - [x] zip_with_int_vector*
  - [x] zip_with_different_lengths*
  - [x] fold_left_test*
  - [x] fold_right_test*
  - [x] scan_left_test*
- [ ] validation_block_tests*
  - [ ] processnewblock_signals_ordering*
- [ ] versionbits_tests*
  - [ ] versionbits_test*
  - [ ] versionbits_computeblockversion*
- [x] waiter_tests*
  - [x] wait_and_wake_test*
- [ ] mnemonic_tests*
  - [ ] mnemonic_test*
  - [ ] mnemonic_test_fails*
  - [ ] mnemonic_addchecksum*
  - [ ] mnemonic_detect_english*
  - [ ] mnemonic_detect_french*
  - [ ] mnemonic_detect_italian*
  - [ ] mnemonic_detect_spanish*
  - [ ] mnemonic_detect_japanese*
  - [ ] mnemonic_detect_korean*
  - [ ] mnemonic_detect_chinese_simplified*
  - [ ] mnemonic_detect_chinese_traditional*
  - [ ] mnemonic_seed_english*
  - [ ] mnemonic_seed_english_with_passphrase*
  - [ ] mnemonic_seed_spanish*
  - [ ] mnemonic_seed_spanish_with_passphrase*
  - [ ] mnemonic_test_json*
- [x] proposer_tests*
  - [x] start_stop*
  - [x] stop_twice*
  - [x] stop_without_start*
  - [x] stop_twice_without_start*
  - [x] wallet_distribution*
  - [x] single_wallet_too_many_threads_specified*
  - [x] single_wallet_too_few_threads_specified*
- [ ] accounting_tests*
  - [ ] acc_orderupgrade*
- [ ] wallet_tests*
  - [ ] coin_selection_tests*
  - [ ] ApproximateBestSubset*
  - [ ] rescan*
  - [ ] importwallet_rescan*
  - [ ] coin_mark_dirty_immature_credit*
  - [ ] ComputeTimeSmart*
  - [ ] LoadReceiveRequests*
  - [ ] ListCoins*
- [x] wallet_crypto*
  - [x] passphrase*
  - [x] encrypt*
  - [x] decrypt*

