### PR TITLE
LOCK SnapshotIndex during serialization

### DIFF
--- a/src/snapshot/snapshot_index.h
+++ b/src/snapshot/snapshot_index.h
@@ -78,6 +78,8 @@ class SnapshotIndex {
 
   template <typename Stream, typename Operation>
   inline void SerializationOp(Stream &s, Operation ser_action) {
+    LOCK(m_cs);
+
     READWRITE(m_index_map);
     READWRITE(m_snapshots_for_removal);
   }


### PR DESCRIPTION
Adding snapshot hash or removing it from the `SnapshotIndex` is thread-safe
as the `LOCK(m_cs)` is used. However, serialization is not locked
which means the potential data-race can occur on the `std::map` or `std::set`.

There is no problem right now as serialization is happening only in one thread
currently (in unite-snapshot) but as this data structure supposed to be thread-safe,
serialization shouldn't violate this rule.

Found this potential flaw while debugging the following issue https://github.com/dtr-org/unit-e/issues/382#issuecomment-457204515
 but it turned out it wasn't related. 

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>