### PR TITLE
WIP: use ubuntu xenial in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ jobs:
         UNITE_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
 # Win32
     - stage: test
+      dist: trusty
       env: >-
         HOST=i686-w64-mingw32
         DPKG_ADD_ARCH="i386"
@@ -101,6 +102,7 @@ jobs:
         USE_SHELL="/bin/dash"
 # Win64
     - stage: test
+      dist: trusty
       env: >-
         HOST=x86_64-w64-mingw32
         DPKG_ADD_ARCH="i386"


### PR DESCRIPTION
So far travis only supported ubuntu precise (12.04, EOL) and trusty (14.04). It's 2018 and after 4 years they are now starting to support xenial (16.04). The feature is undocumented as of yet, but works! Hooray!

...Ubuntu 16.04 is also what current bitcoin builds against, using docker. Ubuntu 16.04 has some useful packages available which are not available in 14.04, for example `clang-tidy`.