### PR TITLE
Fix a possible race in proposer_stakeable_balance

### DIFF
--- a/test/functional/proposer_stakeable_balance.py
+++ b/test/functional/proposer_stakeable_balance.py
@@ -28,6 +28,16 @@ class ProposerStakeableBalanceTest(UnitETestFramework):
 
         nodes = self.nodes
 
+        def has_synced_blockchain(i):
+            def predicate():
+                status = nodes[i].proposerstatus()
+                return status['wallets'][0]['status'] != 'NOT_PROPOSING_SYNCING_BLOCKCHAIN'
+            return predicate
+
+        # wait for nodes to exit NOT_PROPOSING_SYNCING_BLOCKCHAIN status
+        for i in range(0, self.num_nodes):
+            wait_until(has_synced_blockchain(i))
+
         # at first none of the nodes will propose as it has no peers
         for i in range(0, self.num_nodes):
             status = nodes[i].proposerstatus()


### PR DESCRIPTION
This was brought to my attention by @AM5800 who saw that test failing with `AssertionError: not(NOT_PROPOSING_SYNCING_BLOCKCHAIN == NOT_PROPOSING_NO_PEERS)` in https://api.travis-ci.com/v3/job/163298238/log.txt?log.token=EVe7vW-dtxbuVu0V2NQFQw

In this test the proposer is checked to actually advance through the different states correctly until funds are available. Before it transitions into `NOT_PROPOSING_NO_PEERS` it will be in `NOT_PROPOSING_SYNCING_BLOCKCHAIN`. This is not anything which can triggered from the outside as the node will only have the genesis block in this scenario anyway. It might very rarely happen cause usually processing this one block is pretty fast.

So this change waits for the node to have progressed into the state at which it is not connected to any peers.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>