### PR TITLE
Document maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,21 +30,23 @@ We do assume a model of shared ownership of the code. So other maintainers, peer
 reviewers, and contributors are encouraged to review and work on all parts of
 the code.
 
-The Proof-of-Stake consensus protocol is at the core of UnitE. Changes to it
-can affect the whole network so they need special review. The implementation
-consist of the code to run nodes in the different required roles as proposers,
-validators, or general nodes.
+The consensus implementation is at the core of UnitE. Changes to it can affect
+the whole network so they need special review. The implementation consist of the
+code to run nodes in the different required roles as proposers, validators, or
+general nodes.
 
-* Block proposal, the process of creating new blocks for the blockchain: [Julian
+* Block proposal, the process of creating new blocks for the blockchain (mostly
+  in `src/proposer`): [Julian
   Fleischer (@scravy)](https://github.com/scravy)
 * Validator role, which mainly contains finalization, the process of making
-  blocks non reversible through Byzantine agreement: [Matteo
+  blocks non reversible through Byzantine agreement (mostly in `src/esperanza`): [Matteo
   Sumberaz (@Gnappuraz)](https://github.com/Gnappuraz)
-* Shared validation logic run by all nodes:  [Julian
+* Shared validation logic run by all nodes (mostly in `src/staking`):  [Julian
   Fleischer (@scravy)](https://github.com/scravy),
   [Matteo Sumberaz (@Gnappuraz)](https://github.com/Gnappuraz)
 * Permissioning system, manages validator whitelist and stores it in the
-  blockchain, used for bootstrapping the blockchain: [Aleksandr
+  blockchain, used for bootstrapping the blockchain (mostly in `src/esperanza/admin*`): [Aleksandr
   Mikhailov (@AM5800)](https://github.com/AM5800)
-* Snapshots, fast syncing of clients through snapshots of the UTXO database:
+* Snapshots, fast syncing of clients through snapshots of the UTXO database
+  (mostly in `src/snapshot/`):
   [Kostiantyn Stepaniuk (@kostyantyn)](https://github.com/kostyantyn)


### PR DESCRIPTION
Add MAINTAINERS.md as human-readable definition of maintainers and
CODEOWNERS as machine-readable form which lets GitHub automatically
assign reviewers to pull requests changing files matched by the
patterns defined in the CODEOWNERS files.

Fixes https://github.com/dtr-org/unit-e-docs/issues/17

There are a few things left to do:

* [x] Complete the list of expert areas
* [x] Create `Maintainers` team on GitHub in the `dtr-org` organization

I would also appreciate feedback if the way we list people here is ok with everybody.
