### PR TITLE
Remove 0x00 trailing tx_count in accordance with ADR-8

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2077,8 +2077,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 pindex = chainActive.Next(pindex);
         }
 
-        // we must use CBlocks, as CBlockHeaders won't include the 0x00 nTx count at the end
-        std::vector<CBlock> vHeaders;
+        std::vector<CBlockHeader> vHeaders;
         int nLimit = MAX_HEADERS_RESULTS;
         LogPrint(BCLog::NET, "getheaders %d to %s from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.IsNull() ? "end" : hashStop.ToString(), pfrom->GetId());
         for (; pindex; pindex = chainActive.Next(pindex))
@@ -2594,7 +2593,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
     {
         std::vector<CBlockHeader> headers;
 
-        // Bypass the normal CBlock deserialization, as we don't want to risk deserializing 2000 full blocks.
+        // Bypass the normal CBlockHeader deserialization, as we don't want to risk deserializing 2000 full blocks.
         unsigned int nCount = ReadCompactSize(vRecv);
         if (nCount > MAX_HEADERS_RESULTS) {
             LOCK(cs_main);
@@ -2604,7 +2603,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         headers.resize(nCount);
         for (unsigned int n = 0; n < nCount; n++) {
             vRecv >> headers[n];
-            ReadCompactSize(vRecv); // ignore tx count; assume it is 0.
         }
 
         // Headers received via a HEADERS message should be valid, and reflect
@@ -3280,7 +3278,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
             // blocks, or if the peer doesn't want headers, just
             // add all to the inv queue.
             LOCK(pto->cs_inventory);
-            std::vector<CBlock> vHeaders;
+            std::vector<CBlockHeader> vHeaders;
             bool fRevertToInv = ((!state.fPreferHeaders &&
                                  (!state.fPreferHeaderAndIDs || pto->vBlockHashesToAnnounce.size() > 1)) ||
                                 pto->vBlockHashesToAnnounce.size() > MAX_BLOCKS_TO_ANNOUNCE);

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1213,14 +1213,15 @@ class msg_headers():
         self.headers = headers if headers is not None else []
 
     def deserialize(self, f):
-        # comment in united indicates these should be deserialized as blocks
-        blocks = deser_vector(f, CBlock)
+        blocks = deser_vector(f, CBlockHeader)
         for x in blocks:
-            self.headers.append(CBlockHeader(x))
+            self.headers.append(x)
 
     def serialize(self):
-        blocks = [CBlock(x) for x in self.headers]
-        return ser_vector(blocks)
+        headers_to_send = []
+        for header in self.headers:
+            headers_to_send.append(CBlockHeader(header))
+        return ser_vector(headers_to_send)
 
     def __repr__(self):
         return "msg_headers(headers=%s)" % repr(self.headers)


### PR DESCRIPTION
This removes the superfluous trailing byte from the `headers` message.

I had a conversation with Pieter Wuille on the matter at stackexchange:

> Was the headers message also there along with the getheaders, or did the getheaders use to respond with blocks? – scravy

> The headers message was also there. – Pieter Wuille

> The headers message includes a transaction count which is always zero, bitcoin-core even skips it with a comment "assume it is 0". It looks like this was supposed to ease writing software that could just apply its block parsing logic on that message. But technically that number of transactions is superfluous, right? So I believe it is just a historical artefact that does not serve any future purpose? – scravy

> That's right. At the time, there was no separate CBlockHeader and CBlock; a header was just a CBlock with no transactions. – Pieter Wuille

We have an ADR for that: https://github.com/dtr-org/unit-e-docs/blob/master/adrs/2018-09-25-ADR-8%20Proper%20headers%20Message.md (PR was https://github.com/dtr-org/unit-e-docs/pull/9)