### PR TITLE
remove unused functionality already ported from particl

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -105,19 +105,6 @@ void CChainParams::UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64
     consensus.vDeployments[d].nTimeout = nTimeout;
 }
 
-bool CChainParams::CheckImportCoinbase(int nHeight, uint256 &hash) const {
-  for (auto &cth : Params().vImportedCoinbaseTxns) {
-    if (cth.nHeight != (uint32_t)nHeight) {
-      continue;
-    }
-    if (hash == cth.hash) {
-      return true;
-    }
-    return error("%s - Hash mismatch at height %d: %s, expect %s.", __func__, nHeight, hash.ToString(), cth.hash.ToString());
-  }
-  return error("%s - Unknown height.", __func__);
-}
-
 /**
  * Main network
  */
@@ -128,7 +115,6 @@ bool CChainParams::CheckImportCoinbase(int nHeight, uint256 &hash) const {
  *    timestamp before)
  * + Contains no strange transactions
  */
-
 class CMainParams : public CChainParams {
 public:
     CMainParams() {
@@ -450,7 +436,7 @@ void UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64_t nStartTime,
     globalChainParams->UpdateVersionBitsParameters(d, nStartTime, nTimeout);
 }
 
-void UpdateFinalizationParams(esperanza::FinalizationParams &params) {
+void UpdateFinalizationParams(esperanza::FinalizationParams &params)
+{
     globalChainParams->UpdateFinalizationParams(params);
 }
-

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -35,15 +35,6 @@ struct ChainTxData {
     double dTxRate;
 };
 
-//! TODO document
-class CImportedCoinbaseTxn
-{
-public:
-    CImportedCoinbaseTxn(uint32_t nHeightIn, uint256 hashIn) : nHeight(nHeightIn), hash(hashIn) {};
-    uint32_t nHeight;
-    uint256 hash; // hash of output data
-};
-
 /**
  * CChainParams defines various tweakable parameters of a given instance of the
  * UnitE system. There are three: the main network on which people trade goods
@@ -91,9 +82,6 @@ public:
     void UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout);
     void UpdateFinalizationParams(esperanza::FinalizationParams &params);
 
-    bool CheckImportCoinbase(int nHeight, uint256 &hash) const;
-
-
 protected:
     CChainParams() {}
 
@@ -114,9 +102,6 @@ protected:
     bool fMineBlocksOnDemand;
     CCheckpointData checkpointData;
     ChainTxData chainTxData;
-
-    std::vector<CImportedCoinbaseTxn> vImportedCoinbaseTxns;
-    uint32_t nLastImportHeight;
 };
 
 /**

--- a/src/esperanza/stakevalidation.cpp
+++ b/src/esperanza/stakevalidation.cpp
@@ -177,9 +177,4 @@ bool ProposeBlock(const CBlock &block) {
                          /* fNewBlock out */ nullptr);
 }
 
-int GetNumBlocksOfPeers() {
-  // todo
-  return 0;
-}
-
 }  // namespace esperanza

--- a/src/esperanza/stakevalidation.h
+++ b/src/esperanza/stakevalidation.h
@@ -26,8 +26,6 @@ bool CheckBlock(const CBlock &block);
 
 bool ProposeBlock(const CBlock &block);
 
-int GetNumBlocksOfPeers();
-
 }  // namespace esperanza
 
 #endif  // UNITE_ESPERANZA_STAKEVALIDATION_H


### PR DESCRIPTION
remove some functions which were already ported from particl but we decided against using.

- `bool CChainParams::CheckImportCoinbase(int,uint256&)` According to https://github.com/dtr-org/unit-e-docs/pull/8 we do not use the import mechanism but take the initial supply from the genesis block only. This is safe and sound as we run permissioned in the beginning either way, so we can distribute funds also in early transactions if at all needed. The import-genesis-outputs functionality has already not been ported in the proposer.
- `class CImportedCoinbaseTxn` ditto
- `CChainParams::std::vector<CImportedCoinbaseTxn> vImportedCoinbaseTxns` ditto
- `uint32_t nLastImportHeight` ditto
` int GetNumBlocksOfPeers()` this relies on a modification of the ping message which we do not want to modify. It counts the height of the peers (a bit like `GetTime()`) but this information should already be available from the current chain tip. The implementation removed is a stub anyway and so far would be only used in the proposer
