### PR TITLE
Fix references to issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
     - depends/sdk-sources
     - $HOME/.ccache
 git:
-  depth: false  # full clone for git subtree check, this works around issue #12388
+  depth: false  # full clone for git subtree check, this works around issue bitcoin/bitcoin#12388
 env:
   global:
     - MAKEJOBS=-j3

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -499,13 +499,13 @@ void OptionsModel::checkAndMigrate()
     }
 
     // Overwrite the 'addrProxy' setting in case it has been set to an illegal
-    // default value (see issue #12623; PR #12650).
+    // default value (see issue bitcoin/bitcoin#12623; PR bitcoin/bitcoin#12650).
     if (settings.contains("addrProxy") && settings.value("addrProxy").toString().endsWith("%2")) {
         settings.setValue("addrProxy", GetDefaultProxyAddress());
     }
 
     // Overwrite the 'addrSeparateProxyTor' setting in case it has been set to an illegal
-    // default value (see issue #12623; PR #12650).
+    // default value (see issue bitcoin/bitcoin#12623; PR bitcoin/bitcoin#12650).
     if (settings.contains("addrSeparateProxyTor") && settings.value("addrSeparateProxyTor").toString().endsWith("%2")) {
         settings.setValue("addrSeparateProxyTor", GetDefaultProxyAddress());
     }

--- a/src/qt/unitegui.cpp
+++ b/src/qt/unitegui.cpp
@@ -223,7 +223,7 @@ UnitEGUI::UnitEGUI(const PlatformStyle *_platformStyle, const NetworkStyle *netw
     progressBar->setVisible(false);
 
     // Override style sheet for progress bar for styles that have a segmented progress bar,
-    // as they make the text unreadable (workaround for issue #1071)
+    // as they make the text unreadable (workaround for issue bitcoin/bitcoin#1071)
     // See https://qt-project.org/doc/qt-4.8/gallery.html
     QString curStyle = QApplication::style()->metaObject()->className();
     if(curStyle == "QWindowsStyle" || curStyle == "QWindowsXPStyle")
@@ -1052,7 +1052,7 @@ void UnitEGUI::setHDStatus(int hdEnabled)
     labelWalletHDStatusIcon->setPixmap(platformStyle->SingleColorIcon(hdEnabled ? ":/icons/hd_enabled" : ":/icons/hd_disabled").pixmap(STATUSBAR_ICONSIZE,STATUSBAR_ICONSIZE));
     labelWalletHDStatusIcon->setToolTip(hdEnabled ? tr("HD key generation is <b>enabled</b>") : tr("HD key generation is <b>disabled</b>"));
 
-    // eventually disable the QLabel to set its opacity to 50% 
+    // eventually disable the QLabel to set its opacity to 50%
     labelWalletHDStatusIcon->setEnabled(hdEnabled);
 }
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -347,7 +347,7 @@ BOOST_AUTO_TEST_CASE(strprintf_numbers)
 #undef B
 #undef E
 
-/* Check for mingw/wine issue #3494
+/* Check for mingw/wine issue bitcoin/bitcoin#3494
  * Remove this test before time.ctime(0xffffffff) == 'Sun Feb  7 07:28:15 2106'
  */
 BOOST_AUTO_TEST_CASE(gettime)

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -59,7 +59,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
     vTimeOffsets.input(nOffsetSample);
     LogPrint(BCLog::NET,"added time data, samples %d, offset %+d (%+d minutes)\n", vTimeOffsets.size(), nOffsetSample, nOffsetSample/60);
 
-    // There is a known issue here (see issue #4521):
+    // There is a known issue here (see issue bitcoin/bitcoin#4521):
     //
     // - The structure vTimeOffsets contains up to 200 elements, after which
     // any new element added to it will not increase its size, replacing the

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -156,7 +156,7 @@ namespace tfm = tinyformat;
 
 #ifdef __APPLE__
 // Workaround OSX linker warning: xcode uses different default symbol
-// visibilities for static libs vs executables (see issue #25)
+// visibilities for static libs vs executables (see issue c42f/tinyformat#25)
 #   define TINYFORMAT_HIDDEN __attribute__((visibility("hidden")))
 #else
 #   define TINYFORMAT_HIDDEN

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -534,7 +534,7 @@ void TorController::auth_cb(TorControlConnection& _conn, const TorControlReply& 
 
         // Finally - now create the service
         if (private_key.empty()) // No private key, generate one
-            private_key = "NEW:RSA1024"; // Explicitly request RSA1024 - see issue #9214
+            private_key = "NEW:RSA1024"; // Explicitly request RSA1024 - see issue bitcoin/bitcoin#9214
         // Request hidden service, redirect port.
         // Note that the 'virtual' port doesn't have to be the same as our internal port, but this is just a convenient
         // choice.  TODO; refactor the shutdown sequence some day.


### PR DESCRIPTION
Add a full qualifier for the GitHub repo to issue references so
that it's clear that they are not issues in the unit-e repository.

This follows the convention GitHub uses for autoreferencing issues:
https://help.github.com/articles/autolinked-references-and-urls/
