### PR TITLE
Show correct client name in help output

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -90,7 +90,7 @@ UniValue getpeerinfo(const JSONRPCRequest& request)
             "    \"minping\": n,              (numeric) minimum observed ping time (if any at all)\n"
             "    \"pingwait\": n,             (numeric) ping wait (if non-zero)\n"
             "    \"version\": v,              (numeric) The peer version, such as 70001\n"
-            "    \"subver\": \"/" + CLIENT_NAME + ":0.8.5/\",  (string) The string version\n"
+            "    \"subver\": \"/" + CLIENT_NAME + ":x.x.x/\",  (string) The string version\n"
             "    \"inbound\": true|false,     (boolean) Inbound (true) or Outbound (false)\n"
             "    \"addnode\": true|false,     (boolean) Whether connection was due to addnode/-connect or if it was an automatic/inbound connection\n"
             "    \"startingheight\": n,       (numeric) The starting height (block) of the peer\n"


### PR DESCRIPTION
Use the global variable CLIENT_NAME for the client name in the rpc
help output instead of hardcoding the value.

Signed-off-by: Cornelius Schumacher <cornelius@thirdhash.com>
