### PR TITLE
Remove cpp imports from test

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -264,6 +264,7 @@ public:
 
     std::string operator()(const CNoDestination& no) const { return {}; }
 };
+} //namespace
 
 CTxDestination DecodeDestination(const std::string& str, const blockchain::Behavior& params)
 {
@@ -322,7 +323,6 @@ CTxDestination DecodeDestination(const std::string& str, const blockchain::Behav
     }
     return CNoDestination();
 }
-} // namespace
 
 void CUnitESecret::SetKey(const CKey& vchSecret)
 {

--- a/src/base58.h
+++ b/src/base58.h
@@ -145,6 +145,7 @@ typedef CUnitEExtKeyBase<CExtPubKey, BIP32_EXTKEY_SIZE, blockchain::Base58Type::
 
 std::string EncodeDestination(const CTxDestination& dest);
 CTxDestination DecodeDestination(const std::string& str);
+CTxDestination DecodeDestination(const std::string& str, const blockchain::Behavior& params);
 bool IsValidDestinationString(const std::string& str);
 bool IsValidDestinationString(const std::string& str, const blockchain::Behavior&);
 

--- a/src/test/esperanza/walletextension_tests.cpp
+++ b/src/test/esperanza/walletextension_tests.cpp
@@ -5,6 +5,7 @@
 #include <amount.h>
 #include <base58.h>
 #include <blockchain/blockchain_behavior.h>
+#include <chainparams.h>
 #include <consensus/validation.h>
 #include <esperanza/finalizationparams.h>
 #include <esperanza/vote.h>
@@ -17,9 +18,7 @@
 #include <test/test_unite.h>
 #include <txmempool.h>
 #include <validation.h>
-#include <base58.cpp>
 #include <boost/test/unit_test.hpp>
-#include <chainparams.cpp>
 
 BOOST_AUTO_TEST_SUITE(walletextension_tests)
 


### PR DESCRIPTION
As title says, this PR removes a couple of cpp imports and uses the equivalent .h .