### PR TITLE
Don't reverse bytes in uint256.GetHex() function

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -246,10 +246,10 @@ public:
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.BIP16Height = 173805; // 00000000000000ce80a7e057163a4db1d5ad7b20fb6f598c9597b9665c8fb0d4 - April 1, 2012
         consensus.BIP34Height = 227931;
-        consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
+        consensus.BIP34Hash = uint256S("0xb808089c756add1591b1d17bab44bba3fed9e02f942ab4894b02000000000000");
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
-        consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.powLimit = uint256S("ffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = false;
@@ -271,10 +271,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1510704000; // November 15th, 2017.
 
         // The best chain should have at least this much work.
-        consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000f91c579d57cad4bc5278cc");
+        consensus.nMinimumChainWork = uint256S("0xcc7852bcd4ca579d571cf9000000000000000000000000000000000000000000");
 
         // By default assume that the signatures in ancestors of this block are valid.
-        consensus.defaultAssumeValid = uint256S("0x0000000000000000005214481d2d96f898e3d5416e43359c145944a909d242e0"); //506067
+        consensus.defaultAssumeValid = uint256S("0xe042d209a94459149c35436e41d5e398f8962d1d481452000000000000000000"); //506067
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -290,8 +290,8 @@ public:
 
         genesis = CreateGenesisBlock(1231006505, 2083236893, 0x1d00ffff, 1, 50 * UNIT);
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
-        assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        assert(consensus.hashGenesisBlock == uint256S("0x6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000"));
+        assert(genesis.hashMerkleRoot == uint256S("0x3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"));
 
         // Note that of those which support the service bits prefix, most only support a subset of
         // possible options.
@@ -308,19 +308,19 @@ public:
 
         checkpointData = {
             {
-                { 11111, uint256S("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d")},
-                { 33333, uint256S("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6")},
-                { 74000, uint256S("0x0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20")},
-                {105000, uint256S("0x00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97")},
-                {134444, uint256S("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe")},
-                {168000, uint256S("0x000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763")},
-                {193000, uint256S("0x000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317")},
-                {210000, uint256S("0x000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e")},
-                {216116, uint256S("0x00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e")},
-                {225430, uint256S("0x00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932")},
-                {250000, uint256S("0x000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214")},
-                {279000, uint256S("0x0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40")},
-                {295000, uint256S("0x00000000000000004d9b4ef50f0f9d686fd69db2e03af35a100370c64632a983")},
+                { 11111, uint256S("0x1d7c6eb2fd42f55925e92efad68b61edd22fba29fde8783df744e26900000000")},
+                { 33333, uint256S("0xa6d0b5df7d0df069ceb1e736a216ad187a50b07aaa4e78748a58d52d00000000")},
+                { 74000, uint256S("0x201a66b853f9e7814a820e2af5f5dc79c07144e31ce4c9a39339570000000000")},
+                {105000, uint256S("0x97dc6b1d15fbeef373a744fee0b254b0d2c820a3ae7f0228ce91020000000000")},
+                {134444, uint256S("0xfeb0d2420d4a18914c81ac30f494a5d4ff34cd15d34cfd2fb105000000000000")},
+                {168000, uint256S("0x63b703835cb735cb9a89d733cbe66f212f63795e0172ea619e09000000000000")},
+                {193000, uint256S("0x17138bca83bdc3e6f60f01177c3877a98266de40735f2a459f05000000000000")},
+                {210000, uint256S("0x2e3471a19b8e22b7f939c63663076603cf692f19837e34958b04000000000000")},
+                {216116, uint256S("0x4edf231bf170234e6a811460f95c94af9464e41ee833b4f4b401000000000000")},
+                {225430, uint256S("0x32595730b165f097e7b806a679cf7f3e439040f750433808c101000000000000")},
+                {250000, uint256S("0x14d2f24d29bed75354f3f88a5fb50022fc064b02291fdf873800000000000000")},
+                {279000, uint256S("0x407ebde958e44190fa9e810ea1fc3a7ef601c3b0a0728cae0100000000000000")},
+                {295000, uint256S("0x83a93246c67003105af33ae0b29dd66f689d0f0ff54e9b4d0000000000000000")},
             }
         };
 
@@ -344,10 +344,10 @@ public:
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.BIP16Height = 514; // 00000000040b4e986385315e14bee30ad876d8b47f748025b26683116d21aa65
         consensus.BIP34Height = 21111;
-        consensus.BIP34Hash = uint256S("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
+        consensus.BIP34Hash = uint256S("0xf88ecd9912d00d3f5c2a8e0f50417d3e415c75b3abe584346da9b32300000000");
         consensus.BIP65Height = 581885; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
         consensus.BIP66Height = 330776; // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
-        consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.powLimit = uint256S("ffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
@@ -369,10 +369,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1493596800; // May 1st 2017
 
         // The best chain should have at least this much work.
-        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000002830dab7f76dbb7d63");
+        consensus.nMinimumChainWork = uint256S("0x637dbb6df7b7da30280000000000000000000000000000000000000000000000");
 
         // By default assume that the signatures in ancestors of this block are valid.
-        consensus.defaultAssumeValid = uint256S("0x0000000002e9e7b00e1f6dc5123a04aad68dd0f0968d8c7aa45f6640795c37b1"); //1135275
+        consensus.defaultAssumeValid = uint256S("0xb1375c7940665fa47a8c8d96f0d08dd6aa043a12c56d1f0eb0e7e90200000000"); //1135275
 
         pchMessageStart[0] = 0xfd;
         pchMessageStart[1] = 0xfc;
@@ -383,8 +383,8 @@ public:
 
         genesis = CreateGenesisBlock(1296688602, 414098458, 0x1d00ffff, 1, 50 * UNIT);
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256S("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
-        assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        assert(consensus.hashGenesisBlock == uint256S("0x43497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea330900000000"));
+        assert(genesis.hashMerkleRoot == uint256S("0x3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"));
 
         vFixedSeeds.clear();
         vSeeds.clear();
@@ -400,7 +400,7 @@ public:
 
         checkpointData = {
             {
-                {546, uint256S("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70")},
+                {546, uint256S("70cb6af7ebbcb1315d3414029c556c55f3e2fc353c4c9063a76c932a00000000")},
             }
         };
 
@@ -427,7 +427,7 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
-        consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.powLimit = uint256S("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
@@ -459,8 +459,8 @@ public:
 
         genesis = CreateGenesisBlockRegTest(1296688602, 5, 0x207fffff, 1, 50 * UNIT);
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256S("0x0fc0564d6a9b524590b0f79d34a2453fdb962b438b1f6abe119f0d79c1484036"));
-        assert(genesis.hashMerkleRoot == uint256S("0x88d833e448144f214c09cc64f2a7b7f3f47b080c6f8a2f23d1b375f960a95297"));
+        assert(consensus.hashGenesisBlock == uint256S("0x364048c1790d9f11be6a1f8b432b96db3f45a2349df7b09045529b6a4d56c00f"));
+        assert(genesis.hashMerkleRoot == uint256S("0x9752a960f975b3d1232f8a6f0c087bf4f3b7a7f264cc094c214f1448e433d888"));
 
         vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.
         vSeeds.clear();      //!< Regtest mode doesn't have any DNS seeds.
@@ -471,7 +471,7 @@ public:
 
         checkpointData = {
             {
-                {0, uint256S("0x0fc0564d6a9b524590b0f79d34a2453fdb962b438b1f6abe119f0d79c1484036")},
+                {0, uint256S("0x364048c1790d9f11be6a1f8b432b96db3f45a2349df7b09045529b6a4d56c00f")},
             }
         };
 

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1291,7 +1291,7 @@ uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsig
         return ss.GetHash();
     }
 
-    static const uint256 one(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
+    static const uint256 one(uint256S("0100000000000000000000000000000000000000000000000000000000000000"));
 
     // Check for invalid use of SIGHASH_SINGLE
     if ((nHashType & 0x1f) == SIGHASH_SINGLE) {

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -25,7 +25,7 @@ inline arith_uint256 arith_uint256V(const std::vector<unsigned char>& vch)
 const unsigned char R1Array[] =
     "\x9c\x52\x4a\xdb\xcf\x56\x11\x12\x2b\x29\x12\x5e\x5d\x35\xd2\xd2"
     "\x22\x81\xaa\xb5\x33\xf0\x08\x32\xd5\x56\xb1\xf9\xea\xe5\x1d\x7d";
-const char R1ArrayHex[] = "7D1DE5EAF9B156D53208F033B5AA8122D2d2355d5e12292b121156cfdb4a529c";
+const char R1ArrayHex[] = "9c524adbcf5611122b29125e5d35d2D22281AAB533F00832D556B1F9EAE51D7D";
 const double R1Ldouble = 0.4887374590559308955; // R1L equals roughly R1Ldouble * 2^256
 const arith_uint256 R1L = arith_uint256V(std::vector<unsigned char>(R1Array,R1Array+32));
 const uint64_t R1LLow64 = 0x121156cfdb4a529cULL;
@@ -35,7 +35,7 @@ const unsigned char R2Array[] =
     "\x13\x30\x47\xa3\x19\x2d\xda\x71\x49\x13\x72\xf0\xb4\xca\x81\xd7";
 const arith_uint256 R2L = arith_uint256V(std::vector<unsigned char>(R2Array,R2Array+32));
 
-const char R1LplusR2L[] = "549FB09FEA236A1EA3E31D4D58F1B1369288D204211CA751527CFC175767850C";
+const char R1LplusR2L[] = "0C85675717FC7C5251A71C2104D2889236B1F1584D1DE3A31E6A23EA9FB09F54";
 
 const unsigned char ZeroArray[] =
     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
@@ -59,7 +59,7 @@ std::string ArrayToString(const unsigned char A[], unsigned int width)
     Stream << std::hex;
     for (unsigned int i = 0; i < width; ++i)
     {
-        Stream<<std::setw(2)<<std::setfill('0')<<(unsigned int)A[width-i-1];
+        Stream<<std::setw(2)<<std::setfill('0')<<(unsigned int)A[i];
     }
     return Stream.str();
 }
@@ -331,13 +331,13 @@ BOOST_AUTO_TEST_CASE( plusMinus )
 
 BOOST_AUTO_TEST_CASE( multiply )
 {
-    BOOST_CHECK((R1L * R1L).ToString() == "62a38c0486f01e45879d7910a7761bf30d5237e9873f9bff3642a732c4d84f10");
-    BOOST_CHECK((R1L * R2L).ToString() == "de37805e9986996cfba76ff6ba51c008df851987d9dd323f0e5de07760529c40");
+    BOOST_CHECK((R1L * R1L).ToString() == "104fd8c432a74236ff9b3f87e937520df31b76a710799d87451ef086048ca362");
+    BOOST_CHECK((R1L * R2L).ToString() == "409c526077e05d0e3f32ddd9871985df08c051baf66fa7fb6c9986995e8037de");
     BOOST_CHECK((R1L * ZeroL) == ZeroL);
     BOOST_CHECK((R1L * OneL) == R1L);
     BOOST_CHECK((R1L * MaxL) == -R1L);
     BOOST_CHECK((R2L * R1L) == (R1L * R2L));
-    BOOST_CHECK((R2L * R2L).ToString() == "ac8c010096767d3cae5005dec28bb2b45a1d85ab7996ccd3e102a650f74ff100");
+    BOOST_CHECK((R2L * R2L).ToString() == "00f14ff750a602e1d3cc9679ab851d5ab4b28bc2de0550ae3c7d769600018cac");
     BOOST_CHECK((R2L * ZeroL) == ZeroL);
     BOOST_CHECK((R2L * OneL) == R2L);
     BOOST_CHECK((R2L * MaxL) == -R2L);
@@ -346,8 +346,8 @@ BOOST_AUTO_TEST_CASE( multiply )
 
     BOOST_CHECK((R1L * 0) == 0);
     BOOST_CHECK((R1L * 1) == R1L);
-    BOOST_CHECK((R1L * 3).ToString() == "7759b1c0ed14047f961ad09b20ff83687876a0181a367b813634046f91def7d4");
-    BOOST_CHECK((R2L * 0x87654321UL).ToString() == "23f7816e30c4ae2017257b7a0fa64d60402f5234d46e746b61c960d09a26d070");
+    BOOST_CHECK((R1L * 3).ToString() == "d4f7de916f043436817b361a18a076786883ff209bd01a967f0414edc0b15977");
+    BOOST_CHECK((R2L * 0x87654321UL).ToString() == "70d0269ad060c9616b746ed434522f40604da60f7a7b251720aec4306e81f723");
 }
 
 BOOST_AUTO_TEST_CASE( divide )
@@ -481,7 +481,7 @@ BOOST_AUTO_TEST_CASE(bignum_SetCompact)
     BOOST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x01123456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000012");
+    BOOST_CHECK_EQUAL(num.GetHex(), "1200000000000000000000000000000000000000000000000000000000000000");
     BOOST_CHECK_EQUAL(num.GetCompact(), 0x01120000U);
     BOOST_CHECK_EQUAL(fNegative, false);
     BOOST_CHECK_EQUAL(fOverflow, false);
@@ -491,43 +491,43 @@ BOOST_AUTO_TEST_CASE(bignum_SetCompact)
     BOOST_CHECK_EQUAL(num.GetCompact(), 0x02008000U);
 
     num.SetCompact(0x01fedcba, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "000000000000000000000000000000000000000000000000000000000000007e");
+    BOOST_CHECK_EQUAL(num.GetHex(), "7e00000000000000000000000000000000000000000000000000000000000000");
     BOOST_CHECK_EQUAL(num.GetCompact(true), 0x01fe0000U);
     BOOST_CHECK_EQUAL(fNegative, true);
     BOOST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x02123456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000001234");
+    BOOST_CHECK_EQUAL(num.GetHex(), "3412000000000000000000000000000000000000000000000000000000000000");
     BOOST_CHECK_EQUAL(num.GetCompact(), 0x02123400U);
     BOOST_CHECK_EQUAL(fNegative, false);
     BOOST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x03123456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000123456");
+    BOOST_CHECK_EQUAL(num.GetHex(), "5634120000000000000000000000000000000000000000000000000000000000");
     BOOST_CHECK_EQUAL(num.GetCompact(), 0x03123456U);
     BOOST_CHECK_EQUAL(fNegative, false);
     BOOST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x04123456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000012345600");
+    BOOST_CHECK_EQUAL(num.GetHex(), "0056341200000000000000000000000000000000000000000000000000000000");
     BOOST_CHECK_EQUAL(num.GetCompact(), 0x04123456U);
     BOOST_CHECK_EQUAL(fNegative, false);
     BOOST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x04923456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000012345600");
+    BOOST_CHECK_EQUAL(num.GetHex(), "0056341200000000000000000000000000000000000000000000000000000000");
     BOOST_CHECK_EQUAL(num.GetCompact(true), 0x04923456U);
     BOOST_CHECK_EQUAL(fNegative, true);
     BOOST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x05009234, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000092340000");
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000349200000000000000000000000000000000000000000000000000000000");
     BOOST_CHECK_EQUAL(num.GetCompact(), 0x05009234U);
     BOOST_CHECK_EQUAL(fNegative, false);
     BOOST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x20123456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "1234560000000000000000000000000000000000000000000000000000000000");
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000563412");
     BOOST_CHECK_EQUAL(num.GetCompact(), 0x20123456U);
     BOOST_CHECK_EQUAL(fNegative, false);
     BOOST_CHECK_EQUAL(fOverflow, false);

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(bloom_match)
     CTransaction spendingTx(deserialize, spendStream);
 
     CBloomFilter filter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
-    filter.insert(uint256S("0xb4749f017444b051c44dfd2720e88f314ff94f3dd6d56d40ef65854fcd7fff6b"));
+    filter.insert(uint256S("0x6bff7fcd4f8565ef406dd5d63d4ff94f318fe82027fd4dc451b04474019f74b4"));
     BOOST_CHECK_MESSAGE(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match tx hash");
 
     filter = CBloomFilter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
@@ -148,11 +148,11 @@ BOOST_AUTO_TEST_CASE(bloom_match)
     BOOST_CHECK_MESSAGE(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match output address");
 
     filter = CBloomFilter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
-    filter.insert(COutPoint(uint256S("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0));
+    filter.insert(COutPoint(uint256S("0x0b26e9b7735eb6aabdf358bab62f9816a21ba9ebdb719d5299e88607d722c190"), 0));
     BOOST_CHECK_MESSAGE(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match COutPoint");
 
     filter = CBloomFilter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
-    COutPoint prevOutPoint(uint256S("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0);
+    COutPoint prevOutPoint(uint256S("0x0b26e9b7735eb6aabdf358bab62f9816a21ba9ebdb719d5299e88607d722c190"), 0);
     {
         std::vector<unsigned char> data(32 + sizeof(unsigned int));
         memcpy(data.data(), prevOutPoint.hash.begin(), 32);
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(bloom_match)
     BOOST_CHECK_MESSAGE(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match manually serialized COutPoint");
 
     filter = CBloomFilter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
-    filter.insert(uint256S("00000009e784f32f62ef849763d4f45b98e07ba658647343b915ff832b110436"));
+    filter.insert(uint256S("3604112b83ff15b943736458a67be0985bf4d4639784ef622ff384e709000000"));
     BOOST_CHECK_MESSAGE(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched random tx hash");
 
     filter = CBloomFilter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
@@ -170,11 +170,11 @@ BOOST_AUTO_TEST_CASE(bloom_match)
     BOOST_CHECK_MESSAGE(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched random address");
 
     filter = CBloomFilter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
-    filter.insert(COutPoint(uint256S("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 1));
+    filter.insert(COutPoint(uint256S("0x0b26e9b7735eb6aabdf358bab62f9816a21ba9ebdb719d5299e88607d722c190"), 1));
     BOOST_CHECK_MESSAGE(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched COutPoint for an output we didn't care about");
 
     filter = CBloomFilter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
-    filter.insert(COutPoint(uint256S("0x000000d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0));
+    filter.insert(COutPoint(uint256S("0x0b26e9b7735eb6aabdf358bab62f9816a21ba9ebdb719d5299e88607d7000000"), 0));
     BOOST_CHECK_MESSAGE(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched COutPoint for an output we didn't care about");
 
 }
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE(bloom_esperanza_finalization)
     auto regular_filter = CBloomFilter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
 
     // some coutpoint
-    regular_filter.insert(COutPoint(uint256S("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0));
+    regular_filter.insert(COutPoint(uint256S("0x0b26e9b7735eb6aabdf358bab62f9816a21ba9ebdb719d5299e88607d722c190"), 0));
 
     CMutableTransaction mtx;
 
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_1)
     CBlock block = getBlock13b8a();
     CBloomFilter filter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
     // Match the last transaction
-    filter.insert(uint256S("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
+    filter.insert(uint256S("0x201f4587ec86b58297edc2dd32d6fcd998aa794308aac802a8af3be0e081d674"));
 
     CMerkleBlock merkleBlock(block, filter);
     BOOST_CHECK_EQUAL(merkleBlock.header.GetHash().GetHex(), block.GetHash().GetHex());
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_1)
     BOOST_CHECK_EQUAL(merkleBlock.vMatchedTxn.size(), 1);
     std::pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x201f4587ec86b58297edc2dd32d6fcd998aa794308aac802a8af3be0e081d674"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 8);
 
     std::vector<uint256> vMatched;
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_1)
         BOOST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
 
     // Also match the 8th transaction
-    filter.insert(uint256S("0xdd1fd2a6fc16404faf339881a90adbde7f4f728691ac62e8f168809cdfae1053"));
+    filter.insert(uint256S("0x5310aedf9c8068f1e862ac9186724f7fdedb0aa9819833af4f4016fca6d21fdd"));
     merkleBlock = CMerkleBlock(block, filter);
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_1)
 
     BOOST_CHECK(merkleBlock.vMatchedTxn[1] == pair);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0xdd1fd2a6fc16404faf339881a90adbde7f4f728691ac62e8f168809cdfae1053"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x5310aedf9c8068f1e862ac9186724f7fdedb0aa9819833af4f4016fca6d21fdd"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 7);
 
     BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_with_esperanza)
     CBloomFilter filter(10, 0.000001, 0, BLOOM_UPDATE_ALL | MATCH_EPSPERANZA_FINALIZATION);
 
     // Match one of the transactions and esperanza finalization related transactions (3 deposits)
-    filter.insert(uint256S("0xaeb48f2b6d2b446a4301199c9b609d6cf64df6ba35d5c5c1bedb3fe92af6071c"));
+    filter.insert(uint256S("0x1c07f62ae93fdbbec1c5d535baf64df66c9d609b9c1901436a442b6d2b8fb4ae"));
 
 
     CMerkleBlock merkleBlock(block, filter);
@@ -316,17 +316,17 @@ BOOST_AUTO_TEST_CASE(merkle_block_with_esperanza)
     BOOST_CHECK_EQUAL(merkleBlock.vMatchedTxn.size(), 4);
 
     // check the filter matched the normal transaction
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0xaeb48f2b6d2b446a4301199c9b609d6cf64df6ba35d5c5c1bedb3fe92af6071c"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x1c07f62ae93fdbbec1c5d535baf64df66c9d609b9c1901436a442b6d2b8fb4ae"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 1);
 
     // check the filter matched deposits
-    BOOST_CHECK(merkleBlock.vMatchedTxn[1].second == uint256S("0xbfc5d747cf49ed28999d0ea8399d6c4181302060915e37217209b2111c6f1b17"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[1].second == uint256S("0x171b6f1c11b2097221375e9160203081416c9d39a80e9d9928ed49cf47d7c5bf"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[1].first == 2);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[2].second == uint256S("0xe4dbb6ee336c243b40114b8a5d7d47426d7330cf4632c2ddd6eeb4d45b767c4f"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[2].second == uint256S("0x4f7c765bd4b4eed6ddc23246cf30736d42477d5d8a4b11403b246c33eeb6dbe4"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[2].first == 3);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[3].second == uint256S("0x8f5f40ed3df3e9cfbd5156458381f8d044c25698210e879a3835cba5078ab780"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[3].second == uint256S("0x80b78a07a5cb35389a870e219856c244d0f88183455651bdcfe9f33ded405f8f"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[3].first == 4);
 
     std::vector<uint256> vMatched;
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_2)
 
     CBloomFilter filter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
     // Match the first transaction
-    filter.insert(uint256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
+    filter.insert(uint256S("0x703bb9ec7ab4f56d9e417a53ac19cef9c53513dc0352b9734e012d799ffe80e9"));
 
     CMerkleBlock merkleBlock(block, filter);
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
@@ -363,7 +363,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_2)
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
     std::pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x703bb9ec7ab4f56d9e417a53ac19cef9c53513dc0352b9734e012d799ffe80e9"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 0);
 
     std::vector<uint256> vMatched;
@@ -385,13 +385,13 @@ BOOST_AUTO_TEST_CASE(merkle_block_2)
 
     BOOST_CHECK(pair == merkleBlock.vMatchedTxn[0]);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[1].second == uint256S("0x28204cad1d7fc1d199e8ef4fa22f182de6258a3eaafe1bbe56ebdcacd3069a5f"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[1].second == uint256S("0x5f9a06d3acdceb56be1bfeaa3e8a25e62d182fa24fefe899d1c17f1dad4c2028"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[1].first == 1);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[2].second == uint256S("0x6b0f8a73a56c04b519f1883e8aafda643ba61a30bd1439969df21bea5f4e27e2"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[2].second == uint256S("0xe2274e5fea1bf29d963914bd301aa63b64daaf8a3e88f119b5046ca5738a0f6b"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[2].first == 2);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[3].second == uint256S("0x3c1d7e82342158e4109df2e0b6348b6e84e403d8b4046d7007663ace63cddb23"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[3].second == uint256S("0x23dbcd63ce3a6607706d04b4d803e4846e8b34b6e0f29d10e4582134827e1d3c"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[3].first == 3);
 
     BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_2_with_update_none)
 
     CBloomFilter filter(10, 0.000001, 0, BLOOM_UPDATE_NONE);
     // Match the first transaction
-    filter.insert(uint256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
+    filter.insert(uint256S("0x703bb9ec7ab4f56d9e417a53ac19cef9c53513dc0352b9734e012d799ffe80e9"));
 
     CMerkleBlock merkleBlock(block, filter);
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_2_with_update_none)
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
     std::pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x703bb9ec7ab4f56d9e417a53ac19cef9c53513dc0352b9734e012d799ffe80e9"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 0);
 
     std::vector<uint256> vMatched;
@@ -443,10 +443,10 @@ BOOST_AUTO_TEST_CASE(merkle_block_2_with_update_none)
 
     BOOST_CHECK(pair == merkleBlock.vMatchedTxn[0]);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[1].second == uint256S("0x28204cad1d7fc1d199e8ef4fa22f182de6258a3eaafe1bbe56ebdcacd3069a5f"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[1].second == uint256S("0x5f9a06d3acdceb56be1bfeaa3e8a25e62d182fa24fefe899d1c17f1dad4c2028"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[1].first == 1);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[2].second == uint256S("0x3c1d7e82342158e4109df2e0b6348b6e84e403d8b4046d7007663ace63cddb23"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[2].second == uint256S("0x23dbcd63ce3a6607706d04b4d803e4846e8b34b6e0f29d10e4582134827e1d3c"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[2].first == 3);
 
     BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
@@ -468,14 +468,14 @@ BOOST_AUTO_TEST_CASE(merkle_block_3_and_serialize)
 
     CBloomFilter filter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
     // Match the only transaction
-    filter.insert(uint256S("0x63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"));
+    filter.insert(uint256S("0xb50cc069d6a3e33e3ff84a5c41d9d3febe7c770fdcc96b2c3ff60abe184f1963"));
 
     CMerkleBlock merkleBlock(block, filter);
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0xb50cc069d6a3e33e3ff84a5c41d9d3febe7c770fdcc96b2c3ff60abe184f1963"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 0);
 
     std::vector<uint256> vMatched;
@@ -510,7 +510,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_4)
 
     CBloomFilter filter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
     // Match the last transaction
-    filter.insert(uint256S("0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154"));
+    filter.insert(uint256S("0x54c10adf159bf118b8b2e629141ac6b5c69addf4ddea130a7d72a4bdf0922a0a"));
 
     CMerkleBlock merkleBlock(block, filter);
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
@@ -518,7 +518,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_4)
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
     std::pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x54c10adf159bf118b8b2e629141ac6b5c69addf4ddea130a7d72a4bdf0922a0a"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 6);
 
     std::vector<uint256> vMatched;
@@ -529,13 +529,13 @@ BOOST_AUTO_TEST_CASE(merkle_block_4)
         BOOST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
 
     // Also match the 4th transaction
-    filter.insert(uint256S("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"));
+    filter.insert(uint256S("0x41c05bdf71643267ded2cf037af2105a036621fcf46858bc1d48f052a01f9802"));
     merkleBlock = CMerkleBlock(block, filter);
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 2);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x41c05bdf71643267ded2cf037af2105a036621fcf46858bc1d48f052a01f9802"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 3);
 
     BOOST_CHECK(merkleBlock.vMatchedTxn[1] == pair);
@@ -567,9 +567,9 @@ BOOST_AUTO_TEST_CASE(merkle_block_4_test_p2pubkey_only)
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
     // We should match the generation outpoint
-    BOOST_CHECK(filter.contains(COutPoint(uint256S("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
+    BOOST_CHECK(filter.contains(COutPoint(uint256S("0x0b3674c6e50f36f36f7a9f485e76c7868bf4d9f5984eaa0b5996657876aa7c14"), 0)));
     // ... but not the 4th transaction's output (its not pay-2-pubkey)
-    BOOST_CHECK(!filter.contains(COutPoint(uint256S("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0)));
+    BOOST_CHECK(!filter.contains(COutPoint(uint256S("0x41c05bdf71643267ded2cf037af2105a036621fcf46858bc1d48f052a01f9802"), 0)));
 }
 
 BOOST_AUTO_TEST_CASE(merkle_block_4_test_update_none)

--- a/src/test/merkleblock_tests.cpp
+++ b/src/test/merkleblock_tests.cpp
@@ -22,10 +22,10 @@ BOOST_AUTO_TEST_CASE(merkleblock_construct_from_txids_found)
     std::set<uint256> txids;
 
     // Last txn in block.
-    uint256 txhash1 = uint256S("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20");
+    uint256 txhash1 = uint256S("0x201f4587ec86b58297edc2dd32d6fcd998aa794308aac802a8af3be0e081d674");
 
     // Second txn in block.
-    uint256 txhash2 = uint256S("0xf9fc751cb7dc372406a9f8d738d5e6f8f63bab71986a39cf36ee70ee17036d07");
+    uint256 txhash2 = uint256S("0x076d0317ee70ee36cf396a9871ab3bf6f8e6d538d7f8a9062437dcb71c75fcf9");
 
     txids.insert(txhash1);
     txids.insert(txhash2);

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -26,7 +26,7 @@ extern UniValue read_json(const std::string& jsondata);
 // Old script.cpp SignatureHash function
 uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
-    static const uint256 one(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
+    static const uint256 one(uint256S("0100000000000000000000000000000000000000000000000000000000000000"));
     if (nIn >= txTo.vin.size())
     {
         return one;

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -20,7 +20,7 @@ BOOST_FIXTURE_TEST_SUITE(uint256_tests, ReducedTestingSetup)
 const unsigned char R1Array[] =
     "\x9c\x52\x4a\xdb\xcf\x56\x11\x12\x2b\x29\x12\x5e\x5d\x35\xd2\xd2"
     "\x22\x81\xaa\xb5\x33\xf0\x08\x32\xd5\x56\xb1\xf9\xea\xe5\x1d\x7d";
-const char R1ArrayHex[] = "7D1DE5EAF9B156D53208F033B5AA8122D2d2355d5e12292b121156cfdb4a529c";
+const char R1ArrayHex[] = "9c524adbcf5611122b29125e5d35d2D22281AAB533F00832D556B1F9EAE51D7D";
 const uint256 R1L = uint256(std::vector<unsigned char>(R1Array,R1Array+32));
 const uint160 R1S = uint160(std::vector<unsigned char>(R1Array,R1Array+20));
 
@@ -54,7 +54,7 @@ std::string ArrayToString(const unsigned char A[], unsigned int width)
     Stream << std::hex;
     for (unsigned int i = 0; i < width; ++i)
     {
-        Stream<<std::setw(2)<<std::setfill('0')<<(unsigned int)A[width-i-1];
+        Stream<<std::setw(2)<<std::setfill('0')<<(unsigned int)A[i];
     }
     return Stream.str();
 }

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -28,7 +28,7 @@ base_blob<BITS>::base_blob(const uint8_t *p, size_t l)
 template <unsigned int BITS>
 std::string base_blob<BITS>::GetHex() const
 {
-    return HexStr(std::reverse_iterator<const uint8_t*>(data + sizeof(data)), std::reverse_iterator<const uint8_t*>(data));
+    return HexStr(*this);
 }
 
 template <unsigned int BITS>
@@ -44,20 +44,9 @@ void base_blob<BITS>::SetHex(const char* psz)
     if (psz[0] == '0' && tolower(psz[1]) == 'x')
         psz += 2;
 
-    // hex string to uint
-    const char* pbegin = psz;
-    while (::HexDigit(*psz) != -1)
-        psz++;
-    psz--;
-    unsigned char* p1 = (unsigned char*)data;
-    unsigned char* pend = p1 + WIDTH;
-    while (psz >= pbegin && p1 < pend) {
-        *p1 = ::HexDigit(*psz--);
-        if (psz >= pbegin) {
-            *p1 |= ((unsigned char)::HexDigit(*psz--) << 4);
-            p1++;
-        }
-    }
+
+    std::vector<unsigned char> d = ParseHex(psz);
+    std::copy(d.begin(), d.end(), data);
 }
 
 template <unsigned int BITS>

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -188,7 +188,7 @@ class FullBlockTest(ComparisonTestFramework):
         return block
 
     def get_tests(self):
-        self.genesis_hash = int(self.nodes[0].getbestblockhash(), 16)
+        self.genesis_hash = uint256_from_str(hex_str_to_bytes(self.nodes[0].getbestblockhash()))
         self.block_heights[self.genesis_hash] = 0
         spendable_outputs = []
 


### PR DESCRIPTION
Since internally the protocol uses little endian
and most of the data are printed without reversing the order of bytes
it makes sense to also not to reverse it for uint256. This will
make debugging easier as you can dump bytes in any language
and simply grep logs using that string.

The change affects only slightly RPC and logs.
We also need to test how block explorer will behave.

I fixed ~half of unit tests (including `uint256_tests.cpp`) and `feature_block.py`
 just to give an idea what changes are needed.

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>