### PR TITLE
Fix finalization state lookup in ContextualCheckBlock

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3322,7 +3322,12 @@ static bool ContextualCheckBlock(const CBlock& block, CValidationState& state, c
         if (tx->IsCommit() && fin_state == nullptr) {
             fin_state = esperanza::FinalizationState::GetState(pindexPrev);
             if (fin_state == nullptr) {
-                LogPrint(BCLog::FINALIZATION, "Cannot validate commit transaction: no finalization state for %s (%d)\n", pindexPrev->GetBlockHash().GetHex(), pindexPrev->nHeight);
+                if (pindexPrev != nullptr) {
+                    LogPrint(BCLog::FINALIZATION, "Cannot validate commit transaction: no finalization state for %s (%d)\n",
+                             pindexPrev->GetBlockHash().GetHex(), pindexPrev->nHeight);
+                } else {
+                    LogPrint(BCLog::FINALIZATION, "Cannot validate commit transaction: no finalization state, pindexPrev=nullptr\n");
+                }
                 return false;
             }
         }


### PR DESCRIPTION
While investigating #421 @AM5800 found issue that finalization state is invalid, it happened for commits transactions only, so it was hidden in tests. This commit fixes the problem.

Signed-off-by: Stanislav Frolov <stanislav@thirdhash.com>
