### PR TITLE
Re-enable out-of-order and repeated processing in validation unit tests

### DIFF
--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -213,14 +213,14 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
             for (int i = 0; i < 1000; i++) {
                 auto block = blocks[GetRand(blocks.size() - 1)];
                 bool processed = ProcessNewBlock(Params(), block, true, &ignored);
-                assert(processed);
+                BOOST_CHECK(processed);
             }
 
             // to make sure that eventually we process the full chain - do it here
             for (auto block : blocks) {
                 if (block->vtx.size() == 1) {
                     bool processed = ProcessNewBlock(Params(), block, true, &ignored);
-                    assert(processed);
+                    BOOST_CHECK(processed);
                 }
             }
         });


### PR DESCRIPTION
Fix #491: Re-enable ouf-or-order and repeated processing in validation unit tests.

#65 removed parallelism from a test in `validation_block_tests`.

Apparently it was just committed by accident and maybe commented for easier debugging.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
