### PR TITLE
Fix end() iterator definition

### DIFF
--- a/src/better-enums/enum_set.h
+++ b/src/better-enums/enum_set.h
@@ -74,7 +74,7 @@ class EnumSet {
   class iterator {
    private:
     const EnumSet<Enum> *m_parent;
-    std::size_t m_index = 0;
+    std::size_t m_index;
 
    public:
     explicit iterator(const EnumSet<Enum> &parent) : m_parent(&parent), m_index(0) {

--- a/src/test/better_enum_set_tests.cpp
+++ b/src/test/better_enum_set_tests.cpp
@@ -247,15 +247,10 @@ BOOST_AUTO_TEST_CASE(check_initializer_list) {
 
 BOOST_AUTO_TEST_CASE(empty_iterator) {
   EnumSet<SomeTestEnum> s{};
-  std::set<SomeTestEnum> s2;
   std::size_t count = 0;
   for (const auto &e : s) {
-    if (++count > s.GetSize()) {
-      break;
-    }
-    s2.emplace(e);
+    BOOST_CHECK(++count <= s.GetSize());
   }
-  BOOST_CHECK(count == s.GetSize());
 }
 
 BOOST_AUTO_TEST_CASE(iterator_with_one_element) {
@@ -263,12 +258,8 @@ BOOST_AUTO_TEST_CASE(iterator_with_one_element) {
   std::set<SomeTestEnum> s2;
   std::size_t count = 0;
   for (const auto &e : s) {
-    if (++count > s.GetSize()) {
-      break;
-    }
-    s2.emplace(e);
+    BOOST_CHECK(++count <= s.GetSize());
   }
-  BOOST_CHECK(count == s.GetSize());
 }
 
 BOOST_AUTO_TEST_CASE(iterator_checks) {
@@ -276,27 +267,18 @@ BOOST_AUTO_TEST_CASE(iterator_checks) {
   std::set<SomeTestEnum> s2;
   std::size_t count = 0;
   for (const auto &e : s) {
-    if (++count > s.GetSize()) {
-      break;
-    }
-    s2.emplace(e);
+    BOOST_CHECK(++count <= s.GetSize());
   }
-  BOOST_CHECK(count == s.GetSize());
 }
 
 BOOST_AUTO_TEST_CASE(iterator_on_set_with_all_elements) {
   EnumSet<SomeTestEnum> s{SomeTestEnum::A, SomeTestEnum::B, SomeTestEnum::C,
                           SomeTestEnum::D, SomeTestEnum::E, SomeTestEnum::F,
                           SomeTestEnum::G, SomeTestEnum::H};
-  std::set<SomeTestEnum> s2;
   std::size_t count = 0;
   for (const auto &e : s) {
-    if (++count > s.GetSize()) {
-      break;
-    }
-    s2.emplace(e);
+    BOOST_CHECK(++count <= s.GetSize());
   }
-  BOOST_CHECK(count == s.GetSize());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes the definition for `end()` iterator. In a foolish attempt to cache the end validator it would not be valid for multiple instances as the `m_parent` will be initialized to the first instance that invoked end; leading to endless iterations in the subsequent invocation with other sets.

Also removes a superfluous semicolon.