### PR TITLE
Add brainstorming label

### DIFF
--- a/.github/labels/dtr-org-unit-e-labels.svg
+++ b/.github/labels/dtr-org-unit-e-labels.svg
@@ -33,15 +33,21 @@
       has adr
     </text>
   </g>
-  <rect x="650" y="90" width="130" height="40" fill="#f7ca96" rx="5"/>
+  <rect x="650" y="90" width="130" height="40" fill="#cccccc" rx="5"/>
   <g font-size="14" font-family="arial" fill="black">
     <text x="663" y="116">
+      brainstorming
+    </text>
+  </g>
+  <rect x="200" y="150" width="130" height="40" fill="#f7ca96" rx="5"/>
+  <g font-size="14" font-family="arial" fill="black">
+    <text x="213" y="176">
       backport
     </text>
   </g>
-  <rect x="200" y="150" width="130" height="40" fill="#f7931a" rx="5"/>
+  <rect x="350" y="150" width="130" height="40" fill="#f7931a" rx="5"/>
   <g font-size="14" font-family="arial" fill="white">
-    <text x="213" y="176">
+    <text x="363" y="176">
       backported
     </text>
   </g>

--- a/.github/labels/dtr-org-unit-e-labels.yaml
+++ b/.github/labels/dtr-org-unit-e-labels.yaml
@@ -15,6 +15,10 @@ categories:
     color: 'aaaaaa'
     description: ''
     id: 1134741914
+  - name: brainstorming
+    color: 'cccccc'
+    description: Needs input, ideas are welcome
+    id: brainstorming
   - name: backport
     color: f7ca96
     description: Feature should be contributed to bitcoin


### PR DESCRIPTION
Add a new label `brainstorming` for everything which needs input, ideas,
or asks a question. This label can act as an initial state for an issue
which needs some discussion before it can be defined more accurately.
