### PR TITLE
Adapt command inserting copyright headers to Unit-e

### DIFF
--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -460,7 +460,7 @@ def get_header_lines(header, start_year, end_year):
     return [line + '\n' for line in lines]
 
 CPP_HEADER = '''
-// Copyright (c) %s The Bitcoin Core developers
+// Copyright (c) %s The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''
@@ -469,7 +469,7 @@ def get_cpp_header_lines_to_insert(start_year, end_year):
     return reversed(get_header_lines(CPP_HEADER, start_year, end_year))
 
 PYTHON_HEADER = '''
-# Copyright (c) %s The Bitcoin Core developers
+# Copyright (c) %s The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''
@@ -523,7 +523,7 @@ def insert_cpp_header(filename, file_lines, start_year, end_year):
 def exec_insert_header(filename, style):
     file_lines = read_file_lines(filename)
     if file_already_has_core_copyright(file_lines):
-        sys.exit('*** %s already has a copyright by The Bitcoin Core developers'
+        sys.exit('*** %s already has a copyright by The Unit-e developers'
                  % (filename))
     start_year, end_year = get_git_change_year_range(filename)
     if style == 'python':
@@ -536,7 +536,7 @@ def exec_insert_header(filename, style):
 ################################################################################
 
 INSERT_USAGE = """
-Inserts a copyright header for "The Bitcoin Core developers" at the top of the
+Inserts a copyright header for "The Unit-e developers" at the top of the
 file in either Python or C++ style as determined by the file extension. If the
 file is a Python file and it has a '#!' starting the first line, the header is
 inserted in the line below it.
@@ -550,7 +550,7 @@ where <year_introduced> is according to the 'git log' history. If
 
 "<current_year>"
 
-If the file already has a copyright for "The Bitcoin Core developers", the
+If the file already has a copyright for "The Unit-e developers", the
 script will exit.
 
 Usage:
@@ -582,8 +582,8 @@ def insert_cmd(argv):
 ################################################################################
 
 USAGE = """
-copyright_header.py - utilities for managing copyright headers of 'The UnitE
-Core developers' in repository source files.
+copyright_header.py - utilities for managing copyright headers of 'The Unit-e
+developers' in repository source files.
 
 Usage:
     $ ./copyright_header <subcommand>


### PR DESCRIPTION
Adapt `copyright_header.py insert <filename> command so that it
inserts copyright headers for the Unit-e developers.

This is a prerequisite for proceeding with https://github.com/dtr-org/unit-e/pull/214 to get clean license headers throughout the code base. It's also related to settling on a consistent naming scheme (#228).

Note that this pull request implies the decision to settle on "Copyright (c) 2018 The Unit-e developers" as the canonical copyright header for code written by the Unit-e team.

Using a team name in a copyright header is a bit of a stretch as it only has limited legal usefulness. The actual copyright is still determined by who has written the code. This can be determined through the git history. It still is a common practice to add such a general header in order to avoid having to track individual copyright holders separately from the git history.

In this sense this copyright header can be interpreted broadly to refer to the whole Unit-e community which is contributing to the project. Adding individual copyrights, especially when code is brought in from external sources, is still fine.

Also note that this pull request implies that we are referring to the software as `Unit-e`, not `Unit-e Core` because this is more natural in our context as we don't have the history which triggered using Core as the attribute for the upstream client.

This patch only changes the tool to add copyright headers. Actually adding headers in the files where these headers are missing will be done in a follow-up pull request.