### PR TITLE
Fixed test using fakeit for gcc with optimization enabled

### DIFF
--- a/src/test/proposer/proposer_tests.cpp
+++ b/src/test/proposer/proposer_tests.cpp
@@ -8,9 +8,17 @@
 #include <wallet/wallet.h>
 #include <boost/test/unit_test.hpp>
 
-#include <test/fakeit/fakeit.hpp>
-
 #include <thread>
+
+#ifdef __GNUG__
+
+// Fakeit does not work with GCC's devirtualization
+// which is enabled with -O2 (the default) or higher.
+#pragma GCC optimize("no-devirtualize")
+
+#endif
+
+#include <test/fakeit/fakeit.hpp>
 
 namespace proposer {
 


### PR DESCRIPTION
It turns out that fakeit doesn't work with GCC's devirtualization (clang's one is fine). So we can either stop using fakeit, always run tests with debug enabled, or disable devirtualization where we use fakeit.
I think the solution is fine, as we are using fakeit only in tests, and we turn off devirtualization only in the files using fakeit (nothing else is affected by it - the binary output for united does not change either).

Some info about the issue [here](https://github.com/eranpeer/FakeIt/issues/84#issuecomment-288130069).