### PR TITLE
Add whitelisting to avoid relay delays

### DIFF
--- a/test/functional/esperanza_deposit.py
+++ b/test/functional/esperanza_deposit.py
@@ -18,9 +18,10 @@ class EsperanzaDepositTest(UnitETestFramework):
             '-proposing=0',
             '-debug=all',
             '-rescan=1',
+            '-whitelist=127.0.0.1',
             '-esperanzaconfig=' + json_params
         ]
-        proposer_node_params = ['-proposing=0', '-debug=all', '-esperanzaconfig=' + json_params]
+        proposer_node_params = ['-proposing=0', '-debug=all', '-whitelist=127.0.0.1', '-esperanzaconfig=' + json_params]
 
         self.extra_args = [validator_node_params,
                            proposer_node_params,

--- a/test/functional/esperanza_finalizationstate.py
+++ b/test/functional/esperanza_finalizationstate.py
@@ -23,10 +23,11 @@ def test_setup(test, proposers, validators):
     validator_node_params = [
         '-validating=1',
         '-proposing=0',
+        '-whitelist=127.0.0.1',
         '-debug=all',
         '-esperanzaconfig=' + json_params
     ]
-    proposer_node_params = ['-proposing=0', '-debug=all', '-esperanzaconfig=' + json_params]
+    proposer_node_params = ['-proposing=0', '-debug=all', '-whitelist=127.0.0.1', '-esperanzaconfig=' + json_params]
 
     for n in range(0, proposers):
         test.extra_args.append(proposer_node_params)

--- a/test/functional/esperanza_vote.py
+++ b/test/functional/esperanza_vote.py
@@ -18,9 +18,10 @@ class EsperanzaVoteTest(UnitETestFramework):
             '-validating=1',
             '-proposing=0',
             '-debug=all',
+            '-whitelist=127.0.0.1',
             '-esperanzaconfig=' + json_params
         ]
-        proposer_node_params = ['-proposing=0','-debug=all', '-esperanzaconfig='+json_params]
+        proposer_node_params = ['-proposing=0','-debug=all', '-whitelist=127.0.0.1', '-esperanzaconfig='+json_params]
 
         self.extra_args = [proposer_node_params,
                            validator_node_params,


### PR DESCRIPTION
In order to make the tests faster and less reliable to delays
introduced by INVENTORY_BROADCAST_INTERVAL that causes some tests to
sometimes fail because of votes being outdated before arriving to a
proposer.