### PR TITLE
Use snake_case

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -14,7 +14,7 @@ There are a few additional rules:
 - **Symbol naming conventions**. These are preferred in new code, but are not
 required when doing so would need changes to significant pieces of existing
 code.
-  - Variable and namespace start with a lowercase character, and may use `_` to
+  - Variable (including function arguments) and namespace names are all lowercase, and may use _ to separate words (snake_case).
     separate words (snake_case).
     - Class member variables have a `m_` prefix.
     - Global variables have a `g_` prefix.


### PR DESCRIPTION
Dear Team,

the eternal code style discussion goes on. If one reads the developer notes closely one will find out that they do not distinguish between local/stack variables and member/fields on structs/classes. They explicitly _allow_ `separating_words_with_underscore` (snake case). They do, however, require variables to be all lowercase :D

I for one am fine with this. However, a lot of code uses camel case, especially newly written code. So... this relaxes the requirement of having "all lowercase" (you're doing it wrong otherwise!) to just have the first letter start with a lower case character. `m_iCANSEETHISHAPPENING`.

Or we just settle for one.

I for one have adopted the weird habit of doing `m_member_variable_on_classes` and `localVariablesInCamelCase`.

I say: WDYS!