### PR TITLE
Rename esperanza/validation.cpp to checks.cpp

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -108,13 +108,13 @@ UNITE_CORE_H = \
   esperanza/adminparams.h \
   esperanza/adminstate.h \
   esperanza/checkpoint.h \
+  esperanza/checks.h \
   esperanza/finalizationparams.h \
   esperanza/finalizationstate.h \
   esperanza/init.h \
   esperanza/params.h \
   esperanza/settings.h \
   esperanza/settings_init.h \
-  esperanza/validation.h \
   esperanza/validator.h \
   esperanza/validatorstate.h \
   esperanza/vote.h \
@@ -268,9 +268,9 @@ libunite_server_a_SOURCES = \
   esperanza/admincommand.cpp \
   esperanza/adminstate.cpp \
   esperanza/checkpoint.cpp \
+  esperanza/checks.cpp \
   esperanza/finalizationstate.cpp \
   esperanza/finalizationparams.cpp \
-  esperanza/validation.cpp \
   esperanza/validator.cpp \
   httprpc.cpp \
   httpserver.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -51,6 +51,7 @@ UNITE_TESTS = \
   test/DoS_tests.cpp \
   test/esperanza/admincommand_tests.cpp \
   test/esperanza/adminstate_tests.cpp \
+  test/esperanza/checks_tests.cpp \
   test/esperanza/finalization_utils.h \
   test/esperanza/finalization_utils.cpp \
   test/esperanza/finalizationparams_tests.cpp \
@@ -62,7 +63,6 @@ UNITE_TESTS = \
   test/esperanza/finalizationstate_slash_tests.cpp \
   test/esperanza/finalizationstate_utils.h \
   test/esperanza/finalizationstate_utils.cpp \
-  test/esperanza/validation_tests.cpp \
   test/getarg_tests.cpp \
   test/hash_tests.cpp \
   test/interpreter_tests.cpp \

--- a/src/esperanza/checks.cpp
+++ b/src/esperanza/checks.cpp
@@ -4,9 +4,9 @@
 
 #include <chainparams.h>
 #include <esperanza/adminparams.h>
+#include <esperanza/checks.h>
 #include <esperanza/finalizationstate.h>
 #include <esperanza/params.h>
-#include <esperanza/validation.h>
 #include <script/interpreter.h>
 #include <script/standard.h>
 #include <util.h>

--- a/src/esperanza/checks.h
+++ b/src/esperanza/checks.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNITE_ESPERANZA_VALIDATION_H
-#define UNITE_ESPERANZA_VALIDATION_H
+#ifndef UNITE_ESPERANZA_CHECKS_H
+#define UNITE_ESPERANZA_CHECKS_H
 
 #include <chain.h>
 #include <consensus/validation.h>
@@ -45,4 +45,4 @@ bool ExtractValidatorAddress(const CTransaction &tx,
 
 }  // namespace esperanza
 
-#endif  // UNIT_E_VALIDATION_H
+#endif  // UNITE_ESPERANZA_CHECKS_H

--- a/src/esperanza/finalizationstate.cpp
+++ b/src/esperanza/finalizationstate.cpp
@@ -5,7 +5,7 @@
 #include <esperanza/finalizationstate.h>
 
 #include <chainparams.h>
-#include <esperanza/validation.h>
+#include <esperanza/checks.h>
 #include <esperanza/vote.h>
 #include <script/ismine.h>
 #include <snapshot/creator.h>

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -13,7 +13,7 @@
 #include <consensus/tx_verify.h>
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
-#include <esperanza/validation.h>
+#include <esperanza/checks.h>
 #include <hash.h>
 #include <validation.h>
 #include <net.h>

--- a/src/test/esperanza/checks_tests.cpp
+++ b/src/test/esperanza/checks_tests.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <esperanza/checks.h>
 #include <esperanza/finalizationstate.h>
-#include <esperanza/validation.h>
 #include <keystore.h>
 #include <random.h>
 #include <script/script.h>

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -8,7 +8,7 @@
 #include <consensus/consensus.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
-#include <esperanza/validation.h>
+#include <esperanza/checks.h>
 #include <validation.h>
 #include <policy/policy.h>
 #include <policy/fees.h>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -14,7 +14,7 @@
 #include <consensus/merkle.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
-#include <esperanza/validation.h>
+#include <esperanza/checks.h>
 #include <cuckoocache.h>
 #include <hash.h>
 #include <init.h>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -11,7 +11,7 @@
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <esperanza/finalizationstate.h>
-#include <esperanza/validation.h>
+#include <esperanza/checks.h>
 #include <fs.h>
 #include <key.h>
 #include <key/mnemonic/mnemonic.h>


### PR DESCRIPTION
We discussed a similar renaming proposal before: https://github.com/dtr-org/unit-e/pull/191

This pull request proposes to rename `esperanza/validation.cpp` to `esperanza/checks.cpp`.

It has bitten me several times now that these two files have the same name. Yes, it is an IDE issue, but it is an issue that we're all facing. Having unique file (base) names helps talking about the project. It helps locating files. It helps distinguish files.

The `esperanza/validation.cpp` file contains almost exclusively functions that look like `Check*`, which is why I think `checks.cpp` is a justified and good name for it.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>