### PR TITLE
Require to use snake_case convention for variables

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -24,8 +24,8 @@ tool to clean up patches automatically before submission.
     braces are required, and the `then` and `else` clauses must appear
     correctly indented on a new line.
 
-- **Symbol naming conventions**. These are required for new code but no need
-change the old one just for the sake of renaming, only if the logic is touched.
+- **Symbol naming conventions**. These are required for the new code but no need
+to change the old one just for the sake of renaming, only if the logic is touched.
   - Variable and namespace names are all lowercase, and may use `_` to
     separate words (snake_case).
     - Class member variables have a `m_` prefix.


### PR DESCRIPTION
Reasons:
1. no need to have two standards, we need to stick to the one
2. snake_case is already recommended by Bitcoin
3. snake_case is the requirement from the Google Style Guide
4. we already have the standard to use `m_` prefix for member variables,
it contradicts with the rest of the variable name, `m_mixedCase`, we should either have
`m_snake_case` or `mMixedCase`