### PR TITLE
Fix issue #497 (flaky feature_ltor.py test)

### DIFF
--- a/test/functional/feature_ltor.py
+++ b/test/functional/feature_ltor.py
@@ -58,13 +58,11 @@ class LTORTest(UnitETestFramework):
         self.tip = None
         self.block_time = None
 
-        # This mininode will help us to create blocks
-        mininode = self.nodes[0].add_p2p_connection(P2PInterface())
-        self.nodes[1].add_p2p_connection(mininode)
-
         test = TestManager(self, self.options.tmpdir)
         test.add_all_connections(self.nodes)
 
+        # This mininode will help us to create blocks
+        mininode = self.nodes[0].add_p2p_connection(P2PInterface())
         network_thread_start()
         mininode.wait_for_verack()
         test.run()


### PR DESCRIPTION
This PR fixes issue #497 . There was a previous PR ( #498 ), but it turns out that it didn't completely fix the problem.

As this build ( https://travis-ci.com/dtr-org/unit-e/builds/99435444 ) shows, the changes in this PR seem to have fixed the problem: 100 executions for the `feature_ltor.py` test file in the Travis CI environment.

This PR basically does:
  * Avoids relying on `comptool.TestManager.sync_blocks`, which is problematic because it checks whether the nodes are synced by waiting for block requests. This mechanism is problematic because the nodes can decide to obtain the blocks from other nodes rather than relying on `TestManager`'s mininode, and this is what usually happens. Having full control on the block creation process and relying on `util.sync_blocks` solves the problem.

There are some *cosmetic* changes too:
  * Fixes the block height parameter that we use to create blocks. This does not seem to have a real effect in the tests, but is changed for correctness.
  * Decreases the number of transactions that we ask the nodes to be created, this is just to decrease testing time, as we don't need many transactions to check the nodes' behaviour.
  * Decreases the number of 0-conf chained transactions in a same block to be further from the limit where the nodes reject some 0-conf transactions, which can lead to tests flakiness. This change also slightly decreases test times.

Signed-off-by: Andres Correa Casablanca <andres@thirdhash.com>