### PR TITLE
Adjust snapshot struct names

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -245,7 +245,7 @@ void CCoinsViewCache::ClearCoins() {
 
 bool CCoinsViewCache::ApplySnapshot(std::unique_ptr<snapshot::Indexer> &&indexer) {
     LogPrint(BCLog::COINDB, "%s: Apply snapshot hash=%s.\n",
-             __func__, indexer->GetMeta().m_snapshotHash.GetHex());
+             __func__, indexer->GetMeta().snapshot_hash.GetHex());
 
     ClearCoins();
 
@@ -258,9 +258,9 @@ bool CCoinsViewCache::ApplySnapshot(std::unique_ptr<snapshot::Indexer> &&indexer
     constexpr uint64_t batchSize = 100000;
     while (iter.Valid()) {
         snapshot::UTXOSubset &subset = iter.GetUTXOSubset();
-        for (auto const &p : subset.m_outputs) {
-            COutPoint out(subset.m_txId, p.first);
-            Coin coin(p.second, subset.m_height, subset.m_isCoinBase);
+        for (auto const &p : subset.outputs) {
+            COutPoint out(subset.tx_id, p.first);
+            Coin coin(p.second, subset.height, subset.is_coin_base);
             AddCoin(out, std::move(coin), true);
         }
 

--- a/src/snapshot/creator.h
+++ b/src/snapshot/creator.h
@@ -29,11 +29,11 @@ BETTER_ENUM(
 // clang-format on
 
 struct CreationInfo {
-  Status m_status;
-  Meta m_indexerMeta;
-  int m_totalOutputs;
+  Status status;
+  Meta indexer_meta;
+  int total_outputs;
 
-  CreationInfo() : m_status(Status::OK), m_totalOutputs(0) {}
+  CreationInfo() : status(Status::OK), total_outputs(0) {}
 };
 
 //! Creator class accepts the CCoinsViewDB and takes the cursor of it

--- a/src/snapshot/initialization.cpp
+++ b/src/snapshot/initialization.cpp
@@ -34,11 +34,11 @@ bool Initialize(const Params &params) {
       LogPrintf("Snapshot was successfully applied.\n");
     } else {
       for (const Checkpoint &p : GetSnapshotCheckpoints()) {
-        std::unique_ptr<Indexer> idx = Indexer::Open(p.snapshotHash);
+        std::unique_ptr<Indexer> idx = Indexer::Open(p.snapshot_hash);
         if (idx) {
-          StoreCandidateBlockHash(idx->GetMeta().m_blockHash);
+          StoreCandidateBlockHash(idx->GetMeta().block_hash);
           LogPrint(BCLog::SNAPSHOT, "Candidate snapshot for the block %s has found.\n",
-                   idx->GetMeta().m_blockHash.GetHex());
+                   idx->GetMeta().block_hash.GetHex());
         }
       }
     }

--- a/src/snapshot/iterator.cpp
+++ b/src/snapshot/iterator.cpp
@@ -20,7 +20,7 @@ Iterator::Iterator(std::unique_ptr<Indexer> indexer)
       m_file(nullptr),
       m_readTotal(0),
       m_subsetLeft(0) {
-  if (m_indexer->GetMeta().m_totalUTXOSubsets > 0) {
+  if (m_indexer->GetMeta().total_utxo_subsets > 0) {
     Next();
   }
 }
@@ -33,15 +33,15 @@ bool Iterator::Valid() {
     return false;
   }
 
-  return (m_readTotal <= m_indexer->GetMeta().m_totalUTXOSubsets);
+  return (m_readTotal <= m_indexer->GetMeta().total_utxo_subsets);
 }
 
 void Iterator::Next() {
-  if (m_readTotal > m_indexer->GetMeta().m_totalUTXOSubsets) {
+  if (m_readTotal > m_indexer->GetMeta().total_utxo_subsets) {
     return;  // whole snapshot is read
   }
 
-  if (m_readTotal == m_indexer->GetMeta().m_totalUTXOSubsets) {
+  if (m_readTotal == m_indexer->GetMeta().total_utxo_subsets) {
     ++m_readTotal;  // mark as end of snapshot
     return;
   }
@@ -66,7 +66,7 @@ void Iterator::Next() {
 }
 
 bool Iterator::MoveCursorTo(uint64_t subsetIndex) {
-  if (m_indexer->GetMeta().m_totalUTXOSubsets <= subsetIndex) {
+  if (m_indexer->GetMeta().total_utxo_subsets <= subsetIndex) {
     return false;
   }
 
@@ -134,9 +134,9 @@ uint256 Iterator::CalculateHash(uint256 stakeModifier) {
   SnapshotHash hash;
   while (Valid()) {
     UTXOSubset subset = GetUTXOSubset();
-    for (const auto &p : subset.m_outputs) {
-      const COutPoint out(subset.m_txId, p.first);
-      const Coin coin(p.second, subset.m_height, subset.m_isCoinBase);
+    for (const auto &p : subset.outputs) {
+      const COutPoint out(subset.tx_id, p.first);
+      const Coin coin(p.second, subset.height, subset.is_coin_base);
       hash.AddUTXO(UTXO(out, coin));
     }
 

--- a/src/snapshot/iterator.h
+++ b/src/snapshot/iterator.h
@@ -24,11 +24,11 @@ class Iterator {
   explicit Iterator(std::unique_ptr<Indexer> indexer);
   ~Iterator();
 
-  uint256 GetSnapshotHash() { return m_indexer->GetMeta().m_snapshotHash; }
-  uint256 GetBestBlockHash() { return m_indexer->GetMeta().m_blockHash; }
-  uint256 GetStakeModifier() { return m_indexer->GetMeta().m_stakeModifier; }
+  uint256 GetSnapshotHash() { return m_indexer->GetMeta().snapshot_hash; }
+  uint256 GetBestBlockHash() { return m_indexer->GetMeta().block_hash; }
+  uint256 GetStakeModifier() { return m_indexer->GetMeta().stake_modifier; }
   uint64_t GetTotalUTXOSubsets() {
-    return m_indexer->GetMeta().m_totalUTXOSubsets;
+    return m_indexer->GetMeta().total_utxo_subsets;
   }
 
   UTXOSubset &GetUTXOSubset() { return m_utxoSubset; }

--- a/src/snapshot/messages.cpp
+++ b/src/snapshot/messages.cpp
@@ -13,10 +13,10 @@
 namespace snapshot {
 
 UTXO::UTXO(const COutPoint &out, const Coin &coin)
-    : m_outPoint(out),
-      m_height(coin.nHeight),
-      m_isCoinBase(coin.IsCoinBase()),
-      m_txOut(coin.out) {}
+    : out_point(out),
+      height(coin.nHeight),
+      is_coin_base(coin.IsCoinBase()),
+      tx_out(coin.out) {}
 
 secp256k1_context *context = nullptr;
 

--- a/src/snapshot/messages.h
+++ b/src/snapshot/messages.h
@@ -20,95 +20,95 @@ namespace snapshot {
 //! snapshot on disk too. It is used instead of UTXO because it has more compact
 //! form, doesn't repeat TX specific fields for each output.
 struct UTXOSubset {
-  uint256 m_txId;
+  uint256 tx_id;
 
   //! at which block height the TX was included
-  uint32_t m_height;
+  uint32_t height;
 
-  bool m_isCoinBase;
+  bool is_coin_base;
 
   //! key is the CTxOut index
-  std::map<uint32_t, CTxOut> m_outputs;
+  std::map<uint32_t, CTxOut> outputs;
 
-  UTXOSubset() : m_txId(), m_height(0), m_isCoinBase(false), m_outputs() {}
+  UTXOSubset() : tx_id(), height(0), is_coin_base(false), outputs() {}
 
-  UTXOSubset(uint256 txId, uint32_t height, bool isCoinBase,
-             std::map<uint32_t, CTxOut> outMap)
-      : m_txId(txId),
-        m_height(height),
-        m_isCoinBase(isCoinBase),
-        m_outputs{std::move(outMap)} {}
+  UTXOSubset(uint256 _tx_id, uint32_t _height, bool _is_coin_base,
+             std::map<uint32_t, CTxOut> out_map)
+      : tx_id(_tx_id),
+        height(_height),
+        is_coin_base(_is_coin_base),
+        outputs{std::move(out_map)} {}
 
   ADD_SERIALIZE_METHODS;
 
   template <typename Stream, typename Operation>
   inline void SerializationOp(Stream &s, Operation ser_action) {
-    READWRITE(m_txId);
-    READWRITE(m_height);
-    READWRITE(m_isCoinBase);
-    READWRITE(m_outputs);
+    READWRITE(tx_id);
+    READWRITE(height);
+    READWRITE(is_coin_base);
+    READWRITE(outputs);
   }
 };
 
 //! \brief GetSnapshot is a message to request the snapshot chunk.
 //!
 //! During the initial request to peers it has the following values:
-//! bestBlockHash = empty
-//! m_utxoSubsetIndex = 0
-//! m_utxoSubsetCount = >0
+//! best_block_hash = empty
+//! utxo_subset_index = 0
+//! utxo_subset_count = >0
 struct GetSnapshot {
-  uint256 m_bestBlockHash;
-  uint64_t m_utxoSubsetIndex;
-  uint16_t m_utxoSubsetCount;
+  uint256 best_block_hash;
+  uint64_t utxo_subset_index;
+  uint16_t utxo_subset_count;
 
   GetSnapshot()
-      : m_bestBlockHash(), m_utxoSubsetIndex(0), m_utxoSubsetCount(0) {}
+      : best_block_hash(), utxo_subset_index(0), utxo_subset_count(0) {}
 
-  explicit GetSnapshot(const uint256 &bestBlockHash)
-      : m_bestBlockHash(bestBlockHash),
-        m_utxoSubsetIndex(0),
-        m_utxoSubsetCount(0) {}
+  explicit GetSnapshot(const uint256 &_best_block_hash)
+      : best_block_hash(_best_block_hash),
+        utxo_subset_index(0),
+        utxo_subset_count(0) {}
 
   ADD_SERIALIZE_METHODS;
 
   template <typename Stream, typename Operation>
   inline void SerializationOp(Stream &s, Operation ser_action) {
-    READWRITE(m_bestBlockHash);
-    READWRITE(m_utxoSubsetIndex);
-    READWRITE(m_utxoSubsetCount);
+    READWRITE(best_block_hash);
+    READWRITE(utxo_subset_index);
+    READWRITE(utxo_subset_count);
   }
 };
 
 //! \brief Snapshot message is used to reply to GetSnapshot P2P request.
 //!
-//! When m_totalUTXOSubsets == m_utxoSubsetIndex + m_utxoSubsets.size() this
+//! When total_utxo_subsets == utxo_subset_index + utxo_subsets.size() this
 //! chunk is considered the last chunk of the snapshot.
 struct Snapshot {
-  uint256 m_snapshotHash;
-  uint256 m_bestBlockHash;
-  uint256 m_stakeModifier;
-  uint64_t m_totalUTXOSubsets;
-  uint64_t m_utxoSubsetIndex;
-  std::vector<UTXOSubset> m_utxoSubsets;
+  uint256 snapshot_hash;
+  uint256 best_block_hash;
+  uint256 stake_modifier;
+  uint64_t total_utxo_subsets;
+  uint64_t utxo_subset_index;
+  std::vector<UTXOSubset> utxo_subsets;
 
   Snapshot()
-      : m_snapshotHash(),
-        m_bestBlockHash(),
-        m_stakeModifier(),
-        m_totalUTXOSubsets(0),
-        m_utxoSubsetIndex(0),
-        m_utxoSubsets() {}
+      : snapshot_hash(),
+        best_block_hash(),
+        stake_modifier(),
+        total_utxo_subsets(0),
+        utxo_subset_index(0),
+        utxo_subsets() {}
 
   ADD_SERIALIZE_METHODS;
 
   template <typename Stream, typename Operation>
   inline void SerializationOp(Stream &s, Operation ser_action) {
-    READWRITE(m_snapshotHash);
-    READWRITE(m_bestBlockHash);
-    READWRITE(m_stakeModifier);
-    READWRITE(m_totalUTXOSubsets);
-    READWRITE(m_utxoSubsetIndex);
-    READWRITE(m_utxoSubsets);
+    READWRITE(snapshot_hash);
+    READWRITE(best_block_hash);
+    READWRITE(stake_modifier);
+    READWRITE(total_utxo_subsets);
+    READWRITE(utxo_subset_index);
+    READWRITE(utxo_subsets);
   }
 };
 
@@ -116,16 +116,16 @@ struct Snapshot {
 //! snapshot hash. Coin class (which has the same schema) is not used as it
 //! doesn't follow the P2P serialization convention.
 struct UTXO {
-  COutPoint m_outPoint;
-  uint32_t m_height;
-  bool m_isCoinBase;
-  CTxOut m_txOut;
+  COutPoint out_point;
+  uint32_t height;
+  bool is_coin_base;
+  CTxOut tx_out;
 
   UTXO()
-      : m_outPoint(),
-        m_height(0),
-        m_isCoinBase(false),
-        m_txOut() {}
+      : out_point(),
+        height(0),
+        is_coin_base(false),
+        tx_out() {}
 
   UTXO(const COutPoint &out, const Coin &coin);
 
@@ -133,10 +133,10 @@ struct UTXO {
 
   template <typename Stream, typename Operation>
   inline void SerializationOp(Stream &s, Operation ser_action) {
-    READWRITE(m_outPoint);
-    READWRITE(m_height);
-    READWRITE(m_isCoinBase);
-    READWRITE(m_txOut);
+    READWRITE(out_point);
+    READWRITE(height);
+    READWRITE(is_coin_base);
+    READWRITE(tx_out);
   }
 };
 

--- a/src/snapshot/rpc_processing.cpp
+++ b/src/snapshot/rpc_processing.cpp
@@ -30,15 +30,15 @@ UniValue SnapshotNode(const uint256 &snapshotHash) {
   }
 
   node.push_back(Pair("valid", true));
-  node.push_back(Pair("block_hash", idx->GetMeta().m_blockHash.GetHex()));
-  node.push_back(Pair("block_height", mapBlockIndex[idx->GetMeta().m_blockHash]->nHeight));
-  node.push_back(Pair("stake_modifier", idx->GetMeta().m_stakeModifier.GetHex()));
-  node.push_back(Pair("total_utxo_subsets", idx->GetMeta().m_totalUTXOSubsets));
+  node.push_back(Pair("block_hash", idx->GetMeta().block_hash.GetHex()));
+  node.push_back(Pair("block_height", mapBlockIndex[idx->GetMeta().block_hash]->nHeight));
+  node.push_back(Pair("stake_modifier", idx->GetMeta().stake_modifier.GetHex()));
+  node.push_back(Pair("total_utxo_subsets", idx->GetMeta().total_utxo_subsets));
 
   uint64_t outputs = 0;
   Iterator iter(std::move(idx));
   while (iter.Valid()) {
-    outputs += iter.GetUTXOSubset().m_outputs.size();
+    outputs += iter.GetUTXOSubset().outputs.size();
     iter.Next();
   }
   node.push_back(Pair("total_outputs", outputs));
@@ -58,7 +58,7 @@ UniValue listsnapshots(const JSONRPCRequest &request) {
 
   UniValue listNode(UniValue::VARR);
   for (const Checkpoint &p : GetSnapshotCheckpoints()) {
-    UniValue node = SnapshotNode(p.snapshotHash);
+    UniValue node = SnapshotNode(p.snapshot_hash);
     node.push_back(Pair("snapshot_finalized", p.finalized));
     listNode.push_back(node);
   }
@@ -127,7 +127,7 @@ UniValue getblocksnapshot(const JSONRPCRequest &request) {
 
   UniValue node = SnapshotNode(snapshotHash);
   for (const Checkpoint &p : GetSnapshotCheckpoints()) {
-    if (p.snapshotHash == snapshotHash) {
+    if (p.snapshot_hash == snapshotHash) {
       node.push_back(Pair("snapshot_finalized", p.finalized));
       return node;
     }
@@ -157,9 +157,9 @@ UniValue createsnapshot(const JSONRPCRequest &request) {
   }
 
   CreationInfo info = creator.Create();
-  if (info.m_status != +Status::OK) {
+  if (info.status != +Status::OK) {
     UniValue rootNode(UniValue::VOBJ);
-    switch (info.m_status) {
+    switch (info.status) {
       case Status::WRITE_ERROR:
         rootNode.push_back(Pair("error", "can't write to any *.dat files"));
         break;
@@ -172,7 +172,7 @@ UniValue createsnapshot(const JSONRPCRequest &request) {
     return rootNode;
   }
 
-  return SnapshotNode(info.m_indexerMeta.m_snapshotHash);
+  return SnapshotNode(info.indexer_meta.snapshot_hash);
 }
 
 UniValue deletesnapshot(const JSONRPCRequest &request) {

--- a/src/snapshot/snapshot_index.cpp
+++ b/src/snapshot/snapshot_index.cpp
@@ -30,7 +30,7 @@ std::vector<uint256> SnapshotIndex::AddSnapshotHash(const uint256 &snapshotHash,
 
   auto it = m_indexMap.find(blockIndex->nHeight);
   if (it != m_indexMap.end()) {
-    m_snapshotsForRemoval.emplace(it->second.snapshotHash);
+    m_snapshotsForRemoval.emplace(it->second.snapshot_hash);
     it = m_indexMap.erase(it);
     m_indexMap.emplace_hint(it, blockIndex->nHeight, checkpoint);
     return SnapshotsForRemoval();
@@ -62,7 +62,7 @@ void SnapshotIndex::RemoveLowest() {
 
   if (finalized > m_minFinalizedSnapshots) {
     auto it = m_indexMap.begin();
-    m_snapshotsForRemoval.emplace(it->second.snapshotHash);
+    m_snapshotsForRemoval.emplace(it->second.snapshot_hash);
     it = m_indexMap.erase(it);
     return;
   }
@@ -72,7 +72,7 @@ void SnapshotIndex::RemoveLowest() {
       continue;
     }
 
-    m_snapshotsForRemoval.emplace(it->second.snapshotHash);
+    m_snapshotsForRemoval.emplace(it->second.snapshot_hash);
     m_indexMap.erase(it);
     return;
   }
@@ -83,7 +83,7 @@ void SnapshotIndex::RemoveHighest() {
     return;
   }
   auto it = std::prev(m_indexMap.end());
-  m_snapshotsForRemoval.emplace(it->second.snapshotHash);
+  m_snapshotsForRemoval.emplace(it->second.snapshot_hash);
   m_indexMap.erase(it);
 }
 
@@ -92,8 +92,8 @@ bool SnapshotIndex::GetSnapshotHash(const CBlockIndex *blockIndex,
   LOCK(m_cs);
 
   for (const auto &p : m_indexMap) {
-    if (p.second.blockHash == blockIndex->GetBlockHash()) {
-      snapshotHashOut = p.second.snapshotHash;
+    if (p.second.block_hash == blockIndex->GetBlockHash()) {
+      snapshotHashOut = p.second.snapshot_hash;
       return true;
     }
   }
@@ -116,7 +116,7 @@ void SnapshotIndex::DeleteSnapshotHash(const uint256 &snapshotHash) {
   LOCK(m_cs);
 
   for (auto it = m_indexMap.begin(); it != m_indexMap.end(); ++it) {
-    if (it->second.snapshotHash == snapshotHash) {
+    if (it->second.snapshot_hash == snapshotHash) {
       m_indexMap.erase(it);
       break;
     }
@@ -148,7 +148,7 @@ void SnapshotIndex::DeleteSnapshot(const uint256 &snapshotHash) {
 
 void SnapshotIndex::Clear() {
   for (const auto &c : g_snapshotIndex.GetSnapshotCheckpoints()) {
-    g_snapshotIndex.DeleteSnapshotHash(c.snapshotHash);
+    g_snapshotIndex.DeleteSnapshotHash(c.snapshot_hash);
   }
 }
 
@@ -172,10 +172,10 @@ std::vector<uint256> SnapshotIndex::FinalizeSnapshots(const CBlockIndex *blockIn
     }
 
     const CBlockIndex *ancestor = blockIndex->GetAncestor(it->second.height);
-    if (*ancestor->phashBlock == it->second.blockHash) {  // same branch
+    if (*ancestor->phashBlock == it->second.block_hash) {  // same branch
       it->second.finalized = true;
     } else {  // different branch, remove it
-      m_snapshotsForRemoval.emplace(it->second.snapshotHash);
+      m_snapshotsForRemoval.emplace(it->second.snapshot_hash);
       it = m_indexMap.erase(it);
     }
   }
@@ -188,7 +188,7 @@ bool SnapshotIndex::GetLatestFinalizedSnapshotHash(uint256 &snapshotHashOut) {
 
   for (auto it = m_indexMap.rbegin(); it != m_indexMap.rend(); ++it) {
     if (it->second.finalized) {
-      snapshotHashOut = it->second.snapshotHash;
+      snapshotHashOut = it->second.snapshot_hash;
       return true;
     }
   }
@@ -202,8 +202,8 @@ bool SnapshotIndex::GetFinalizedSnapshotHash(const CBlockIndex *blockIndex,
 
   for (auto it = m_indexMap.rbegin(); it != m_indexMap.rend(); ++it) {
     if (it->second.finalized &&
-        it->second.blockHash == blockIndex->GetBlockHash()) {
-      snapshotHashOut = it->second.snapshotHash;
+        it->second.block_hash == blockIndex->GetBlockHash()) {
+      snapshotHashOut = it->second.snapshot_hash;
       return true;
     }
   }

--- a/src/snapshot/snapshot_index.h
+++ b/src/snapshot/snapshot_index.h
@@ -22,20 +22,20 @@ namespace snapshot {
 struct Checkpoint {
   int height;
   bool finalized;
-  uint256 snapshotHash;
-  uint256 blockHash;
+  uint256 snapshot_hash;
+  uint256 block_hash;
 
   Checkpoint()
       : height(0),
         finalized(false),
-        snapshotHash(),
-        blockHash() {}
+        snapshot_hash(),
+        block_hash() {}
 
-  Checkpoint(int _height, uint256 _snapshotHash, uint256 _blockHash)
+  Checkpoint(int _height, uint256 _snapshot_hash, uint256 _block_hash)
       : height(_height),
         finalized(false),
-        snapshotHash(_snapshotHash),
-        blockHash(_blockHash) {}
+        snapshot_hash(_snapshot_hash),
+        block_hash(_block_hash) {}
 
   ADD_SERIALIZE_METHODS;
 
@@ -43,8 +43,8 @@ struct Checkpoint {
   inline void SerializationOp(Stream &s, Operation ser_action) {
     READWRITE(height);
     READWRITE(finalized);
-    READWRITE(snapshotHash);
-    READWRITE(blockHash);
+    READWRITE(snapshot_hash);
+    READWRITE(block_hash);
   }
 };
 

--- a/src/test/snapshot/chainstate_iterator_tests.cpp
+++ b/src/test/snapshot/chainstate_iterator_tests.cpp
@@ -54,13 +54,13 @@ BOOST_AUTO_TEST_CASE(chainstate_iterator) {
   uint64_t count = 0;
   while (iter.Valid()) {
     snapshot::UTXOSubset subset = iter.GetUTXOSubset();
-    BOOST_CHECK_EQUAL(subset.m_height, count);
-    BOOST_CHECK_EQUAL(subset.m_txId.GetUint64(0), count);
-    BOOST_CHECK_EQUAL(subset.m_isCoinBase, count % 2 == 1);
-    BOOST_CHECK_EQUAL(subset.m_outputs.size(), count + 1);
+    BOOST_CHECK_EQUAL(subset.height, count);
+    BOOST_CHECK_EQUAL(subset.tx_id.GetUint64(0), count);
+    BOOST_CHECK_EQUAL(subset.is_coin_base, count % 2 == 1);
+    BOOST_CHECK_EQUAL(subset.outputs.size(), count + 1);
 
     int n = 0;
-    for (const auto &p : subset.m_outputs) {
+    for (const auto &p : subset.outputs) {
       BOOST_CHECK_EQUAL(p.first, n);
       BOOST_CHECK_EQUAL(p.second.nValue, count * 100 + n);
       ++n;

--- a/src/test/snapshot/creator_tests.cpp
+++ b/src/test/snapshot/creator_tests.cpp
@@ -17,7 +17,7 @@ BOOST_FIXTURE_TEST_SUITE(snapshot_creator_tests, BasicTestingSetup)
 
 bool HasSnapshotHash(const uint256 &hash) {
   for (const snapshot::Checkpoint &p : snapshot::GetSnapshotCheckpoints()) {
-    if (p.snapshotHash == hash) {
+    if (p.snapshot_hash == hash) {
       return true;
     }
   }
@@ -80,30 +80,30 @@ BOOST_AUTO_TEST_CASE(snapshot_creator) {
 
       if (idx == 4) {
         for (const snapshot::Checkpoint &p : checkpoints) {
-          deletedSnapshots.push_back(p.snapshotHash);
+          deletedSnapshots.push_back(p.snapshot_hash);
         }
       }
 
       // validate reported state
-      BOOST_CHECK_EQUAL(info.m_status, +snapshot::Status::OK);
-      BOOST_CHECK(!info.m_indexerMeta.m_snapshotHash.IsNull());
-      BOOST_CHECK_EQUAL(info.m_indexerMeta.m_snapshotHash.GetHex(),
-                        checkpoints.rbegin()->snapshotHash.GetHex());
-      BOOST_CHECK_EQUAL(HexStr(info.m_indexerMeta.m_blockHash),
+      BOOST_CHECK_EQUAL(info.status, +snapshot::Status::OK);
+      BOOST_CHECK(!info.indexer_meta.snapshot_hash.IsNull());
+      BOOST_CHECK_EQUAL(info.indexer_meta.snapshot_hash.GetHex(),
+                        checkpoints.rbegin()->snapshot_hash.GetHex());
+      BOOST_CHECK_EQUAL(HexStr(info.indexer_meta.block_hash),
                         HexStr(bestBlock));
-      BOOST_CHECK_EQUAL(info.m_indexerMeta.m_totalUTXOSubsets, totalTX);
-      BOOST_CHECK_EQUAL(info.m_totalOutputs,
+      BOOST_CHECK_EQUAL(info.indexer_meta.total_utxo_subsets, totalTX);
+      BOOST_CHECK_EQUAL(info.total_outputs,
                         static_cast<int>(totalTX * coinsPerTX));
 
       // validate snapshot content
-      auto i = snapshot::Indexer::Open(checkpoints.rbegin()->snapshotHash);
+      auto i = snapshot::Indexer::Open(checkpoints.rbegin()->snapshot_hash);
       snapshot::Iterator iter(std::move(i));
       uint64_t count = 0;
       while (iter.Valid()) {
         ++count;
         iter.Next();
       }
-      BOOST_CHECK_EQUAL(info.m_indexerMeta.m_totalUTXOSubsets, count);
+      BOOST_CHECK_EQUAL(info.indexer_meta.total_utxo_subsets, count);
     }
 
     BOOST_CHECK_EQUAL(deletedSnapshots.size(), 5);

--- a/src/test/snapshot/indexer_tests.cpp
+++ b/src/test/snapshot/indexer_tests.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(snapshot_indexer_flush) {
     snapshot::UTXOSubset subset;
     CDataStream s(SER_DISK, PROTOCOL_VERSION);
     s << i << uint64_t(0) << uint64_t(0) << uint64_t(0);
-    s >> subset.m_txId;
+    s >> subset.tx_id;
     streamIn << subset;
     BOOST_CHECK(idx->WriteUTXOSubset(subset));
   }
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(snapshot_indexer_writer) {
     snapshot::UTXOSubset utxoSet;
     stream << utxoSet;
     BOOST_CHECK(indexer.WriteUTXOSubset(utxoSet));
-    BOOST_CHECK_EQUAL(indexer.GetMeta().m_totalUTXOSubsets, i + 1);
+    BOOST_CHECK_EQUAL(indexer.GetMeta().total_utxo_subsets, i + 1);
   }
 
   fs::path dir = GetDataDir() / "snapshots" / snapshotHash.GetHex();
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(snapshot_indexer_writer) {
   BOOST_CHECK(fs::exists(dir / "index.dat"));
   BOOST_CHECK(!fs::exists(dir / "utxo3.dat"));
 
-  BOOST_CHECK_EQUAL(indexer.GetMeta().m_snapshotHash.GetHex(), snapshotHash.GetHex());
+  BOOST_CHECK_EQUAL(indexer.GetMeta().snapshot_hash.GetHex(), snapshotHash.GetHex());
 }
 
 BOOST_AUTO_TEST_CASE(snapshot_indexer_resume_writing) {
@@ -96,11 +96,11 @@ BOOST_AUTO_TEST_CASE(snapshot_indexer_resume_writing) {
     s << uint64_t(0);
     s << uint64_t(0);
     snapshot::UTXOSubset utxoSet;
-    s >> utxoSet.m_txId;
+    s >> utxoSet.tx_id;
 
     streamIn << utxoSet;
     BOOST_CHECK(indexer->WriteUTXOSubset(utxoSet));
-    BOOST_CHECK_EQUAL(indexer->GetMeta().m_totalUTXOSubsets, i + 1);
+    BOOST_CHECK_EQUAL(indexer->GetMeta().total_utxo_subsets, i + 1);
     BOOST_CHECK(indexer->Flush());
     indexer = snapshot::Indexer::Open(snapshotHash);
     BOOST_CHECK(indexer);
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(snapshot_indexer_resume_writing) {
     BOOST_CHECK(iter.MoveCursorTo(i));
     auto msg = iter.GetUTXOSubset();
     streamOut << msg;
-    BOOST_CHECK_EQUAL(msg.m_txId.GetUint64(0), i);
+    BOOST_CHECK_EQUAL(msg.tx_id.GetUint64(0), i);
   }
   BOOST_CHECK_EQUAL(HexStr(streamIn), HexStr(streamOut));
   BOOST_CHECK_EQUAL(iter.GetSnapshotHash().GetHex(), snapshotHash.GetHex());
@@ -145,19 +145,19 @@ BOOST_AUTO_TEST_CASE(snapshot_indexer_open) {
   uint64_t totalMsgs = (step * stepsPerFile) * 2 + step;
   for (uint64_t i = 0; i < totalMsgs; ++i) {
     BOOST_CHECK(indexer.WriteUTXOSubset(snapshot::UTXOSubset()));
-    BOOST_CHECK_EQUAL(indexer.GetMeta().m_totalUTXOSubsets, i + 1);
+    BOOST_CHECK_EQUAL(indexer.GetMeta().total_utxo_subsets, i + 1);
   }
   BOOST_CHECK(indexer.Flush());
 
   auto openedIdx = snapshot::Indexer::Open(snapshotHash);
   BOOST_CHECK(openedIdx);
-  BOOST_CHECK_EQUAL(HexStr(openedIdx->GetMeta().m_snapshotHash),
+  BOOST_CHECK_EQUAL(HexStr(openedIdx->GetMeta().snapshot_hash),
                     HexStr(snapshotHash));
-  BOOST_CHECK_EQUAL(HexStr(openedIdx->GetMeta().m_blockHash),
+  BOOST_CHECK_EQUAL(HexStr(openedIdx->GetMeta().block_hash),
                     HexStr(bestBlockHash));
-  BOOST_CHECK_EQUAL(HexStr(openedIdx->GetMeta().m_stakeModifier),
+  BOOST_CHECK_EQUAL(HexStr(openedIdx->GetMeta().stake_modifier),
                     HexStr(stakeModifier));
-  BOOST_CHECK_EQUAL(openedIdx->GetMeta().m_totalUTXOSubsets, totalMsgs);
+  BOOST_CHECK_EQUAL(openedIdx->GetMeta().total_utxo_subsets, totalMsgs);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/snapshot/iterator_tests.cpp
+++ b/src/test/snapshot/iterator_tests.cpp
@@ -22,14 +22,14 @@ BOOST_AUTO_TEST_CASE(snapshot_iterator) {
     snapshot::Indexer idx(uint256S("bb"), blockHash, uint256(), 3, 2);
     for (uint32_t i = 0; i < msgsToGenerate; ++i) {
       snapshot::UTXOSubset subset;
-      subset.m_txId.SetHex(std::to_string(i));
+      subset.tx_id.SetHex(std::to_string(i));
 
       CTxOut out;
       out.nValue = 1000 + i;
-      subset.m_outputs[i] = out;
+      subset.outputs[i] = out;
       idx.WriteUTXOSubset(subset);
       snapshotHash.AddUTXO(
-          snapshot::UTXO(COutPoint(subset.m_txId, i), Coin(out, 0, false)));
+          snapshot::UTXO(COutPoint(subset.tx_id, i), Coin(out, 0, false)));
     }
     BOOST_CHECK(idx.Flush());
   }
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(snapshot_iterator) {
     uint32_t count = 0;
     while (iter.Valid()) {
       uint32_t value = 1000 + count;
-      BOOST_CHECK_EQUAL(iter.GetUTXOSubset().m_outputs.at(count).nValue, value);
+      BOOST_CHECK_EQUAL(iter.GetUTXOSubset().outputs.at(count).nValue, value);
       iter.Next();
       ++count;
     }
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(snapshot_iterator) {
     for (uint32_t i = 0; i < msgsToGenerate; ++i) {
       BOOST_CHECK(iter.MoveCursorTo(i));
       int value = 1000 + i;
-      BOOST_CHECK_EQUAL(iter.GetUTXOSubset().m_outputs.at(i).nValue, value);
+      BOOST_CHECK_EQUAL(iter.GetUTXOSubset().outputs.at(i).nValue, value);
     }
 
     // iterate via cursor moving backward
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(snapshot_iterator) {
       BOOST_CHECK(iter.MoveCursorTo(i - 1));
 
       uint32_t value = 1000 + i - 1;
-      BOOST_CHECK_EQUAL(iter.GetUTXOSubset().m_outputs.at(i - 1).nValue, value);
+      BOOST_CHECK_EQUAL(iter.GetUTXOSubset().outputs.at(i - 1).nValue, value);
     }
   }
 }

--- a/src/test/snapshot/messages_tests.cpp
+++ b/src/test/snapshot/messages_tests.cpp
@@ -25,9 +25,9 @@ BOOST_AUTO_TEST_CASE(snapshot_utxo_set_serializer) {
   BOOST_CHECK_EQUAL(HexStr(s), exp);
   s.clear();
 
-  subset.m_txId.SetHex("aa");
-  subset.m_height = 0xbb;
-  subset.m_isCoinBase = true;
+  subset.tx_id.SetHex("aa");
+  subset.height = 0xbb;
+  subset.is_coin_base = true;
   s << subset;
   exp =
       "aa000000000000000000000000000000"  // tx id
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(snapshot_utxo_set_serializer) {
                       "expected: " << HexStr(s) << " got: " << exp);
   s.clear();
 
-  subset.m_outputs[2] = CTxOut();
+  subset.outputs[2] = CTxOut();
   s << subset;
   exp =
       "aa000000000000000000000000000000"  // tx id
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(snapshot_utxo_set_serializer) {
   auto out = CTxOut();
   out.nValue = 0xcc;
   out.scriptPubKey << OP_RETURN;
-  subset.m_outputs[2] = out;
+  subset.outputs[2] = out;
   s << subset;
   exp =
       "aa000000000000000000000000000000"  // tx id
@@ -74,9 +74,9 @@ BOOST_AUTO_TEST_CASE(snapshot_utxo_set_serializer) {
 
 BOOST_AUTO_TEST_CASE(snapshot_get_snapshot_serialization) {
   snapshot::GetSnapshot msg;
-  msg.m_bestBlockHash.SetHex("bb");
-  msg.m_utxoSubsetIndex = 55;
-  msg.m_utxoSubsetCount = 17;
+  msg.best_block_hash.SetHex("bb");
+  msg.utxo_subset_index = 55;
+  msg.utxo_subset_count = 17;
 
   CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
   stream << msg;
@@ -93,9 +93,9 @@ BOOST_AUTO_TEST_CASE(snapshot_get_snapshot_serialization) {
 
   snapshot::GetSnapshot msg2;
   stream >> msg2;
-  BOOST_CHECK_EQUAL(msg.m_bestBlockHash, msg2.m_bestBlockHash);
-  BOOST_CHECK_EQUAL(msg.m_utxoSubsetIndex, msg2.m_utxoSubsetIndex);
-  BOOST_CHECK_EQUAL(msg.m_utxoSubsetCount, msg2.m_utxoSubsetCount);
+  BOOST_CHECK_EQUAL(msg.best_block_hash, msg2.best_block_hash);
+  BOOST_CHECK_EQUAL(msg.utxo_subset_index, msg2.utxo_subset_index);
+  BOOST_CHECK_EQUAL(msg.utxo_subset_count, msg2.utxo_subset_count);
 }
 
 BOOST_AUTO_TEST_CASE(snapshot_snapshot_serialization) {
@@ -119,20 +119,20 @@ BOOST_AUTO_TEST_CASE(snapshot_snapshot_serialization) {
   BOOST_CHECK_EQUAL(got, exp);
 
   // serialize filled
-  msg.m_snapshotHash.SetHex("aa");
-  msg.m_bestBlockHash.SetHex("bb");
-  msg.m_stakeModifier.SetHex("cc");
-  msg.m_totalUTXOSubsets = 25000000;
-  msg.m_utxoSubsetIndex = 128;
+  msg.snapshot_hash.SetHex("aa");
+  msg.best_block_hash.SetHex("bb");
+  msg.stake_modifier.SetHex("cc");
+  msg.total_utxo_subsets = 25000000;
+  msg.utxo_subset_index = 128;
 
   snapshot::UTXOSubset subset;
-  subset.m_height = 53;
-  subset.m_isCoinBase = true;
-  subset.m_txId.SetHex("bb");
+  subset.height = 53;
+  subset.is_coin_base = true;
+  subset.tx_id.SetHex("bb");
   CScript script;
   script << OP_RETURN;
-  subset.m_outputs[5] = CTxOut(5, script);
-  msg.m_utxoSubsets.emplace_back(subset);
+  subset.outputs[5] = CTxOut(5, script);
+  msg.utxo_subsets.emplace_back(subset);
 
   stream.clear();
   stream << msg;
@@ -162,25 +162,25 @@ BOOST_AUTO_TEST_CASE(snapshot_snapshot_serialization) {
 
   snapshot::Snapshot msg2;
   stream >> msg2;
-  BOOST_CHECK_EQUAL(msg.m_bestBlockHash, msg2.m_bestBlockHash);
-  BOOST_CHECK_EQUAL(msg.m_stakeModifier, msg2.m_stakeModifier);
-  BOOST_CHECK_EQUAL(msg.m_totalUTXOSubsets, msg2.m_totalUTXOSubsets);
-  BOOST_CHECK_EQUAL(msg.m_utxoSubsetIndex, msg2.m_utxoSubsetIndex);
-  BOOST_CHECK_EQUAL(msg.m_utxoSubsets.size(), msg2.m_utxoSubsets.size());
-  BOOST_CHECK_EQUAL(msg.m_utxoSubsets[0].m_txId, msg2.m_utxoSubsets[0].m_txId);
-  BOOST_CHECK_EQUAL(msg.m_utxoSubsets[0].m_outputs.size(),
-                    msg2.m_utxoSubsets[0].m_outputs.size());
+  BOOST_CHECK_EQUAL(msg.best_block_hash, msg2.best_block_hash);
+  BOOST_CHECK_EQUAL(msg.stake_modifier, msg2.stake_modifier);
+  BOOST_CHECK_EQUAL(msg.total_utxo_subsets, msg2.total_utxo_subsets);
+  BOOST_CHECK_EQUAL(msg.utxo_subset_index, msg2.utxo_subset_index);
+  BOOST_CHECK_EQUAL(msg.utxo_subsets.size(), msg2.utxo_subsets.size());
+  BOOST_CHECK_EQUAL(msg.utxo_subsets[0].tx_id, msg2.utxo_subsets[0].tx_id);
+  BOOST_CHECK_EQUAL(msg.utxo_subsets[0].outputs.size(),
+                    msg2.utxo_subsets[0].outputs.size());
 }
 
 BOOST_AUTO_TEST_CASE(utxo_construct) {
   COutPoint out;
   Coin coin;
   snapshot::UTXO utxo1(out, coin);
-  BOOST_CHECK_EQUAL(utxo1.m_outPoint.hash, out.hash);
-  BOOST_CHECK_EQUAL(utxo1.m_outPoint.n, out.n);
-  BOOST_CHECK_EQUAL(utxo1.m_height, coin.nHeight);
-  BOOST_CHECK_EQUAL(utxo1.m_isCoinBase, coin.IsCoinBase());
-  BOOST_CHECK(utxo1.m_txOut == coin.out);
+  BOOST_CHECK_EQUAL(utxo1.out_point.hash, out.hash);
+  BOOST_CHECK_EQUAL(utxo1.out_point.n, out.n);
+  BOOST_CHECK_EQUAL(utxo1.height, coin.nHeight);
+  BOOST_CHECK_EQUAL(utxo1.is_coin_base, coin.IsCoinBase());
+  BOOST_CHECK(utxo1.tx_out == coin.out);
 
   out.hash.SetHex("aa");
   out.n = 10;
@@ -190,11 +190,11 @@ BOOST_AUTO_TEST_CASE(utxo_construct) {
   coin.out.scriptPubKey << OP_RETURN;
 
   snapshot::UTXO utxo2(out, coin);
-  BOOST_CHECK_EQUAL(utxo2.m_outPoint.hash, out.hash);
-  BOOST_CHECK_EQUAL(utxo2.m_outPoint.n, out.n);
-  BOOST_CHECK_EQUAL(utxo2.m_height, coin.nHeight);
-  BOOST_CHECK_EQUAL(utxo2.m_isCoinBase, coin.IsCoinBase());
-  BOOST_CHECK(utxo2.m_txOut == coin.out);
+  BOOST_CHECK_EQUAL(utxo2.out_point.hash, out.hash);
+  BOOST_CHECK_EQUAL(utxo2.out_point.n, out.n);
+  BOOST_CHECK_EQUAL(utxo2.height, coin.nHeight);
+  BOOST_CHECK_EQUAL(utxo2.is_coin_base, coin.IsCoinBase());
+  BOOST_CHECK(utxo2.tx_out == coin.out);
 }
 
 BOOST_AUTO_TEST_CASE(utxo_serialization) {
@@ -250,11 +250,11 @@ BOOST_AUTO_TEST_CASE(snapshot_hash) {
   std::string nullHash = h.GetHash(stakeModifier).GetHex();
 
   snapshot::UTXO a;
-  a.m_outPoint.hash.SetHex("aa");
+  a.out_point.hash.SetHex("aa");
   snapshot::UTXO b;
-  b.m_outPoint.hash.SetHex("bb");
+  b.out_point.hash.SetHex("bb");
   snapshot::UTXO c;
-  c.m_outPoint.hash.SetHex("cc");
+  c.out_point.hash.SetHex("cc");
 
   std::string aHash =
       "cf51b4881eef3133d8869fbff8754fa2"

--- a/src/test/snapshot/snapshot_index_tests.cpp
+++ b/src/test/snapshot/snapshot_index_tests.cpp
@@ -15,7 +15,7 @@ BOOST_FIXTURE_TEST_SUITE(snapshot_snapshot_index_tests, ReducedTestingSetup)
 
 bool HasSnapshotHash(snapshot::SnapshotIndex &index, const uint256 &hash) {
   for (const snapshot::Checkpoint &p : index.GetSnapshotCheckpoints()) {
-    if (p.snapshotHash == hash) {
+    if (p.snapshot_hash == hash) {
       return true;
     }
   }


### PR DESCRIPTION
1. drop `m_` prefix
2. use snake_case

The reason is to adjust to style guide and since we will have more code
to add/change, would be good to already adhere to the agreed standard.

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>