### PR TITLE
Enable BIP34 by default.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -245,8 +245,6 @@ public:
         strNetworkID = "main";
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.BIP16Height = 173805; // 00000000000000ce80a7e057163a4db1d5ad7b20fb6f598c9597b9665c8fb0d4 - April 1, 2012
-        consensus.BIP34Height = 227931;
-        consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -351,8 +349,6 @@ public:
         strNetworkID = "test";
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.BIP16Height = 514; // 00000000040b4e986385315e14bee30ad876d8b47f748025b26683116d21aa65
-        consensus.BIP34Height = 21111;
-        consensus.BIP34Hash = uint256S("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
         consensus.BIP65Height = 581885; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -438,8 +434,6 @@ public:
         strNetworkID = "regtest";
         consensus.nSubsidyHalvingInterval = 150;
         consensus.BIP16Height = 0; // always enforce P2SH BIP16 on regtest
-        consensus.BIP34Height = 100000000; // BIP34 has not activated on regtest (far in the future so block v1 are not rejected in tests)
-        consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -51,9 +51,6 @@ struct Params {
     int nSubsidyHalvingInterval;
     /** Block height at which BIP16 becomes active */
     int BIP16Height;
-    /** Block height and hash at which BIP34 becomes active */
-    int BIP34Height;
-    uint256 BIP34Hash;
     /** Block height at which BIP65 becomes active */
     int BIP65Height;
     /**

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3356,8 +3356,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
 
     // Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
     // check for version 2, 3 and 4 upgrades
-    if ((block.nVersion < 2 && nHeight >= consensusParams.BIP34Height) ||
-        (block.nVersion < 4 && nHeight >= consensusParams.BIP65Height))
+    if (block.nVersion < 4 && nHeight >= consensusParams.BIP65Height)
             return state.Invalid(false, REJECT_OBSOLETE, strprintf("bad-version(0x%08x)", block.nVersion),
                                  strprintf("rejected nVersion=0x%08x block", block.nVersion));
 
@@ -3383,22 +3382,6 @@ static bool ContextualCheckBlock(const CBlock& block, CValidationState& state, c
     int64_t nLockTimeCutoff = (nLockTimeFlags & LOCKTIME_MEDIAN_TIME_PAST)
                               ? pindexPrev->GetMedianTimePast()
                               : block.GetBlockTime();
-
-
-    // Enforce rule that the coinbase starts with serialized block height
-    if (nHeight >= consensusParams.BIP34Height) {
-
-        CScript expect = CScript() << CScriptNum::serialize(nHeight);
-        if (block.vtx[0]->vin[0].scriptSig.size() < expect.size() ||
-              !std::equal(expect.begin(),expect.end(),block.vtx[0]->vin[0].scriptSig.begin())) {
-            return state.DoS(100,
-                           false,
-                           REJECT_INVALID,
-                           "bad-cb-height",
-                           false,
-                           "block height mismatch in coinbase");
-        }
-    }
 
     CTransactionRef prevTx;
 


### PR DESCRIPTION
This removes the BIP34 soft fork. Please note that the validation check is completely removed. This is because we are switching to the already completed block validation logic of the `BlockValidator`, which does check that the height is included in the _meta input_ of a coinbase transaction. There are tests that check that the `BlockBuilder` builds a correct coinbase transaction and the `BlockValidator` validates it accordingly.

Long story short: We have our own version of BIP34, which also includes the snapshot hash for fast sync; and that code lives in the new staking components. This pull request removes it from chainparams which should bring us closer to replacing `CChainParams` with `blockchain_parameters` in order to completely activate PoS.

This is in the same spirit as #503. Fixes #500.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>