### PR TITLE
Replace travis_wait with a background job

### DIFF
--- a/.travis/test_06_script.sh
+++ b/.travis/test_06_script.sh
@@ -36,7 +36,9 @@ make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $
 export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
 
 if [ "$RUN_TESTS" = "true" ]; then
-  travis_wait 30 make $MAKEJOBS check VERBOSE=1
+  while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
+  make $MAKEJOBS check VERBOSE=1
+  kill %1
 fi
 
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then


### PR DESCRIPTION
travis_wait redirects temporary the output to a file and prevents the
current job to fail because of timeouts. At the moment is being used
when calling "make check", this is problematic since if a test fails
travis just kills the build and any output useful to fix the failing
test is gone forever (let alone the test name itself). With this
solution we prevent travis from killing the process at the cost of
mixing the logs between the "keep-alive" background job and the
"make check".