### PR TITLE
Add chainstate iterator over UTXOSubset

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -172,6 +172,7 @@ UNITE_CORE_H = \
   script/sign.h \
   script/standard.h \
   script/ismine.h \
+  snapshot/chainstate_iterator.h \
   snapshot/creator.h \
   snapshot/indexer.h \
   snapshot/initialization.h \
@@ -276,6 +277,7 @@ libunite_server_a_SOURCES = \
   rpc/server.cpp \
   script/sigcache.cpp \
   script/ismine.cpp \
+  snapshot/chainstate_iterator.cpp \
   snapshot/creator.cpp \
   snapshot/indexer.cpp \
   snapshot/initialization.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -87,6 +87,7 @@ UNITE_TESTS =\
   test/sigopcount_tests.cpp \
   test/sign_tests.cpp \
   test/skiplist_tests.cpp \
+  test/snapshot_chainstate_iterator_tests.cpp \
   test/snapshot_creator_tests.cpp \
   test/snapshot_indexer_tests.cpp \
   test/snapshot_iterator_tests.cpp \

--- a/src/snapshot/chainstate_iterator.cpp
+++ b/src/snapshot/chainstate_iterator.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2018 The unit-e core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <snapshot/chainstate_iterator.h>
+
+#include <coins.h>
+
+namespace snapshot {
+
+ChainstateIterator::ChainstateIterator(CCoinsViewDB *view)
+    : m_valid(true), m_cursor(view->Cursor()) {
+  Next();
+}
+
+bool ChainstateIterator::Valid() { return m_valid; }
+
+void ChainstateIterator::Next() {
+  bool stop = false;
+  while (m_cursor->Valid()) {
+    COutPoint key;
+    Coin coin;
+    if (m_cursor->GetKey(key) && m_cursor->GetValue(coin)) {
+      if (!m_outputs.empty() && key.hash != m_prevTxId) {
+        m_utxoSubset =
+            UTXOSubset(m_prevTxId, m_prevCoin.nHeight, m_prevCoin.IsCoinBase(),
+                       std::move(m_outputs));
+        m_outputs.clear();
+        stop = true;
+      }
+
+      m_outputs[key.n] = coin.out;
+      m_prevCoin = coin;
+      m_prevTxId = key.hash;
+    }
+
+    m_cursor->Next();
+
+    if (stop) {
+      return;
+    }
+  }
+
+  // we reached the end of the out chainstate. construct the last UTXO subset
+
+  if (m_outputs.empty()) {
+    m_valid = false;
+    return;
+  }
+
+  m_utxoSubset = UTXOSubset(m_prevTxId, m_prevCoin.nHeight,
+                            m_prevCoin.IsCoinBase(), std::move(m_outputs));
+  m_outputs.clear();
+}
+
+}  // namespace snapshot

--- a/src/snapshot/chainstate_iterator.h
+++ b/src/snapshot/chainstate_iterator.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2018 The unit-e core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef UNITE_CHAINSTATE_ITERATOR_H
+#define UNITE_CHAINSTATE_ITERATOR_H
+
+#include <stdint.h>
+#include <map>
+#include <memory>
+
+#include <primitives/transaction.h>
+#include <snapshot/messages.h>
+#include <txdb.h>
+#include <uint256.h>
+
+namespace snapshot {
+
+class ChainstateIterator {
+ public:
+  explicit ChainstateIterator(CCoinsViewDB *view);
+  bool Valid();
+  void Next();
+  const UTXOSubset &GetUTXOSubset() { return m_utxoSubset; }
+  const uint256 &GetBestBlock() { return m_cursor->GetBestBlock(); }
+
+ private:
+  bool m_valid;
+  std::unique_ptr<CCoinsViewCursor> m_cursor;
+  std::map<uint32_t, CTxOut> m_outputs;
+  Coin m_prevCoin;
+  uint256 m_prevTxId;
+  UTXOSubset m_utxoSubset;
+};
+
+}  // namespace snapshot
+
+#endif  // UNITE_CHAINSTATE_ITERATOR_H

--- a/src/test/snapshot_chainstate_iterator_tests.cpp
+++ b/src/test/snapshot_chainstate_iterator_tests.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2018 The unit-e core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <snapshot/chainstate_iterator.h>
+
+#include <test/test_unite.h>
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(snapshot_chainstate_iterator_tests, BasicTestingSetup)
+
+uint256 uint256FromUint64(uint64_t n) {
+  CDataStream s(SER_DISK, PROTOCOL_VERSION);
+  s << n;
+  s << uint64_t(0);
+  s << uint64_t(0);
+  s << uint64_t(0);
+  uint256 nn;
+  s >> nn;
+  return nn;
+}
+
+BOOST_AUTO_TEST_CASE(chainstate_iterator) {
+  SetDataDir("snapshot_chainstate_iterator");
+  fs::remove_all(GetDataDir() / snapshot::SNAPSHOT_FOLDER);
+
+  auto view = MakeUnique<CCoinsViewDB>(0, false, true);
+  uint64_t totalTxs = 10;
+  {
+    // generate 10 transactions that every new transaction
+    // has one more output than the previous one.
+    // tx0(1 output), tx1(2 outputs), txn(n outputs)
+    for (uint64_t txId = 0; txId < totalTxs; ++txId) {
+      CCoinsMap map;
+      for (uint32_t i = 0; i < txId + 1; ++i) {
+        COutPoint point;
+        point.n = i;
+        point.hash = uint256FromUint64(txId);
+
+        CCoinsCacheEntry entry;
+        entry.flags |= CCoinsCacheEntry::Flags::DIRTY;
+        entry.coin = Coin();
+        entry.coin.out.nValue = txId * 100 + i;
+        entry.coin.nHeight = static_cast<uint32_t>(txId);
+        entry.coin.fCoinBase = static_cast<unsigned int>(txId % 2);
+
+        map[point] = entry;
+      }
+      BOOST_CHECK(view->BatchWrite(map, uint256S("aa")));
+    }
+  }
+
+  snapshot::ChainstateIterator iter(view.get());
+  uint64_t count = 0;
+  while (iter.Valid()) {
+    snapshot::UTXOSubset subset = iter.GetUTXOSubset();
+    BOOST_CHECK_EQUAL(subset.m_height, count);
+    BOOST_CHECK_EQUAL(subset.m_txId.GetUint64(0), count);
+    BOOST_CHECK_EQUAL(subset.m_isCoinBase, count % 2 == 1);
+    BOOST_CHECK_EQUAL(subset.m_outputs.size(), count + 1);
+
+    int n = 0;
+    for (const auto &p : subset.m_outputs) {
+      BOOST_CHECK_EQUAL(p.first, n);
+      BOOST_CHECK_EQUAL(p.second.nValue, count * 100 + n);
+      ++n;
+    }
+
+    iter.Next();
+    ++count;
+  }
+  BOOST_CHECK_EQUAL(count, totalTxs);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The reason for encapsulating the iteration of UTXO subsets is to accurately test the conversion of UTXOs to UTXO subsets.

Also, I plan to use this iterator later in different benchmarks of UTXO vs. UTXOSubset.