### PR TITLE
Make lint-clang-format.py be useful for pre-commit hook

### DIFF
--- a/contrib/devtools/shared/lib.py
+++ b/contrib/devtools/shared/lib.py
@@ -18,16 +18,27 @@ def changeto(dir = "."):
       sys.exit(1)
   os.chdir(dir)
 
+def listchangedfiles():
+  ps = subprocess.Popen("git diff --cached --name-status --relative",
+                        shell=True,
+                        stdout=subprocess.PIPE)
+  result = []
+  for line in ps.stdout.read().decode("utf-8").splitlines():
+    status, filename = line.split()
+    if status in ["A", "M"]:
+      result += [filename]
+  return result
+
 def listfiles(glob = "*"):
   ps = subprocess.Popen("git ls-files '*'", shell=True, stdout=subprocess.PIPE)
   lines = ps.stdout.read().decode("utf-8")
   return list(filter(None, lines.split("\n")))
 
-def checkfiles(action, pattern = None, glob = "*", dir = ".", invert = False):
+def checkfiles(action, pattern = None, glob = "*", dir = ".", invert = False, only_changed = False):
   workingdirectory = os.getcwd()
   try:
     changeto(dir)
-    fileset = listfiles()
+    fileset = listchangedfiles() if only_changed else listfiles()
     violations = []
     for filename in fileset:
       if pattern:
@@ -39,4 +50,3 @@ def checkfiles(action, pattern = None, glob = "*", dir = ".", invert = False):
     return violations
   finally:
     os.chdir(workingdirectory) # restory working directory
-


### PR DESCRIPTION
There are some improvements for lint-clang-format.py checker I made in order to comfortably use it from git pre-commit hook. It might be useful in order to save our times when travis rejects changes just because of code style.

* The default behavior is the same as it was.
* An option added to scan only files added and modified by the current commit (with respect to original bitcoin's files). It's much faster rather than scan all the files.
* Options added to auto update/add formatted files back into commit.

As an example there is my pre-commit:
```
#!/bin/sh

unset GIT_DIR
./contrib/devtools/lint-clang-format.py --check-commit --replace --git-add
```
If you don't want it updates your files on every commit, use only `--check-commit` option.