### PR TITLE
Sign the coinbase with a wallet key

### DIFF
--- a/src/blockchain/blockchain_behavior.h
+++ b/src/blockchain/blockchain_behavior.h
@@ -64,6 +64,7 @@ class Behavior {
 
   bool IsGenesisBlockHash(const uint256 &) const;
 
+  //! \brief extracts the pubkey stored in the staking transaction's witness program.
   boost::optional<CPubKey> ExtractBlockSigningKey(const CBlock &) const;
 
   //! \brief The name of this network as a standard string.

--- a/src/proposer/block_builder.cpp
+++ b/src/proposer/block_builder.cpp
@@ -62,6 +62,7 @@ class BlockBuilderImpl : public BlockBuilder {
         m_settings(settings) {}
 
   const CTransactionRef BuildCoinbaseTransaction(
+      const CPubKey &signing_key,
       const uint256 &snapshot_hash,
       const EligibleCoin &eligible_coin,
       const std::vector<staking::Coin> &coins,
@@ -104,8 +105,7 @@ class BlockBuilderImpl : public BlockBuilder {
     }
 
     // destination to send stake + reward to
-    const CPubKey pub_key;
-    const CTxDestination destination = WitnessV0KeyHash(pub_key.GetID());
+    const CTxDestination destination = WitnessV0KeyHash(signing_key.GetID());
     const CScript script_pub_key = GetScriptForDestination(destination);
 
     // add outputs
@@ -133,6 +133,7 @@ class BlockBuilderImpl : public BlockBuilder {
   }
 
   std::shared_ptr<const CBlock> BuildBlock(
+      const CPubKey &signing_key,
       const CBlockIndex &prev_block,
       const uint256 &snapshot_hash,
       const EligibleCoin &coin,
@@ -151,7 +152,7 @@ class BlockBuilderImpl : public BlockBuilder {
 
     // add coinbase transaction first
     const CTransactionRef coinbase_transaction =
-        BuildCoinbaseTransaction(snapshot_hash, coin, coins, fees, wallet);
+        BuildCoinbaseTransaction(signing_key, snapshot_hash, coin, coins, fees, wallet);
     if (!coinbase_transaction) {
       Log("Failed to create coinbase transaction.");
       return nullptr;

--- a/src/proposer/block_builder.h
+++ b/src/proposer/block_builder.h
@@ -24,6 +24,7 @@ class BlockBuilder {
  public:
   //! \brief Builds a coinbase transaction.
   virtual const CTransactionRef BuildCoinbaseTransaction(
+      const CPubKey &signing_key,               //!< The key used to sign the coinbase.
       const uint256 &snapshot_hash,             //!< The snapshot hash to be included.
       const EligibleCoin &eligible_coin,        //!< The eligible coin to reference as stake. Also contains the target height.
       const std::vector<staking::Coin> &coins,  //!< Any other coins that should be combined into the coinbase tx.
@@ -33,13 +34,14 @@ class BlockBuilder {
 
   //! \brief Builds a brand new block.
   virtual std::shared_ptr<const CBlock> BuildBlock(
-      const CBlockIndex &,                   //!< The previous block / current tip
-      const uint256 &,                       //!< The snapshot hash to be included in the new block
-      const EligibleCoin &,                  //!< The coin to use as stake
-      const std::vector<staking::Coin> &,    //!< Other coins to combine with the stake
-      const std::vector<CTransactionRef> &,  //!< Transactions to include in the block
-      CAmount,                               //!< The fees on the transactions
-      staking::StakingWallet &               //!< A wallet used to sign blocks and stake
+      const CPubKey &signing_key,               //!< The key to use for signing the block.
+      const CBlockIndex &index,                 //!< The previous block / current tip.
+      const uint256 &snapshot_hash,             //!< The snapshot hash to be included in the new block.
+      const EligibleCoin &stake_coin,           //!< The coin to use as stake.
+      const std::vector<staking::Coin> &coins,  //!< Other coins to combine with the stake.
+      const std::vector<CTransactionRef> &txs,  //!< Transactions to include in the block.
+      CAmount,                                  //!< The fees on the transactions.
+      staking::StakingWallet &                  //!< A wallet used to sign blocks and stake.
       ) const = 0;
 
   virtual ~BlockBuilder() = default;

--- a/src/proposer/proposer.cpp
+++ b/src/proposer/proposer.cpp
@@ -113,8 +113,15 @@ class ProposerImpl : public Proposer {
           const CAmount fees = std::accumulate(result.fees.begin(), result.fees.end(), CAmount(0));
           const uint256 snapshot_hash = m_active_chain->ComputeSnapshotHash();
 
+          // Generate an internal key to sign the block and to which send the reward.
+          CPubKey signing_key;
+          if (!wallet->GetKeyFromPool(signing_key, true)) {
+            LogPrint(BCLog::PROPOSING, "Wallet is locked, cannot generate key for proposing.\n");
+            continue;
+          }
+
           block = m_block_builder->BuildBlock(
-              tip, snapshot_hash, coin, coins, result.transactions, fees, wallet_ext);
+              signing_key, tip, snapshot_hash, coin, coins, result.transactions, fees, wallet_ext);
         }
         if (m_interrupted) {
           break;

--- a/src/test/esperanza/walletextension_tests.cpp
+++ b/src/test/esperanza/walletextension_tests.cpp
@@ -147,7 +147,7 @@ BOOST_FIXTURE_TEST_CASE(sign_coinbase_transaction, WalletTestingSetup) {
 
   // BuildCoinbaseTransaction() will also sign it
   CTransactionRef coinbase_transaction =
-      block_builder->BuildCoinbaseTransaction(uint256(), eligible_coin, coins, 700, pwalletMain->GetWalletExtension());
+      block_builder->BuildCoinbaseTransaction(pubkey, uint256(), eligible_coin, coins, 700, pwalletMain->GetWalletExtension());
 
   // check that a coinbase transaction was built successfully
   BOOST_REQUIRE(static_cast<bool>(coinbase_transaction));
@@ -168,6 +168,11 @@ BOOST_FIXTURE_TEST_CASE(sign_coinbase_transaction, WalletTestingSetup) {
     BOOST_CHECK_EQUAL(stack.size(), 2);  // signature + public key
     auto &witness_pubkey = stack[1];
     BOOST_CHECK(witness_pubkey == pubkeydata);
+  }
+
+  // We should be able to spend all the outputs
+  for (auto out : coinbase_transaction->vout) {
+    BOOST_CHECK(::IsMine(*pwalletMain, out.scriptPubKey) == ISMINE_SPENDABLE);
   }
 }
 

--- a/src/test/proposer/block_builder_tests.cpp
+++ b/src/test/proposer/block_builder_tests.cpp
@@ -141,10 +141,18 @@ BOOST_AUTO_TEST_CASE(build_block_and_validate) {
   };
 
   auto block = builder->BuildBlock(
-      current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, f.wallet);
+      f.pubkey, current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, f.wallet);
   BOOST_REQUIRE(static_cast<bool>(block));
   auto is_valid = validator->CheckBlock(*block);
   BOOST_CHECK(is_valid);
+
+  auto stake_in = block->vtx[0]->vin[1];
+  BOOST_CHECK(stake_in.scriptWitness.stack[1] == f.pubkeydata);
+
+  std::vector<uint8_t> signature;
+  f.key.Sign(block->GetHash(), signature);
+
+  BOOST_CHECK(signature == block->signature);
 }
 
 BOOST_AUTO_TEST_CASE(split_amount) {
@@ -179,7 +187,7 @@ BOOST_AUTO_TEST_CASE(split_amount) {
     };
 
     auto block = builder->BuildBlock(
-        current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, f.wallet);
+        f.pubkey, current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, f.wallet);
     BOOST_REQUIRE(static_cast<bool>(block));
     auto is_valid = validator->CheckBlock(*block);
     // must have a coinbase transaction

--- a/src/test/proposer/proposer_tests.cpp
+++ b/src/test/proposer/proposer_tests.cpp
@@ -99,12 +99,14 @@ struct Fixture {
 
   class BlockBuilderMock : public proposer::BlockBuilder {
     const CTransactionRef BuildCoinbaseTransaction(
+        const CPubKey &,
         const uint256 &,
         const proposer::EligibleCoin &,
         const std::vector<staking::Coin> &,
         CAmount,
         staking::StakingWallet &) const override { return nullptr; };
     std::shared_ptr<const CBlock> BuildBlock(
+        const CPubKey &,
         const CBlockIndex &,
         const uint256 &,
         const proposer::EligibleCoin &,


### PR DESCRIPTION
This PR implements signing the coinbase transaction with a key reserved from the wallet that is proposing the block.