### PR TITLE
ignore build system temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ test/cache/*
 libuniteconsensus.pc
 contrib/devtools/split-debug.sh
 *.tmp
+confdefs.h
+conftest.c
+conftest.err


### PR DESCRIPTION
I upgraded to Mojave over the holiday and had to do a clean build including configure because things changed. While configure was running I committed something using `git commit -am` and ka-ching had some temporary files in my commit, emitted by configure.

Added them go .gitignore.