### PR TITLE
Set names for jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,7 @@ jobs:
         UNITE_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER"
 
     - stage: test
-      name: "x86_64 Linux, No wallet (unit and functional tests)"
+      name: "x86_64 Linux, No wallet (unit tests)"
       env: >-
         HOST=x86_64-unknown-linux-gnu
         PACKAGES="python3"


### PR DESCRIPTION
I have been experimenting with travis and found a way to assign human-readable names to jobs. 
Hope you like it.

before:
https://travis-ci.com/dtr-org/unit-e

after:
https://travis-ci.com/AM5800/unit-e

P.S. I took job names from corresponding comments

Signed-off-by: Aleksandr Mikhailov <aleksandr@thirdhash.com>