### PR TITLE
Introduce cs_validatorstate

### DIFF
--- a/src/esperanza/validatorstate.h
+++ b/src/esperanza/validatorstate.h
@@ -9,6 +9,7 @@
 #include <esperanza/vote.h>
 #include <primitives/transaction.h>
 #include <stdint.h>
+#include <sync.h>
 #include <uint256.h>
 #include <map>
 
@@ -25,6 +26,7 @@ BETTER_ENUM(
 )
 // clang-format on
 
+static CCriticalSection cs_validatorstate;
 struct ValidatorState {
   typedef _Phase Phase;
 

--- a/src/wallet/rpcvalidator.cpp
+++ b/src/wallet/rpcvalidator.cpp
@@ -27,7 +27,7 @@ UniValue deposit(const JSONRPCRequest &request)
         "1. address              (required) the destination for the deposit.\n"
         "2. amount               (required) the amount deposit.\n"
         "\nExamples:\n"
-            + HelpExampleRpc("deposit", ""));
+            + HelpExampleRpc("deposit", "\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" 150000000000"));
   }
 
   pwallet->BlockUntilSyncedToCurrentChain();


### PR DESCRIPTION
To avoid having to lock `cs_wallet` to guard the validatorState and to also avoid some problematic `cs_wallet` lock acquisition before calling `CommitTransaction()` that calls `LOCK2(cs_main, cs_wallet)`, potentially causing deadlocks. 