### PR TITLE
Fix PPA name for getting BDB 4.8

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -85,7 +85,7 @@ BerkeleyDB is required for the wallet.
 You can add the repository and install using the following commands:
 
     sudo apt-get install software-properties-common
-    sudo add-apt-repository ppa:unite/unite
+    sudo add-apt-repository ppa:bitcoin/bitcoin
     sudo apt-get update
     sudo apt-get install libdb4.8-dev libdb4.8++-dev
 


### PR DESCRIPTION
This has to be fixed properly in clonemachine and it's probably only one of several occurences of this type of issue.

Adding it as a pull request for now to get at least working build docs here.