### PR TITLE
Clarification to C++ code style

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -27,21 +27,6 @@ code.
 - **If-Statements**.
     - Always use braces around if statements, even blocks
       that contain just one statement.
-    - Avoid double negation.
-      ```c++
-      // bad
-      if (!smth) {
-        // do A
-      } else {
-        // do B
-      }
-
-      // good
-      if (smth) {
-        // do B
-      } else {
-        // do A
-      }
     - Prefer early return as a guard clause
       ```c++
       if (!smth) {


### PR DESCRIPTION
Issue was raised in https://github.com/dtr-org/unit-e/pull/302#discussion_r237565978 that some of practices were discussed internally but were not documented. 

This PR Adds:
1. Root namespace must live in its own folder
2. Avoid non-negative conditions

and removes:
1. Position of `*` and `&` as it's already covered by clang-format

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>
