### PR TITLE
Fix flaky rpc_sendtypeto functional test (fixes #130)

### DIFF
--- a/.travis/test_06_script.sh
+++ b/.travis/test_06_script.sh
@@ -42,7 +42,7 @@ if [ "$RUN_TESTS" = "true" ]; then
 fi
 
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-  extended="--extended --exclude feature_pruning,feature_dbcrash,rpc_sendtypeto"
+  extended="--extended --exclude feature_pruning,feature_dbcrash"
 fi
 
 if [ "$RUN_TESTS" = "true" ]; then

--- a/test/functional/rpc_sendtypeto.py
+++ b/test/functional/rpc_sendtypeto.py
@@ -66,15 +66,16 @@ class SendtypetoTest(UnitETestFramework):
 
         # Estimate fee
         estimate_fee = True
+        outputs = [{'address': '2NBYu3St3rtzJb8AzvraXnXCUxEuCs23eZo', 'amount': 0.1}]
         fee_per_byte = Decimal('0.001') / 1000
         self.nodes[0].settxfee(fee_per_byte * 1000)
         fees = self.nodes[0].sendtypeto('unite', 'unite', outputs, 'comment', 'comment-to', estimate_fee)
-        assert_equal(fees['fee'], fees['bytes'] * fee_per_byte)
+        assert_greater_than(Decimal('1e-7'), abs(fee_per_byte - fees['fee'] / fees['bytes']))
 
         fee_per_byte *= 2
         coin_control = {'fee_rate': fee_per_byte * 1000}
         fees = self.nodes[0].sendtypeto('unite', 'unite', outputs, 'comment', 'comment-to', estimate_fee, coin_control)
-        assert_equal(fees['fee'], fees['bytes'] * fee_per_byte)
+        assert_greater_than(Decimal('1e-7'), abs(fee_per_byte - fees['fee'] / fees['bytes']))
 
 
 if __name__ == "__main__":

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -131,6 +131,7 @@ BASE_SCRIPTS= [
     'feature_spend_genesis.py',
     'rpc_filtertransactions.py',
     'feature_nulldummy.py',
+    'rpc_sendtypeto.py',
     'wallet_import_rescan.py',
     'mining_basic.py',
     'wallet_bumpfee.py',
@@ -181,7 +182,6 @@ EXTENDED_SCRIPTS = [
     'rpc_bind.py',
     # vv Tests less than 30s vv
     'example_test.py',
-    'rpc_sendtypeto.py',
 ]
 
 # Place EXTENDED_SCRIPTS first since it has the 3 longest running tests


### PR DESCRIPTION
The problem was in the transaction size calculation. `CWallet::CreateTransaction` calls `GetVirtualTransactionSize` for fee calculation after `DummySignTx`, and `sendtypeto` returns the size with actual signatures. In some cases, dummy signatures are longer than actual signatures and it results in higher than expected fees. I rewrote the test so it checks that the difference between the expected and actual fee rates is small enough. I guess this approach is ok because it is done in the same way in the wallet_bumpfee functional test.