### PR TITLE
Fix data parsing in mininode.py

### DIFF
--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -118,7 +118,6 @@ class P2PConnection(asyncore.dispatcher):
         """asyncore callback when a connection is closed."""
         logger.debug("Closing connection to: %s:%d" % (self.dstaddr, self.dstport))
         self.state = "closed"
-        self.recvbuf = b""
         self.sendbuf = b""
         try:
             self.close()


### PR DESCRIPTION
`handle_close` function is called concurrently with `handle_read` 
and the issue is that it resets the `recvbuf` which `handle_read` 
uses to parse the content. When server closed the socket but there are still
data available for reading, `handle_read` will be triggered which consumes the available bytes
but since the previous ones that are stored in `recvbuf` are reset, it causes the following crash:

```
ValueError: got garbage b'\x05block\x10Umandatory-script-verify-flag-failed (Operation not valid with the current stack size)\xe9\x174\x91awF"-\x1e\xbd\xb7d\xcc\x99\x9b\xb2\xaa\xea\xf9\xd8S\x03\xc2\xf6\xe2\r\xb5\x7f\x17\xb7d'
```

This PR resolves https://github.com/dtr-org/unit-e/issues/357 issue
and possibly other functional tests where it's expected that c++ node will disconnect mininode.

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>