### PR TITLE
Fix compilation warning

### DIFF
--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -669,7 +669,7 @@ void WalletExtension::BlockConnected(
 
         // In case we are logged out, stop validating.
         FinalizationState *state = FinalizationState::GetState(pindex);
-        int currentDynasty = state->GetCurrentDynasty();
+        uint32_t currentDynasty = state->GetCurrentDynasty();
         if (currentDynasty >= validatorState.m_endDynasty) {
           LOCK(m_enclosingWallet->cs_wallet);
           validatorState.m_phase = ValidatorState::Phase::NOT_VALIDATING;


### PR DESCRIPTION
```
esperanza/walletextension.cpp:673:28: warning: comparison of integers of different signs: 'int' and 'uint32_t'
      (aka 'unsigned int') [-Wsign-compare]
        if (currentDynasty >= validatorState.m_endDynasty) {
            ~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
```