### PR TITLE
Use & for EnumSet intersection

### DIFF
--- a/src/better-enums/enum_set.h
+++ b/src/better-enums/enum_set.h
@@ -136,7 +136,7 @@ class EnumSet {
   }
 
   //! \brief set intersection
-  EnumSet<Enum> operator^(const EnumSet<Enum> other) const {
+  EnumSet<Enum> operator&(const EnumSet<Enum> other) const {
     return EnumSet(m_bits & other.m_bits);
   }
 
@@ -160,8 +160,8 @@ class EnumSet {
     return *this;
   }
 
-  EnumSet<Enum> &operator^=(const EnumSet<Enum> other) {
-    *this = *this ^ other;
+  EnumSet<Enum> &operator&=(const EnumSet<Enum> other) {
+    *this = *this & other;
     return *this;
   }
 

--- a/src/test/better_enum_set_tests.cpp
+++ b/src/test/better_enum_set_tests.cpp
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(check_intersection) {
   s2 += SomeTestEnum::F;
   s2 += SomeTestEnum::H;
 
-  EnumSet<SomeTestEnum> s3 = s1 ^ s2;
+  EnumSet<SomeTestEnum> s3 = s1 & s2;
 
   // clang-format off
   BOOST_CHECK(!s3.Contains(SomeTestEnum::A));


### PR DESCRIPTION
^ might be confused with XOR operator.
& on the other hand, will have the same effect as bitwise AND operator.

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>
