### PR TITLE
Correct the include guard for staking/coin.h

### DIFF
--- a/src/staking/coin.h
+++ b/src/staking/coin.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_COIN_H
-#define UNIT_E_COIN_H
+#ifndef UNIT_E_STAKING_COIN_H
+#define UNIT_E_STAKING_COIN_H
 
 #include <amount.h>
 #include <blockchain/blockchain_types.h>
@@ -49,4 +49,4 @@ struct Coin {
 
 }  // namespace staking
 
-#endif  //UNIT_E_COIN_H
+#endif  //UNIT_E_STAKING_COIN_H


### PR DESCRIPTION
I feel like there is a tiny risk that the current include guard
will collide with the root coins.h file we have. Prefixing with STAKING_*
should avoid a possible collision.

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>