### PR TITLE
Remove unused Python test imports

### DIFF
--- a/test/functional/esperanza_deposit.py
+++ b/test/functional/esperanza_deposit.py
@@ -5,7 +5,6 @@
 
 from test_framework.util import json
 from test_framework.util import assert_equal
-from test_framework.util import sync_blocks
 from test_framework.util import JSONRPCException
 from test_framework.test_framework import UnitETestFramework
 from test_framework.admin import Admin

--- a/test/functional/esperanza_logout.py
+++ b/test/functional/esperanza_logout.py
@@ -5,8 +5,6 @@
 
 from test_framework.util import json
 from test_framework.util import assert_equal
-from test_framework.util import sync_blocks
-from test_framework.util import time
 from test_framework.util import JSONRPCException
 from test_framework.test_framework import UnitETestFramework
 from test_framework.admin import Admin

--- a/test/functional/esperanza_slash.py
+++ b/test/functional/esperanza_slash.py
@@ -6,10 +6,10 @@
 from test_framework.blocktools import *
 from test_framework.util import *
 from test_framework.test_framework import UnitETestFramework
-from test_framework.mininode import CTransaction, CBlock
+from test_framework.mininode import CTransaction
 from test_framework.admin import Admin
 from test_framework.address import *
-from test_framework.key import CECKey, CPubKey
+from test_framework.key import CECKey
 
 
 class Vote:

--- a/test/functional/esperanza_vote.py
+++ b/test/functional/esperanza_vote.py
@@ -5,8 +5,6 @@
 
 from test_framework.util import json
 from test_framework.util import assert_equal
-from test_framework.util import sync_blocks
-from test_framework.util import time
 from test_framework.util import JSONRPCException
 from test_framework.test_framework import UnitETestFramework
 from test_framework.admin import Admin

--- a/test/functional/esperanza_withdraw.py
+++ b/test/functional/esperanza_withdraw.py
@@ -6,8 +6,6 @@
 import math
 from test_framework.util import json
 from test_framework.util import assert_equal
-from test_framework.util import sync_blocks
-from test_framework.util import time
 from test_framework.util import JSONRPCException
 from test_framework.test_framework import UnitETestFramework
 from test_framework.admin import Admin


### PR DESCRIPTION
This keeps the Python linter happy, in case someone has it as a pre-commit hook.