### PR TITLE
Fix access to already deleted finalization state

### DIFF
--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -404,13 +404,12 @@ bool WalletExtension::SendWithdraw(const CTxDestination &address,
 }
 
 void WalletExtension::VoteIfNeeded(const std::shared_ptr<const CBlock> &pblock,
-                                   const CBlockIndex &blockIndex, const FinalizationState *state) {
+                                   const CBlockIndex &blockIndex, const FinalizationState &state) {
 
-  assert(state);
   assert(validatorState);
   ValidatorState &validator = validatorState.get();
 
-  const uint32_t dynasty = state->GetCurrentDynasty();
+  const uint32_t dynasty = state.GetCurrentDynasty();
 
   if (dynasty >= validator.m_endDynasty) {
     return;
@@ -420,7 +419,7 @@ void WalletExtension::VoteIfNeeded(const std::shared_ptr<const CBlock> &pblock,
     return;
   }
 
-  const uint32_t epoch = state->GetEpoch(blockIndex);
+  const uint32_t epoch = state.GetEpoch(blockIndex);
 
   // Avoid double votes
   if (validator.m_voteMap.find(epoch) != validator.m_voteMap.end()) {
@@ -434,7 +433,7 @@ void WalletExtension::VoteIfNeeded(const std::shared_ptr<const CBlock> &pblock,
            "%s: Validator voting for epoch %d and dynasty %d.\n", __func__,
            epoch, dynasty);
 
-  Vote vote = state->GetRecommendedVote(validator.m_validatorAddress);
+  Vote vote = state.GetRecommendedVote(validator.m_validatorAddress);
 
   // Check for sorrounding votes
   if (vote.m_targetEpoch < validator.m_lastTargetEpoch ||
@@ -633,7 +632,7 @@ void WalletExtension::BlockConnected(
         if (currentDynasty >= validatorState.get().m_endDynasty) {
           validatorState.get().m_phase = ValidatorState::Phase::NOT_VALIDATING;
         } else {
-          VoteIfNeeded(pblock, index, state);
+          VoteIfNeeded(pblock, index, *state);
         }
 
         break;

--- a/src/esperanza/walletextension.h
+++ b/src/esperanza/walletextension.h
@@ -58,7 +58,7 @@ class WalletExtension : public staking::StakingWallet {
   std::vector<std::pair<finalization::VoteRecord, finalization::VoteRecord>> pendingSlashings;
 
   void VoteIfNeeded(const std::shared_ptr<const CBlock> &pblock,
-                    const CBlockIndex &index, const FinalizationState *state);
+                    const CBlockIndex &index, const FinalizationState &state);
 
   void ManagePendingSlashings();
 


### PR DESCRIPTION
This PR tackles a bug emerged sporadically in functional tests. The symptom was the node suddenly crushing while validating an incoming block. 

After some investigation by @kostyantyn we found out that during some functional tests where the epoch size is set to 5 and many blocks are generated through rpc without any wait in between, it might happen that by the time that the `GetMainSignal().BlockConnected()` gets processed by the signals thread,  the FinalizationState regarding that block has been already cleared (because old and outdated), so that when the node tries to vote on it, it crashes. 

The expected behavior is that when a node is about to vote on a block that he's received, it should be checked if the block is still relevant (in the same epoch) in regards of our current tip. 

In case it is not, is not worth voting, cause any vote casted would be already outdated and not accepted even by the same node's mempool.

Fixes https://github.com/dtr-org/unit-e/issues/382.