### PR TITLE
Resolve todos in esperanza_admin_full_cycle

### DIFF
--- a/test/functional/esperanza_admin_full_cycle.py
+++ b/test/functional/esperanza_admin_full_cycle.py
@@ -199,13 +199,11 @@ class AdminFullCycle(UnitETestFramework):
         # should continue voting
         admin.end_permissioning()
 
-        # TODO:
-        # validator1.deposit_ok()
+        validator1.deposit_ok()
         self.sync_generate(proposer, n_blocks)
 
-        # TODO:
-        # assert (
-        #     prev_n_blocks_have_txs_from(proposer, validator1.address, n_blocks))
+        assert (
+            prev_n_blocks_have_txs_from(proposer, validator1.address, n_blocks))
         assert (
             prev_n_blocks_have_txs_from(proposer, validator2.address, n_blocks))
         assert (


### PR DESCRIPTION
When permissioning was first merged - there were some todos left. They were related to a minor bug in withdraw. Bug is fixed a long time ago (not sure if the issue exists). So it is time to fix todos

Signed-off-by: Aleksandr Mikhailov <aleksandr@thirdhash.com>