### PR TITLE
Use snapshot category for its RPCs instead of blockchain

### DIFF
--- a/src/snapshot/rpc_processing.cpp
+++ b/src/snapshot/rpc_processing.cpp
@@ -284,14 +284,14 @@ UniValue gettipsnapshot(const JSONRPCRequest &request) {
 
 // clang-format off
 static const CRPCCommand commands[] = {
-    // category     name                 actor (function)   argNames
-    // --------     -----------------   ----------------   --------
-    { "blockchain", "createsnapshot",   &createsnapshot,   {"maxutxosubsets"} },
-    { "blockchain", "deletesnapshot",   &deletesnapshot,   {"snapshothash"} },
-    { "blockchain", "getblocksnapshot", &getblocksnapshot, {"blockhash"} },
-    { "blockchain", "listsnapshots",    &listsnapshots,    {""} },
-    { "blockchain", "gettipsnapshot",   &gettipsnapshot,   {}},
-    { "blockchain", "calcsnapshothash", &calcsnapshothash, {}},
+    // category   name                actor (function)   argNames
+    // --------   ------------------  -----------------  --------
+    { "snapshot", "createsnapshot",   &createsnapshot,   {"maxutxosubsets"} },
+    { "snapshot", "deletesnapshot",   &deletesnapshot,   {"snapshothash"} },
+    { "snapshot", "getblocksnapshot", &getblocksnapshot, {"blockhash"} },
+    { "snapshot", "listsnapshots",    &listsnapshots,    {""} },
+    { "snapshot", "gettipsnapshot",   &gettipsnapshot,   {}},
+    { "snapshot", "calcsnapshothash", &calcsnapshothash, {}},
 };
 // clang-format on
 


### PR DESCRIPTION
This change will group snapshot RPC commands under snapshot category in help response
```
➜  unit-e ./src/unite-cli help
...
== Snapshot ==
calcsnapshothash
createsnapshot (<maxutxosubsets>)
deletesnapshot (<snapshothash>)
getblocksnapshot (<blockhash>)
gettipsnapshot
listsnapshots
```

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>