### PR TITLE
Fix flaky block generation

### DIFF
--- a/test/functional/esperanza_admin_full_cycle.py
+++ b/test/functional/esperanza_admin_full_cycle.py
@@ -108,13 +108,6 @@ class AdminFullCycle(UnitETestFramework):
             for j in range(i + 1, self.num_nodes):
                 connect_nodes_bi(self.nodes, i, j)
 
-    def sync_generate(self, node, n_blocks):
-        # When it comes to checking votes - it is important to always sync
-        # all - this guarantees that votes are not outdated/stuck anywhere
-        for _ in range(n_blocks):
-            node.generate(1)
-            self.sync_all()
-
     def run_test(self):
         self.nodes[0].importmasterkey(
             'swap fog boost power mountain pair gallery crush price fiscal '
@@ -166,7 +159,7 @@ class AdminFullCycle(UnitETestFramework):
 
         # Generate some blocks and check that validators are voting
         n_blocks = 2 * EPOCH_LENGTH
-        self.sync_generate(proposer, n_blocks)
+        self.generate_sync(proposer, n_blocks)
 
         assert (prev_n_blocks_have_txs_from(proposer, validator1.address,
                                             n_blocks))
@@ -177,7 +170,7 @@ class AdminFullCycle(UnitETestFramework):
 
         # Blacklist v1
         admin.blacklist([validator1.pubkey])
-        self.sync_generate(proposer, n_blocks)
+        self.generate_sync(proposer, n_blocks)
 
         assert (not prev_n_blocks_have_txs_from(proposer, validator1.address,
                                                 n_blocks))
@@ -189,9 +182,9 @@ class AdminFullCycle(UnitETestFramework):
         # v1 should be able to logout even if blacklisted
         validator1.logout_ok()
 
-        self.sync_generate(proposer, DYNASTY_LOGOUT_DELAY * EPOCH_LENGTH)
-        self.sync_generate(proposer, WITHDRAWAL_EPOCH_DELAY * EPOCH_LENGTH)
-        self.sync_generate(proposer, EPOCH_LENGTH)
+        self.generate_sync(proposer, DYNASTY_LOGOUT_DELAY * EPOCH_LENGTH)
+        self.generate_sync(proposer, WITHDRAWAL_EPOCH_DELAY * EPOCH_LENGTH)
+        self.generate_sync(proposer, EPOCH_LENGTH)
 
         validator1.withdraw_ok()
 
@@ -200,7 +193,7 @@ class AdminFullCycle(UnitETestFramework):
         admin.end_permissioning()
 
         validator1.deposit_ok()
-        self.sync_generate(proposer, n_blocks)
+        self.generate_sync(proposer, n_blocks)
 
         assert (
             prev_n_blocks_have_txs_from(proposer, validator1.address, n_blocks))

--- a/test/functional/esperanza_admin_validation.py
+++ b/test/functional/esperanza_admin_validation.py
@@ -119,9 +119,8 @@ class AdminValidation(UnitETestFramework):
 
         assert_equal(10000, self.admin.getbalance())
 
-        # Waiting for maturity
-        self.admin.generate(COINBASE_MATURITY)
-        self.sync_all()
+        # Exit IBD
+        self.generate_sync(self.admin)
 
         self.admin.p2p.wait_for_verack()
 
@@ -184,7 +183,7 @@ class AdminValidation(UnitETestFramework):
                      "b'admin-invalid-command'")
 
         # This is to ensure end_permissioning was not applied
-        self.admin.generate(1)
+        self.generate_sync(self.admin)
 
         # Going to reset admin keys. Generate new keys first
         new_addresses = list(self.admin.getnewaddress() for _ in range(3))
@@ -198,7 +197,7 @@ class AdminValidation(UnitETestFramework):
         self.accepts([reset_admin_cmd], admin_address)
 
         # Admin commands have no power until included into block
