### PR TITLE
Fix listchangedfiles() in lib.py

### DIFF
--- a/contrib/devtools/shared/lib.py
+++ b/contrib/devtools/shared/lib.py
@@ -19,14 +19,13 @@ def changeto(dir = "."):
   os.chdir(dir)
 
 def listchangedfiles():
-  ps = subprocess.Popen("git diff --cached --name-status --relative",
+  ps = subprocess.Popen("git diff --cached --name-status --relative --diff-filter=AM",
                         shell=True,
                         stdout=subprocess.PIPE)
   result = []
   for line in ps.stdout.read().decode("utf-8").splitlines():
-    status, filename = line.split()
-    if status in ["A", "M"]:
-      result += [filename]
+    _, filename = line.split()
+    result += [filename]
   return result
 
 def listfiles(glob = "*"):


### PR DESCRIPTION
The `listchangedfiles()` function in lib.py fails if used to evaluate a diff that contains multiple files in the same line (i.e. a rename entry).

```
Commit failed with error
0 files committed, 8 files failed to commit: Rename esperanza params to parameters
Formatting commit with clang-format
splitting: M	finalizationstate.cpp
splitting: R098	params.cpp	parameters.cpp
Traceback (most recent call last):
File "./contrib/devtools/lint-clang-format.py", line 78, in <module>
sys.exit(main(sys.argv))
File "./contrib/devtools/lint-clang-format.py", line 74, in main
only_changed = iscurrentcommit)
File "/Users/darkstar/projects/unit-e/contrib/devtools/shared/lib.py", line 42, in checkfiles
fileset = listchangedfiles() if only_changed else listfiles()
File "/Users/darkstar/projects/unit-e/contrib/devtools/shared/lib.py", line 28, in listchangedfiles
status, filename = line.split()
ValueError: too many values to unpack (expected 2)
```