### PR TITLE
introduce ReducedTestingSetup for blockchain agnostic unit tests

### DIFF
--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -78,7 +78,7 @@ static CService ResolveService(std::string ip, int port = 0)
     return ResolveService(ip.c_str(), port);
 }
 
-BOOST_FIXTURE_TEST_SUITE(addrman_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(addrman_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(addrman_simple)
 {

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(allocator_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(allocator_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(arena_tests)
 {

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -8,7 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(amount_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(amount_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(MoneyRangeTest)
 {

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -14,7 +14,7 @@
 #include <version.h>
 #include <test/test_unite.h>
 
-BOOST_FIXTURE_TEST_SUITE(arith_uint256_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(arith_uint256_tests, ReducedTestingSetup)
 
 /// Convert vector to arith_uint256, via uint256 blob
 inline arith_uint256 arith_uint256V(const std::vector<unsigned char>& vch)

--- a/src/test/base16_tests.cpp
+++ b/src/test/base16_tests.cpp
@@ -11,7 +11,7 @@
 
 #include <univalue.h>
 
-BOOST_FIXTURE_TEST_SUITE(base16_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(base16_tests, ReducedTestingSetup)
 
 template<std::size_t length>
 std::vector<uint8_t> toUtf8Vector(const char(&text)[length])

--- a/src/test/base32_tests.cpp
+++ b/src/test/base32_tests.cpp
@@ -7,7 +7,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(base32_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(base32_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(base32_testvectors)
 {

--- a/src/test/base64_tests.cpp
+++ b/src/test/base64_tests.cpp
@@ -7,7 +7,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(base64_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(base64_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(base64_testvectors)
 {

--- a/src/test/bech32_tests.cpp
+++ b/src/test/bech32_tests.cpp
@@ -7,7 +7,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(bech32_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(bech32_tests, ReducedTestingSetup)
 
 bool CaseInsensitiveEqual(const std::string &s1, const std::string &s2)
 {

--- a/src/test/blockchain_tests.cpp
+++ b/src/test/blockchain_tests.cpp
@@ -54,7 +54,7 @@ void TestDifficulty(uint32_t nbits, double expected_difficulty)
     RejectDifficultyMismatch(difficulty, expected_difficulty);
 }
 
-BOOST_FIXTURE_TEST_SUITE(blockchain_difficulty_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(blockchain_difficulty_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(get_difficulty_for_very_low_target)
 {

--- a/src/test/bswap_tests.cpp
+++ b/src/test/bswap_tests.cpp
@@ -7,7 +7,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(bswap_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(bswap_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(bswap_tests)
 {

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -95,7 +95,7 @@ public:
 
 } // namespace
 
-BOOST_FIXTURE_TEST_SUITE(coins_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(coins_tests, ReducedTestingSetup)
 
 static const unsigned int NUM_SIMULATION_ITERATIONS = 40000;
 

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -22,7 +22,7 @@
 // amounts 50 .. 21000000
 #define NUM_MULTIPLES_50UNT 420000
 
-BOOST_FIXTURE_TEST_SUITE(compress_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(compress_tests, ReducedTestingSetup)
 
 bool static TestEncode(uint64_t in) {
     return in == CTxOutCompressor::DecompressAmount(CTxOutCompressor::CompressAmount(in));

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -20,7 +20,7 @@
 #include <openssl/aes.h>
 #include <openssl/evp.h>
 
-BOOST_FIXTURE_TEST_SUITE(crypto_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(crypto_tests, ReducedTestingSetup)
 
 template<typename Hasher, typename In, typename Out>
 void TestVector(const Hasher &h, const In &in, const Out &out) {

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -21,7 +21,7 @@ bool is_null_key(const std::vector<unsigned char>& key) {
     return isnull;
 }
  
-BOOST_FIXTURE_TEST_SUITE(dbwrapper_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(dbwrapper_tests, ReducedTestingSetup)
                        
 BOOST_AUTO_TEST_CASE(dbwrapper)
 {

--- a/src/test/esperanza/finalizationparams_tests.cpp
+++ b/src/test/esperanza/finalizationparams_tests.cpp
@@ -5,7 +5,7 @@
 #include <univalue.h>
 #include <util.h>
 
-BOOST_FIXTURE_TEST_SUITE(finalization_params_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(finalization_params_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(parse_params_invalid_json)
 {

--- a/src/test/esperanza/finalizationstate_tests.cpp
+++ b/src/test/esperanza/finalizationstate_tests.cpp
@@ -39,7 +39,7 @@ class EsperanzaStateSpy : public FinalizationState {
   using FinalizationState::ProcessWithdraw;
 };
 
-BOOST_FIXTURE_TEST_SUITE(finalizationstate_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(finalizationstate_tests, ReducedTestingSetup)
 
 // Constructor tests
 

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -11,7 +11,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(getarg_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(getarg_tests, ReducedTestingSetup)
 
 static void ResetArgs(const std::string& strArg)
 {

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -10,7 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(hash_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(hash_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(murmurhash3)
 {

--- a/src/test/interpreter_tests.cpp
+++ b/src/test/interpreter_tests.cpp
@@ -7,7 +7,7 @@
 #include <script/script.h>
 #include <util.h>
 
-BOOST_FIXTURE_TEST_SUITE(interpreter_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(interpreter_tests, ReducedTestingSetup)
 
 uint256 GetPrevoutHash(const CTransaction& txTo) {
     CHashWriter ss(SER_GETHASH, 0);

--- a/src/test/limitedmap_tests.cpp
+++ b/src/test/limitedmap_tests.cpp
@@ -8,7 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(limitedmap_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(limitedmap_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(limitedmap_test)
 {

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(multisig_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(multisig_tests, ReducedTestingSetup)
 
 CScript
 sign_multisig(CScript scriptPubKey, std::vector<CKey> keys, CTransaction transaction, int whichIn)

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -10,7 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(netbase_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(netbase_tests, ReducedTestingSetup)
 
 static CNetAddr ResolveIP(const char* ip)
 {

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -26,7 +26,7 @@ public:
     }
 };
 
-BOOST_FIXTURE_TEST_SUITE(pmt_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(pmt_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(pmt_test1)
 {

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -12,7 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(policyestimator_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(policyestimator_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
 {

--- a/src/test/raii_event_tests.cpp
+++ b/src/test/raii_event_tests.cpp
@@ -36,7 +36,7 @@ static void tag_free(void* mem) {
     free(mem);
 }
 
-BOOST_FIXTURE_TEST_SUITE(raii_event_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(raii_event_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(raii_event_creation)
 {

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -8,7 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(random_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(random_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(osrandom_tests)
 {

--- a/src/test/reverselock_tests.cpp
+++ b/src/test/reverselock_tests.cpp
@@ -7,7 +7,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(reverselock_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(reverselock_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(reverselock_basics)
 {

--- a/src/test/sanity_tests.cpp
+++ b/src/test/sanity_tests.cpp
@@ -8,7 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(sanity_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(sanity_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(basic_sanity)
 {

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -46,7 +46,7 @@ Verify(const CScript& scriptSig, const CScript& scriptPubKey, bool fStrict, Scri
 }
 
 
-BOOST_FIXTURE_TEST_SUITE(script_P2SH_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(script_P2SH_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sign)
 {

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -13,7 +13,7 @@
 #include <boost/test/unit_test.hpp>
 
 
-BOOST_FIXTURE_TEST_SUITE(script_standard_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(script_standard_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
 {

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -119,7 +119,7 @@ ScriptError_t ParseScriptError(const std::string &name)
     return SCRIPT_ERR_UNKNOWN_ERROR;
 }
 
-BOOST_FIXTURE_TEST_SUITE(script_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(script_tests, ReducedTestingSetup)
 
 CMutableTransaction BuildCreditingTransaction(const CScript& scriptPubKey, int nValue = 0)
 {

--- a/src/test/scriptnum_tests.cpp
+++ b/src/test/scriptnum_tests.cpp
@@ -10,7 +10,7 @@
 #include <limits.h>
 #include <stdint.h>
 
-BOOST_FIXTURE_TEST_SUITE(scriptnum_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(scriptnum_tests, ReducedTestingSetup)
 
 /** A selection of numbers that do not trigger int64_t overflow
  *  when added/subtracted. */

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(serialize_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(serialize_tests, ReducedTestingSetup)
 
 class CSerializeMethodsTestSingle
 {

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -115,7 +115,7 @@ void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
     }
 }
 
-BOOST_FIXTURE_TEST_SUITE(sighash_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(sighash_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sighash_test)
 {

--- a/src/test/sign_tests.cpp
+++ b/src/test/sign_tests.cpp
@@ -8,7 +8,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/unit_test_log.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(sign_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(sign_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(producesignature_vote_witness) {
   SeedInsecureRand();

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -23,7 +23,7 @@ Serialize(const CScript& s)
     return sSerialized;
 }
 
-BOOST_FIXTURE_TEST_SUITE(sigopcount_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(sigopcount_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(GetSigOpCount)
 {

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -12,7 +12,7 @@
 
 #define SKIPLIST_LENGTH 300000
 
-BOOST_FIXTURE_TEST_SUITE(skiplist_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(skiplist_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(skiplist_test)
 {

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -8,7 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(streams_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(streams_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(streams_vector_writer)
 {

--- a/src/test/test_unite.cpp
+++ b/src/test/test_unite.cpp
@@ -44,6 +44,25 @@ std::ostream& operator<<(std::ostream& os, const uint256& num)
     return os;
 }
 
+ReducedTestingSetup::ReducedTestingSetup(const std::string& chainName)
+{
+  SHA256AutoDetect();
+  RandomInit();
+  ECC_Start();
+  SetupEnvironment();
+  SetupNetworking();
+  InitSignatureCache();
+  InitScriptExecutionCache();
+  fPrintToDebugLog = false; // don't want to write to debug.log file
+  fCheckBlockIndex = true;
+  noui_connect();
+}
+
+ReducedTestingSetup::~ReducedTestingSetup()
+{
+  ECC_Stop();
+}
+
 BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
 {
         SHA256AutoDetect();

--- a/src/test/test_unite.h
+++ b/src/test/test_unite.h
@@ -44,6 +44,19 @@ static inline void InsecureNewKey(CKey &key, bool fCompressed) {
   assert(key.IsValid()); // Failure should be very rare
 }
 
+//! Configures almost as much as the BasicTestingSetup
+//! except for chain params - useful for testing stuff
+//! that is actually blockchain agnostic, yet requires
+//! a bit of infrastructure like logging or ECC_Start.
+//! This comment was carefully crafted such that every
+//! line would have the same number of characters, yo.
+struct ReducedTestingSetup {
+    ECCVerifyHandle globalVerifyHandle;
+
+    explicit ReducedTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
+    ~ReducedTestingSetup();
+};
+
 /** Basic testing setup.
  * This just configures logging and chain parameters.
  */

--- a/src/test/timedata_tests.cpp
+++ b/src/test/timedata_tests.cpp
@@ -7,7 +7,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(timedata_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(timedata_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(util_MedianFilter)
 {

--- a/src/test/torcontrol_tests.cpp
+++ b/src/test/torcontrol_tests.cpp
@@ -8,7 +8,7 @@
 #include <boost/test/unit_test.hpp>
 
 
-BOOST_FIXTURE_TEST_SUITE(torcontrol_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(torcontrol_tests, ReducedTestingSetup)
 
 void CheckSplitTorReplyLine(std::string input, std::string command, std::string args)
 {

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -91,7 +91,7 @@ std::string FormatScriptFlags(unsigned int flags)
     return ret.substr(0, ret.size() - 1);
 }
 
-BOOST_FIXTURE_TEST_SUITE(transaction_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(transaction_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(tx_valid)
 {

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -15,7 +15,7 @@
 #include <string>
 #include <stdio.h>
 
-BOOST_FIXTURE_TEST_SUITE(uint256_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(uint256_tests, ReducedTestingSetup)
 
 const unsigned char R1Array[] =
     "\x9c\x52\x4a\xdb\xcf\x56\x11\x12\x2b\x29\x12\x5e\x5d\x35\xd2\xd2"

--- a/src/test/util_fun_tests.cpp
+++ b/src/test/util_fun_tests.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(util_fun_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_SUITE(util_fun_tests)
 
 // take_while with different container/element types
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(util_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(util_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(util_criticalsection)
 {

--- a/src/wallet/test/crypto_tests.cpp
+++ b/src/wallet/test/crypto_tests.cpp
@@ -10,7 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(wallet_crypto, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(wallet_crypto, ReducedTestingSetup)
 
 class TestCrypter
 {


### PR DESCRIPTION
I am working on introducing the witness merkle tree root to the block header according to [ADR-3](https://github.com/dtr-org/unit-e-docs/pull/4). When doing this everything breaks (scarily enough everything compiles, C++ is quite a dynamic language...) - i.e. the unit tests segfault.

Most tests use the `BasicTestingSetup` which also initializes the chain params. This is not necessary for most unit test, as they are proper unit tests that test certain units in isolation. Nevertheless there are certain global systems (global state, hooray), like logging, which have to be initialized.

Therefor I am introducing a `ReducedTestingSetup` for some test.

To identify which tests should use the reduced testing setup I ran the tests with the merkle tree root added using the following command:

```
(for category in $(src/test/test_unite --list_content 2>&1 | grep -v -F '    '); do \
  (>&2 echo '## `' ${category} '`'); \
  (>&2 echo ''); \
  (>&2 echo '```'); \
  src/test/test_unite --run_test=${category}; \
  (>&2 echo ''); \
  (>&2 echo '```'); \
  (>&2 echo ''); \
  done) > report.md 2>&1
```

Here is the report: [report-with-witness-root-added-to-header.md.zip](https://github.com/dtr-org/unit-e/files/2375741/report-with-witness-root-added-to-header.md.zip).

That crashes almost every tests, except the ones which are not `FIXTURE` tests suits but simple `AUTO` test suits.

When removing one line form the `BasicTestingSetup` (the one which selects chain params) a lot less tests are breaking (see [report-without-chainparams.md.zip](https://github.com/dtr-org/unit-e/files/2375630/report-without-chainparams.md.zip)).

These are the tests which I moved into the `ReducedTestingSetup` category.