-        self.admin.generate(1)
+        self.generate_sync(self.admin)
 
         # Previous command has changed admin keys. Old address is invalid
         self.rejects([end_permissioning_cmd],
@@ -209,7 +208,7 @@ class AdminValidation(UnitETestFramework):
                                                       "p2sh-segwit")["address"]
 
         self.accepts([end_permissioning_cmd], admin_address)
-        self.admin.generate(1)  # to actually execute above command
+        self.generate_sync(self.admin) # to actually execute above command
 
         self.rejects([end_permissioning_cmd],
                      admin_address,

--- a/test/functional/esperanza_deposit.py
+++ b/test/functional/esperanza_deposit.py
@@ -60,8 +60,6 @@ class EsperanzaDepositTest(UnitETestFramework):
         for n in range(0, 119):
             self.generate_block(nodes[1])
 
-        sync_blocks(self.nodes)
-
         # generates 1 more block
         Admin.authorize_and_disable(self, nodes[1])
 
@@ -74,8 +72,6 @@ class EsperanzaDepositTest(UnitETestFramework):
         for n in range(0, 20):
             self.generate_block(nodes[(n % 3) + 1])
 
-        sync_blocks(self.nodes)
-
         resp = validator.getvalidatorinfo()
         assert resp["enabled"]
         assert_equal(resp["validator_status"], "IS_VALIDATING")
@@ -86,7 +82,7 @@ class EsperanzaDepositTest(UnitETestFramework):
         # invalid at submission. This is to account for those cases.
         while i < 5:
             try:
-                node.generate(1)
+                self.generate_sync(node)
                 return
             except JSONRPCException as exp:
                 i += 1

--- a/test/functional/esperanza_logout.py
+++ b/test/functional/esperanza_logout.py
@@ -41,7 +41,6 @@ class EsperanzaLogoutTest(UnitETestFramework):
 
     def run_test(self):
         nodes = self.nodes
-        block_time = 0.1
 
         validator = nodes[0]
 
@@ -58,8 +57,6 @@ class EsperanzaLogoutTest(UnitETestFramework):
         for n in range(0, 119):
             self.generate_block(nodes[1])
 
-        sync_blocks(self.nodes)
-
         # generates 1 more block
         Admin.authorize_and_disable(self, nodes[1])
 
@@ -73,7 +70,6 @@ class EsperanzaLogoutTest(UnitETestFramework):
         # +1 block to include a vote that was casted in 20th block
         for n in range(0, 21):
             self.generate_block(nodes[(n % 3) + 1])
-            self.sync_all()
 
         assert_equal(validator.getblockchaininfo()['blocks'], 141)
 
@@ -87,8 +83,6 @@ class EsperanzaLogoutTest(UnitETestFramework):
         # wait for 2 dynasties since logout so we are not required to vote anymore
         for n in range(0, 20):
             self.generate_block(nodes[(n % 3) + 1])
-            time.sleep(block_time)
-            sync_blocks(self.nodes)
 
         resp = validator.getvalidatorinfo()
         assert resp["enabled"]
@@ -100,7 +94,7 @@ class EsperanzaLogoutTest(UnitETestFramework):
         # invalid at submission. This is to account for those cases.
         while i < 5:
             try:
-                node.generate(1)
+                self.generate_sync(node)
                 return
             except JSONRPCException as exp:
                 i += 1

--- a/test/functional/esperanza_slash.py
+++ b/test/functional/esperanza_slash.py
@@ -63,8 +63,6 @@ class EsperanzaSlashTest(UnitETestFramework):
         self.setup_clean_chain = True
 
     def run_test(self):
-        block_time = 0.2
-
         nodes = self.nodes
         self.proposer = nodes[0]
         self.validator = nodes[1]
@@ -92,8 +90,6 @@ class EsperanzaSlashTest(UnitETestFramework):
         for n in range(0, 9):
             self.generate_block(proposer)
 
-        sync_blocks(self.nodes)
-
         # generates 1 more block
         Admin.authorize_and_disable(self, proposer)
 
@@ -103,8 +99,6 @@ class EsperanzaSlashTest(UnitETestFramework):
         # generate 2 more epochs
         for n in range(0, 20):
             self.generate_block(proposer)
-            sync_blocks(self.nodes)
-            time.sleep(block_time)
 
         self.wait_for_transaction(self.deposit_id, 30)
 
@@ -154,7 +148,7 @@ class EsperanzaSlashTest(UnitETestFramework):
         # invalid at submission. This is to account for those cases.
         while i < 5:
             try:
-                return node.generate(1)
+                return self.generate_sync(node)
             except JSONRPCException as exp:
                 i += 1
                 print("error generating block:", exp.error)

--- a/test/functional/esperanza_vote.py
+++ b/test/functional/esperanza_vote.py
@@ -40,9 +40,6 @@ class EsperanzaVoteTest(UnitETestFramework):
         self.setup_clean_chain = True
 
     def run_test(self):
-
-        block_time = 1
-
         nodes = self.nodes
 
         nodes[0].importmasterkey('swap fog boost power mountain pair gallery crush price fiscal thing supreme chimney drastic grab acquire any cube cereal another jump what drastic ready')
@@ -59,8 +56,6 @@ class EsperanzaVoteTest(UnitETestFramework):
         # wait for coinbase maturity
         for n in range(0, 119):
             self.generate_block(nodes[0])
-
-        sync_blocks(self.nodes)
 
         # generates 1 more block
         Admin.authorize_and_disable(self, nodes[0])
@@ -82,8 +77,6 @@ class EsperanzaVoteTest(UnitETestFramework):
         # Then we generate other 10 epochs
         for n in range(0, 50):
             self.generate_block(nodes[0])
-            sync_blocks(self.nodes)
-            time.sleep(block_time)
 
         resp = nodes[0].getfinalizationstate()
         assert_equal(resp["currentEpoch"], 17)
@@ -99,7 +92,7 @@ class EsperanzaVoteTest(UnitETestFramework):
         # invalid at submission. This is to account for those cases.
         while i < 5:
             try:
-                node.generate(1)
+                self.generate_sync(node)
                 return
             except JSONRPCException as exp:
                 i += 1

--- a/test/functional/esperanza_withdraw.py
+++ b/test/functional/esperanza_withdraw.py
@@ -42,7 +42,6 @@ class EsperanzaWithdrawTest(UnitETestFramework):
 
     def run_test(self):
         nodes = self.nodes
-        block_time = 0.1
 
         validator = nodes[0]
 
@@ -59,8 +58,6 @@ class EsperanzaWithdrawTest(UnitETestFramework):
         for n in range(0, 119):
             self.generate_block(nodes[1])
 
-        sync_blocks(self.nodes)
-
         # generates 1 more block
         Admin.authorize_and_disable(self, nodes[1])
 
@@ -74,7 +71,6 @@ class EsperanzaWithdrawTest(UnitETestFramework):
         # +1 block to include a vote that was casted in 20th block
         for n in range(0, 21):
             self.generate_block(nodes[(n % 3) + 1])
-            self.sync_all()
 
         assert_equal(validator.getblockchaininfo()['blocks'], 141)
 
@@ -88,8 +84,6 @@ class EsperanzaWithdrawTest(UnitETestFramework):
         # wait for 2 dynasties since logout so we are not required to vote anymore
         for n in range(0, 20):
             self.generate_block(nodes[(n % 3) + 1])
-            time.sleep(block_time)
-            self.sync_all()
 
         resp = validator.getvalidatorinfo()
         assert resp["enabled"]
@@ -99,8 +93,6 @@ class EsperanzaWithdrawTest(UnitETestFramework):
         # fact that the endEpoch is startEpoch(endDynasty + 1) )
         for n in range(0, 140):
             self.generate_block(nodes[(n % 3) + 1])
-            time.sleep(block_time)
-            self.sync_all()
 
         # check that there is no leftover vote in the mempool,
         # this might happen if votes are outdated but not pruned yet
@@ -111,7 +103,6 @@ class EsperanzaWithdrawTest(UnitETestFramework):
 
         # let's mine the withdraw
         self.generate_block(nodes[1])
-        sync_blocks(self.nodes)
 
         # This is the initial deposit - fees for deposit, logout and withdraw
         assert_equal(math.ceil(validator.getbalance()), 10000)
@@ -122,7 +113,7 @@ class EsperanzaWithdrawTest(UnitETestFramework):
         # invalid at submission. This is to account for those cases.
         while i < 5:
             try:
-                node.generate(1)
+                self.generate_sync(node)
                 return
             except JSONRPCException as exp:
                 i += 1

--- a/test/functional/test_framework/admin.py
+++ b/test/functional/test_framework/admin.py
@@ -81,8 +81,7 @@ class Admin:
         self.framework.wait_for_transaction(txid)
         self.prevout = Admin.find_output_for_address(self.admin_node, txid,
                                                      self.address)
-        self.donor_node.generate(1)
-        self.framework.sync_all()
+        self.framework.generate_sync(self.donor_node)
         return txid
 
     @staticmethod

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -338,6 +338,26 @@ class UnitETestFramework():
             sync_blocks(group)
             sync_mempools(group)
 
+    def generate_sync(self, generator_node, nblocks=1):
+        """
+        Generates nblocks on a given node. Performing full sync after each block
+        """
+        generated_blocks = []
+        for _ in range(nblocks):
+            block = generator_node.generate(1)[0]
+            generated_blocks.append(block)
+            sync_blocks(self.nodes)
+
+            # VoteIfNeeded is called on a background thread.
+            # By syncing we ensure that all votes will be in the mempools at the
+            # end of this iteration
+            for node in self.nodes:
+                node.syncwithvalidationinterfacequeue()
+
+            sync_mempools(self.nodes)
+
+        return generated_blocks
+
     def enable_mocktime(self):
         """Enable mocktime for the script.
 


### PR DESCRIPTION
This PR fixes a flakiness in several tests.

`esperanza_deposit.py` flaked at least once with this error:
```
AssertionError: Block sync failed, mismatched block hashes:
  {'height': 139, 'hash': '1e251c4de96f844e20dbafa9394daf9d2b223411c244e4e8d11c0e1f4113b1e9'}
  {'height': 139, 'hash': '1e251c4de96f844e20dbafa9394daf9d2b223411c244e4e8d11c0e1f4113b1e9'}
  {'height': 139, 'hash': '658f822daf4da746caa90ddf6b1a5e45f4da87501c648d3ab3fadd89c9c60ad2'}
  {'height': 139, 'hash': '658f822daf4da746caa90ddf6b1a5e45f4da87501c648d3ab3fadd89c9c60ad2'}
```

I wasn't able to reproduce this locally, but I am almost 100% sure this was caused by:
```python
for n in range(0, 20):
    self.generate_block(nodes[(n % 3) + 1])
```
So it is possible for different nodes to be on a different tip. I, however, do not know for sure why they didn't reorg. But nevertheless, solution is to always sync tips after generate. I have created a function for this: `generate_sync`

Another thing to notice here is the use of `syncwithvalidationinterfacequeue` after block generation. This function waits until validation interface callback thread is free. 
`Generate` generates block, switches to it and exits. But it also queues `BlockConnected` on background thread. This is the place where votes are casted. So there is a chance that we generate an epoch before this handler is ever executed.

I have also removed several sleeps after block generation. I did this assuming that `syncwithvalidationinterfacequeue` is enough. If I am wrong or missing something - please tell me. I will return sleeps back.

This sync is obviously works slower. So I run several performance experiments:
I measured total running time of all `esperanza*` tests.


before | generate_sync | generate_sync + remove sleeps
-------|----------------|-----------------------------------
4m35s|5m7s                 |3m48s 

Signed-off-by: Aleksandr Mikhailov <aleksandr@thirdhash.com>