### PR TITLE
Check initialization status in Initailzie() and Deinitalize()

### DIFF
--- a/src/snapshot/creator.cpp
+++ b/src/snapshot/creator.cpp
@@ -32,12 +32,14 @@ struct SnapshotJob {
       : block_index(_block_index) {}
 };
 
+namespace {
 uint16_t g_create_snapshot_per_epoch = 0;
 std::thread g_creator_thread;
 std::mutex mutex;
 std::condition_variable cv;
 std::queue<std::unique_ptr<SnapshotJob>> jobs;
 std::atomic_bool interrupt(false);
+}  // namespace
 
 void ProcessCreatorQueue() {
   while (!interrupt) {


### PR DESCRIPTION
The deinitialize function of snapshot can be invoked without having been initialized first. This adds the use of an atomic flag to check and guard against that.

Actual scenario where this would crash otherwise: Corrupt block index. The node starts up, finds the corrupt block index, and goes down before it even starts creating the snapshot (things). It invokes deinitialize() and crashes (tries to join on a thread which was not started etc.).

Okay you do not have a corrupt block index every day, but the software should fail gracefully in this case.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>