### PR TITLE
Revert attempt to rename Coinbase to Coinstake

### DIFF
--- a/src/blockchain/blockchain_genesis.cpp
+++ b/src/blockchain/blockchain_genesis.cpp
@@ -19,11 +19,11 @@
 
 namespace blockchain {
 
-const CTransactionRef GenesisBlockBuilder::BuildCoinstakeTransaction() const {
+const CTransactionRef GenesisBlockBuilder::BuildCoinbaseTransaction() const {
   CMutableTransaction tx;
 
   tx.SetVersion(2);
-  tx.SetType(TxType::COINSTAKE);
+  tx.SetType(TxType::COINBASE);
 
   const CScript scriptSig = CScript() << CScriptNum::serialize(0)  // height
                                       << ToByteVector(uint256())   // utxo set hash
@@ -51,8 +51,8 @@ const CBlock GenesisBlockBuilder::Build(const Parameters &parameters) const {
   genesis_block.nTime = behavior->CalculateProposingTimestamp(m_time);
   genesis_block.nBits = m_bits;
 
-  CTransactionRef coinstake_transaction = BuildCoinstakeTransaction();
-  genesis_block.vtx.push_back(coinstake_transaction);
+  CTransactionRef coinbase_transaction = BuildCoinbaseTransaction();
+  genesis_block.vtx.push_back(coinbase_transaction);
 
   genesis_block.hashPrevBlock = uint256();
   genesis_block.hashMerkleRoot = BlockMerkleRoot(genesis_block);

--- a/src/blockchain/blockchain_genesis.h
+++ b/src/blockchain/blockchain_genesis.h
@@ -66,7 +66,7 @@ class GenesisBlockBuilder {
   blockchain::Difficulty m_bits = 0x1d00ffff;
   std::vector<std::pair<CAmount, CTxDestination>> m_initial_funds;
 
-  const CTransactionRef BuildCoinstakeTransaction() const;
+  const CTransactionRef BuildCoinbaseTransaction() const;
 };
 
 }  // namespace blockchain

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -141,7 +141,7 @@ bool IsFinalizationTransaction(const CTransaction &tx)
         case TxType::ADMIN:
             return true;
         case TxType::STANDARD:
-        case TxType::COINSTAKE:
+        case TxType::COINBASE:
         case TxType::WITHDRAW:
             return false;
     }

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -169,7 +169,7 @@ uint256 BlockWitnessMerkleRoot(const CBlock& block, bool* mutated)
 {
     std::vector<uint256> leaves;
     leaves.resize(block.vtx.size());
-    // UNIT-E TODO: In unit-e the coinstake transaction has a witness too
+    // UNIT-E TODO: In unit-e the coinbase transaction has a witness too
     leaves[0].SetNull(); // The witness hash of the coinbase is 0.
     for (size_t s = 1; s < block.vtx.size(); s++) {
         leaves[s] = block.vtx[s]->GetWitnessHash();

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -351,12 +351,6 @@ public:
         return (vin.size() == 1 && vin[0].prevout.IsNull());
     }
 
-    bool IsCoinStake() const
-    {
-        //UNIT-E: TODO: Check whether we need this distinction or we can deduce like Bitcoin's IsCoinBase() above
-        return GetType() == +TxType::COINSTAKE;
-    }
-
     bool IsVote() const {
         return GetType() == +TxType::VOTE;
     }

--- a/src/primitives/txtype.h
+++ b/src/primitives/txtype.h
@@ -19,7 +19,7 @@ BETTER_ENUM(
   TxType,
   uint16_t,
   STANDARD = 0,
-  COINSTAKE = 1,
+  COINBASE = 1,
   DEPOSIT = 2,
   VOTE = 3,
   LOGOUT = 4,

--- a/src/snapshot/messages.h
+++ b/src/snapshot/messages.h
@@ -174,7 +174,7 @@ class SnapshotHash {
   //! GetHash returns the hash that represents the snapshot
   //!
   //! \param stakeModifier which points to the same height as the snapshot hash
-  //! \return the hash which is stored inside the coinstake TX
+  //! \return the hash which is stored inside the coinbase TX
   uint256 GetHash(uint256 stakeModifier) const;
 
   //! GetHashVector is a proxy to GetHash

--- a/src/staking/block_validator.cpp
+++ b/src/staking/block_validator.cpp
@@ -19,34 +19,34 @@ class BlockValidatorImpl : public BlockValidator {
 
   using Error = BlockValidationError;
 
-  //! \brief checks that the coinstake transaction has the right structure, but nothing else
+  //! \brief checks that the coinbase transaction has the right structure, but nothing else
   //!
-  //! A well-formed coinstake transaction:
+  //! A well-formed coinbase transaction:
   //! - has at least two inputs
   //! - the first input contains only meta information
   //! - the first input's scriptSig contains the block height and snapshot hash
-  BlockValidationResult CheckCoinstakeTransaction(CTransactionRef tx) const {
+  BlockValidationResult CheckCoinbaseTransaction(CTransactionRef tx) const {
     BlockValidationResult validationErrors;
 
     if (tx->vin.empty()) {
       validationErrors += Error::NO_META_INPUT;
     } else {
-      validationErrors += CheckCoinstakeMetaInput(tx->vin[0]);
+      validationErrors += CheckCoinbaseMetaInput(tx->vin[0]);
     }
     if (tx->vin.size() < 2) {
       validationErrors += Error::NO_STAKING_INPUT;
     }
     if (tx->vout.empty()) {
-      validationErrors += Error::COINSTAKE_TRANSACTION_WITHOUT_OUTPUT;
+      validationErrors += Error::COINBASE_TRANSACTION_WITHOUT_OUTPUT;
     }
     return validationErrors;
   }
 
-  //! \brief checks that the first input of a coinstake transaction is well-formed
+  //! \brief checks that the first input of a coinbase transaction is well-formed
   //!
   //! A well-formed meta input encodes the block height, followed by the snapshot hash.
   //! It is then either terminated by OP_0 or some data follows (forwards-compatible).
-  BlockValidationResult CheckCoinstakeMetaInput(const CTxIn &in) const {
+  BlockValidationResult CheckCoinbaseMetaInput(const CTxIn &in) const {
     BlockValidationResult validationErrors;
 
     const CScript &scriptSig = in.scriptSig;
@@ -132,17 +132,17 @@ class BlockValidatorImpl : public BlockValidator {
       return validationErrors;
     }
 
-    // check that coinstake transaction is first transaction
-    if (block.vtx[0]->GetType() == +TxType::COINSTAKE) {
-      validationErrors += CheckCoinstakeTransaction(block.vtx[0]);
+    // check that coinbase transaction is first transaction
+    if (block.vtx[0]->GetType() == +TxType::COINBASE) {
+      validationErrors += CheckCoinbaseTransaction(block.vtx[0]);
     } else {
-      validationErrors += Error::FIRST_TRANSACTION_NOT_A_COINSTAKE_TRANSACTION;
+      validationErrors += Error::FIRST_TRANSACTION_NOT_A_COINBASE_TRANSACTION;
     }
 
-    // check that all other transactions are no coinstake transactions
+    // check that all other transactions are no coinbase transactions
     for (auto tx = block.vtx.cbegin() + 1; tx != block.vtx.cend(); ++tx) {
-      if ((*tx)->GetType() == +TxType::COINSTAKE) {
-        validationErrors += Error::COINSTAKE_TRANSACTION_AT_POSITION_OTHER_THAN_FIRST;
+      if ((*tx)->GetType() == +TxType::COINBASE) {
+        validationErrors += Error::COINBASE_TRANSACTION_AT_POSITION_OTHER_THAN_FIRST;
       }
     }
 

--- a/src/staking/block_validator.h
+++ b/src/staking/block_validator.h
@@ -21,11 +21,11 @@ BETTER_ENUM(
     BlockValidationError,
     std::uint8_t,
     BLOCK_SIGNATURE_VERIFICATION_FAILED,
-    COINSTAKE_TRANSACTION_AT_POSITION_OTHER_THAN_FIRST,
-    COINSTAKE_TRANSACTION_WITHOUT_OUTPUT,
+    COINBASE_TRANSACTION_AT_POSITION_OTHER_THAN_FIRST,
+    COINBASE_TRANSACTION_WITHOUT_OUTPUT,
     DUPLICATE_TRANSACTIONS_IN_MERKLE_TREE,
     DUPLICATE_TRANSACTIONS_IN_WITNESS_MERKLE_TREE,
-    FIRST_TRANSACTION_NOT_A_COINSTAKE_TRANSACTION,
+    FIRST_TRANSACTION_NOT_A_COINBASE_TRANSACTION,
     INVALID_BLOCK_HEIGHT,
     INVALID_BLOCK_TIME,
     INVALID_BLOCK_PUBLIC_KEY,
@@ -59,9 +59,9 @@ class BlockValidator {
   //! \brief checks that the block has the right structure, but nothing else
   //!
   //! A well-formed block is supposed to follow the following structure:
-  //! - at least one transaction (the coinstake transaction)
-  //! - the coinstake transaction must be the first transaction
-  //! - no other transaction maybe marked as coinstake transaction
+  //! - at least one transaction (the coinbase transaction)
+  //! - the coinbase transaction must be the first transaction
+  //! - no other transaction maybe marked as coinbase transaction
   virtual BlockValidationResult CheckBlock(const CBlock &) const = 0;
 
   virtual ~BlockValidator() = default;

--- a/src/staking/transactionpicker.cpp
+++ b/src/staking/transactionpicker.cpp
@@ -61,7 +61,7 @@ class BlockAssemblerAdapter final : public TransactionPicker {
     // The block assembler unfortunately also creates a bitcoin-style
     // coinbase transaction. We do not want to touch that logic to
     // retain compatibility with bitcoin. The construction of the
-    // coinstake transaction is left to the component using a
+    // coinbase transaction is left to the component using a
     // TransactionPicker to build a block. Therefore we just pass an
     // empty script to the blockAssembler.
     CScript script(1);


### PR DESCRIPTION
This transition is more painful and not helpful.
This PR proposes to stop this process and use only coinbase.
It's also convenient when we rebase with the upstream

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>