### PR TITLE
Remove qt from travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,4 +143,4 @@ jobs:
         DEP_OPTS="NO_QT=1"
         UNITE_CONFIG="--enable-reduce-exports --enable-werror --with-gui=no"
         OSX_SDK=10.11
-        GOAL="deploy"
+        GOAL="install"


### PR DESCRIPTION
This is the first and quick step to start getting rid of Qt as per https://github.com/dtr-org/unit-e/issues/28, this PR disables Qt builds on travis.