### PR TITLE
Fix restart in feature_snapshot.py

### DIFF
--- a/test/functional/feature_snapshot.py
+++ b/test/functional/feature_snapshot.py
@@ -108,6 +108,7 @@ class SnapshotTest(UnitETestFramework):
 
         # test that isd_node can be restarted
         restart_node(isd_node)
+        wait_until(lambda: isd_node.getblockcount() == 9, timeout=5)
         chain = isd_node.getblockchaininfo()
         assert_equal(chain['headers'], 9)
         assert_equal(chain['blocks'], 9)


### PR DESCRIPTION
The issue was found in this build https://travis-ci.com/dtr-org/unit-e/jobs/161098366

When a node starts, it calls ActivateBestChain in a separate thread
which means that the node might be already listening for RPC commands
but still doesn't have the latest tip

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>
