### PR TITLE
Don't shadow built-in keyword

### DIFF
--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -42,8 +42,8 @@ EXCLUDE_DIRS = [
 ]
 
 def applies_to_file(filename):
-    for dir in EXCLUDE_DIRS:
-        if filename.startswith(dir):
+    for excluded_dir in EXCLUDE_DIRS:
+        if filename.startswith(excluded_dir):
             return False
     return ((EXCLUDE_COMPILED.match(filename) is None) and
             (INCLUDE_COMPILED.match(filename) is not None))


### PR DESCRIPTION
Forward port of changes done in response to feedback on upstream
pull request https://github.com/bitcoin/bitcoin/pull/14785
