### PR TITLE
Fix floating feature_snapshot_creation.py test

### DIFF
--- a/test/functional/feature_snapshot_creation.py
+++ b/test/functional/feature_snapshot_creation.py
@@ -81,6 +81,8 @@ class SnapshotCreationTest(UnitETestFramework):
 
         node.generatetoaddress(10, node.getnewaddress())
         sync_blocks([node, validator])
+        self.stop_node(validator.index)
+
         wait_until(lambda: has_valid_snapshot_for_height(node, 38), timeout=10)
         assert_equal(len(node.listsnapshots()), 5)
         assert(has_valid_snapshot_for_height(node, 8) is False)


### PR DESCRIPTION
The issue was caused by a validator node which was not stopped
and sometimes was fast enough to produce a vote and trigger new finalization.

Stopping the validator node will make sure that finalization can't happen.

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>