### PR TITLE
Suppress unknown pragma warning on mac

### DIFF
--- a/src/test/proposer/proposer_tests.cpp
+++ b/src/test/proposer/proposer_tests.cpp
@@ -10,7 +10,7 @@
 
 #include <thread>
 
-#ifdef __GNUG__
+#if defined(__GNUG__) and not defined(__clang__)
 
 // Fakeit does not work with GCC's devirtualization
 // which is enabled with -O2 (the default) or higher.


### PR DESCRIPTION
On the Mac, the code is compiled by clang with gcc interface. Because it's still clang, it ignores gcc pragmas. So this change is to suppress pragma warnings on the mac.