### PR TITLE
Move LookupBlockIndex to validation.h

### DIFF
--- a/src/snapshot/p2p_processing.cpp
+++ b/src/snapshot/p2p_processing.cpp
@@ -14,14 +14,6 @@
 
 namespace snapshot {
 
-// todo: remove it after merging
-// https://github.com/bitcoin/bitcoin/commit/92fabcd443322dcfdf2b3477515fae79e8647d86
-inline CBlockIndex *LookupBlockIndex(const uint256 &hash) {
-  AssertLockHeld(cs_main);
-  BlockMap::const_iterator it = mapBlockIndex.find(hash);
-  return it == mapBlockIndex.end() ? nullptr : it->second;
-}
-
 inline CBlockIndex *LookupFinalizedBlockIndex(const uint256 &hash) {
   CBlockIndex *bi = LookupBlockIndex(hash);
   if (!bi) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -441,6 +441,15 @@ public:
 /** Replay blocks that aren't fully applied to the database. */
 bool ReplayBlocks(const CChainParams& params, CCoinsView* view);
 
+// UNIT-E: extracted from bitcoin (remove comment after merging)
+// https://github.com/bitcoin/bitcoin/commit/92fabcd443322dcfdf2b3477515fae79e8647d86
+inline CBlockIndex* LookupBlockIndex(const uint256& hash)
+{
+    AssertLockHeld(cs_main);
+    BlockMap::const_iterator it = mapBlockIndex.find(hash);
+    return it == mapBlockIndex.end() ? nullptr : it->second;
+}
+
 /** Find the last common block between the parameter chain and a locator. */
 CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator);
 


### PR DESCRIPTION
There's the useful function added to bitcoin and already ported to the unit-e project by @kostyantyn to the snapshot. This commit moves it to the original global scope place so that we can start to use it and easily merge with bitcoin later.

Signed-off-by: Stanislav Frolov <stanislav@thirdhash.com>