### PR TITLE
add blockchain parameters + genesis

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -430,9 +430,9 @@ libunite_common_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libunite_common_a_SOURCES = \
   base58.cpp \
   bech32.cpp \
-  chainparams.cpp \
   blockchain/blockchain_genesis.cpp \
   blockchain/blockchain_parameters.cpp \
+  chainparams.cpp \
   coins.cpp \
   compressor.cpp \
   core_read.cpp \

--- a/src/blockchain/blockchain_genesis.cpp
+++ b/src/blockchain/blockchain_genesis.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The unit-e core developers
+// Copyright (c) 2018 The The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -31,8 +31,9 @@ class GenesisBlockBuilderImpl : public GenesisBlockBuilder {
     tx.SetVersion(2);
     tx.SetType(TxType::COINSTAKE);
 
-    const std::string comment("Whereof one cannot speak, thereof one must be silent.");
-    const CScript scriptSig = CScript() << std::vector<uint8_t>(comment.cbegin(), comment.cend());
+    const CScript scriptSig = CScript() << CScriptNum::serialize(0)  // height
+                                        << ToByteVector(uint256())   // utxo set hash
+                                        << OP_0;
 
     tx.vin.emplace_back(uint256(), 0, scriptSig);
 
@@ -60,7 +61,7 @@ class GenesisBlockBuilderImpl : public GenesisBlockBuilder {
     genesis_block.hashPrevBlock = uint256();
     genesis_block.hashMerkleRoot = BlockMerkleRoot(genesis_block);
 
-    // TODO: This will be enabled once we merge the proposer/segwit pull request
+    // UNIT-E: TODO: This will be enabled once we merge the proposer/segwit pull request
     // genesis_block.hashWitnessMerkleRoot = BlockWitnessMerkleRoot(genesis_block);
 
     assert(genesis_block.vtx.size() == 1);
@@ -70,59 +71,41 @@ class GenesisBlockBuilderImpl : public GenesisBlockBuilder {
     assert(genesis_block.vtx[0]->vout.size() == m_initial_funds.size());
     assert(genesis_block.hashMerkleRoot == genesis_block.vtx[0]->GetHash());
 
-    // TODO: This will be enabled once we merge the proposer/segwit pull request
+    // UNIT-E: TODO: This will be enabled once we merge the proposer/segwit pull request
     // assert(genesis_block.hashWitnessMerkleRoot == genesis_block.hashMerkleRoot);
 
     return genesis_block;
-  };
+  }
 
   void SetVersion(const uint32_t version) override {
     m_version = version;
-  };
+  }
 
   void SetTime(const uint32_t time) override {
     m_time = time;
-  };
+  }
 
   void SetBits(const uint32_t bits) override {
     m_bits = bits;
-  };
+  }
 
   void SetDifficulty(const uint256 difficulty) override {
     m_bits = UintToArith256(difficulty).GetCompact();
-  };
-
-#ifdef SOME_CONSTANT_THAT_IS_SURELY_NOT_DEFINED
-  void AddFundsForWallet(const CAmount amount,
-                         const std::string &mnemonic,
-                         const std::string &passphrase) override {
-    CWallet wallet;
-    key::mnemonic::Seed seed(mnemonic, passphrase);
-    const CPubKey masterKey = wallet.GenerateNewHDMasterKey(&seed);
-    wallet.SetHDMasterKey(masterKey);
-    CPubKey pubKey;
-    if (!wallet.GetKeyFromPool(pubKey)) {
-      return;
-    }
-    const CKeyID keyID = pubKey.GetID();
-    const std::string keyHash = HexStr(keyID.begin(), keyID.end());
-    AddFundsForPubKeyHash(amount, keyHash);
-  };
-#endif
+  }
 
   void AddFundsForPayToPubKeyHash(const CAmount amount,
                                   const std::string &hexKey) override {
     const std::vector<std::uint8_t> data = ParseHex(hexKey);
     const uint160 pubKeyHash(data);
     m_initial_funds.emplace_back(amount, WitnessV0KeyHash(pubKeyHash));
-  };
+  }
 
   void AddFundsForPayToScriptHash(const CAmount amount,
                                   const std::string &hexScriptHash) override {
     const std::vector<std::uint8_t> data = ParseHex(hexScriptHash);
     const uint256 scriptHash(data);
     m_initial_funds.emplace_back(amount, WitnessV0ScriptHash(scriptHash));
-  };
+  }
 };
 
 std::unique_ptr<GenesisBlockBuilder> GenesisBlockBuilder::New() {

--- a/src/blockchain/blockchain_genesis.h
+++ b/src/blockchain/blockchain_genesis.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The unit-e core developers
+// Copyright (c) 2018 The The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/blockchain/blockchain_parameters.cpp
+++ b/src/blockchain/blockchain_parameters.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The unit-e core developers
+// Copyright (c) 2018 The The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -17,7 +17,6 @@ Parameters BuildMainNetParameters() {
   p.blockStakeTimestampIntervalSeconds = 16;
   p.blockTimeSeconds = 16;
   p.relayNonStandardTransactions = false;
-  p.requireStandard = true;
   p.mineBlocksOnDemand = false;
   p.maximumBlockSize = 1000000;
   p.maximumBlockWeight = 4000000;
@@ -25,17 +24,10 @@ Parameters BuildMainNetParameters() {
   p.maximumBlockSigopsCost = 80000;
   p.coinstakeMaturity = 100;
   p.rewardFunction = [](const Parameters &p, MoneySupply s, BlockHeight h) -> CAmount {
+    // UNIT-E: This reward function is not here to stay, it is just some simple reward function as in particl
     constexpr uint64_t secondsInAYear = 365 * 24 * 60 * 60;
     // 2 percent inflation (2% of current money supply distributed over all blocks in a year)
     return (s * 2 / 100) / (secondsInAYear / p.blockStakeTimestampIntervalSeconds);
-  };
-  p.rewardFunction = [](const Parameters &p, MoneySupply s, BlockHeight h) -> CAmount {
-    constexpr CAmount initial_reward = 50 * UNIT;
-    int halvings = h / 210000;
-    if (halvings >= 64) {
-      return 0;
-    }
-    return initial_reward >> halvings;
   };
   p.messageStartChars[0] = 0xee;
   p.messageStartChars[1] = 0xee;
@@ -59,7 +51,6 @@ Parameters BuildTestNetParameters() {
   Parameters p = Parameters::MainNet();
   p.networkName = "test";
   p.relayNonStandardTransactions = true;
-  p.requireStandard = false;
   p.messageStartChars[0] = 0xfd;
   p.messageStartChars[1] = 0xfc;
   p.messageStartChars[2] = 0xfb;

--- a/src/blockchain/blockchain_parameters.h
+++ b/src/blockchain/blockchain_parameters.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The unit-e core developers
+// Copyright (c) 2018 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -68,23 +68,22 @@ struct Parameters {
   const char *networkName;
 
   //! \brief The genesis hash of the genesis block of this chain.
-  //!
-  //!
   const char *genesisBlockHash;
 
   //! \brief The genesis block of this chain.
-  //!
-  //! This fied
   GenesisBlock const *genesisBlock;
 
-  //! \brief
+  //! \brief The usable staking timestamps
   //!
+  //! The kernel protocol for Proof of Stake masks timestamps such that a proposer
+  //! can use the same stake only every blockStakeTimestampIntervalSeconds. That is:
+  //! The blocktime used to compute the kernel hash is always:
+  //!
+  //! kernel_hash_ingredient = current_time - (current_time % blockStakeTimestampIntervalSeconds)
   //!
   std::uint32_t blockStakeTimestampIntervalSeconds;
 
   //! \brief frequency of blocks (a block time of 37 secs is one block every 37 secs)
-  //!
-  //!
   std::uint32_t blockTimeSeconds;
 
   //! \brief Whether nodes in this network should relay non-standard transactions by default or not.
@@ -95,6 +94,9 @@ struct Parameters {
   //! is set to true. This parameter can be overriden by a client, it is a
   //! network policy.
   bool relayNonStandardTransactions;
+
+  //! \brief The maximum allowed block size (MAX_BLOCK_SIZE).
+  std::uint32_t maximumBlockSize;
 
   //! \brief The maximum allowed weight for a block.
   //!
@@ -108,8 +110,6 @@ struct Parameters {
   //! number of outputs (i.e. a lot more outputs than inputs) then the effective
   //! block size might not be much bigger than MAX_BLOCK_SIZE.
   std::uint32_t maximumBlockWeight;
-
-  std::uint32_t maximumBlockSize;
 
   //! \brief The maximum allowed size for a serialized block, in bytes.
   //!
@@ -127,8 +127,6 @@ struct Parameters {
   std::uint32_t maximumBlockSigopsCost;
 
   //! \brief Coinstake transaction outputs can only be used for staking at this depth.
-  //!
-  //!
   BlockHeight coinstakeMaturity;
 
   //! \brief The function calculating the reward for a newly proposed block.
@@ -136,11 +134,6 @@ struct Parameters {
   //! See description of "RewardFunction". The reward function can (and should)
   //! be given as a pure lambda function.
   RewardFunction rewardFunction;
-
-  //! \brief
-  //!
-  //!
-  bool requireStandard;
 
   //! \brief Whether to allow the "generatetoaddress" and "generate" RPC calls.
   bool mineBlocksOnDemand;
@@ -159,7 +152,7 @@ struct Parameters {
   //!
   //! See https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki
   //!
-  //! TODO: Use a better-enum for deployments to not resort to the MAX_VERSION_BITS_DEPLOYMENTS hack
+  //! UNIT-E: Use a better-enum for deployments to not resort to the MAX_VERSION_BITS_DEPLOYMENTS hack
   //! (the hack here is to utilize one extra enum for the number of enum values)
   Consensus::BIP9Deployment vDeployments[Consensus::MAX_VERSION_BITS_DEPLOYMENTS];
 


### PR DESCRIPTION
I am starting to separate things from #212 in order for it to be easier reviewable and mergable. This particular piece is the blockchain parameters and genesis block creation.

Ultimately I want to get rid of `chainparams` (and chainparamsbase and the like). The idea here being that it can't even conflict with bitcoin if it does not exist. Since we're starting over we are not interested in bitcoin checkpoints, bitcoin versions, etc. Also this version is way cleaner.

Right now it would be dead code though, which changes once merged with #212. I nevertheless would like to merge this separately.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
