### PR TITLE
Add mergable github app config

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,0 +1,7 @@
+mergeable:
+  pull_requests:
+    label: 'work in progress'
+    title: 'wip'
+    description:
+      no-empty: true
+


### PR DESCRIPTION
I enabled the [mergeable github app](https://github.com/apps/mergeable) last friday. The default config is as follows:

```
  ####################
  # default settings
  ####################
  mergeable:
    pull_requests:
      label: 'work in progress|do not merge|experimental|proof of concept'
      title: 'wip|dnm|exp|poc'
      description:
        no-empty: true
```

that is: It requires the title not to match the given regex. This prevents #240 from being merged as it contains "poc" in the title ("[...] epochs"). Adjusting that config to only be triggered for "WIP" (work in progress).

The full configuration options can be found on [mergeable's github page](https://github.com/jusx/mergeable)