### PR TITLE
Shutdown the node in case of invalid -rewardaddress

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -6,6 +6,7 @@
 
 #include <base58.h>
 #include <dependency.h>
+#include <init.h>
 
 std::unique_ptr<Settings> Settings::New(Dependency<::ArgsManager> args) {
   std::unique_ptr<Settings> settings = MakeUnique<Settings>();
@@ -30,6 +31,7 @@ std::unique_ptr<Settings> Settings::New(Dependency<::ArgsManager> args) {
     } else {
       settings->reward_destination = boost::none;
       LogPrintf("%s: -rewardaddress: Invalid address provided %s\n", __func__, reward_address);
+      StartShutdown();
     }
   }
 


### PR DESCRIPTION
It resolves this comment: https://github.com/dtr-org/unit-e/pull/513#discussion_r252632392

```
➜  unit-e git:(fail_in_case_of_invalid_rewardaddress) ✗ ./src/united -testnet -printtoconsole  -rewardaddress=123
2019-02-01 15:32:46 [            ]

           )  (
        ( /(  )\ )  *   )
    (   )\())(()/(` )  /(   (
    )\ ((_)\  /(_))( )(_))  )\
 _ ((_) _((_)(_)) (_(_())  ((_)
| | | || \| ||_ _||_   _|  | __|
| |_| || .` | | |   | |    | _|
 (___/ |_|\_||___|  |_| (  |_(_|               )  (              (     (            )
 )\ )                   )\ ) )\ )    (      ( /(  )\ )      (    )\ )  )\ )      ( /(   *   )
(()/(  (       (   (   (()/((()/(    )\     )\())(()/(      )\  (()/( (()/( (    )\())` )  /(
 /(_)) )\      )\  )\   /(_))/(_))((((_)(  ((_)\  /(_))   (((_)  /(_)) /(_)))\  ((_)\  ( )(_))
(_))_|((_)  _ ((_)((_) (_)) (_))   )\ _ )\  _((_)(_))_    )\___ (_))  (_)) ((_)  _((_)(_(_())
| |_  | __|| | | || __|| _ \| |    (_)_\(_)| \| | |   \  ((/ __|| |   |_ _|| __|| \| ||_   _|
| __| | _| | |_| || _| |   /| |__   / _ \  | .` | | |) |  | (__ | |__  | | | _| | .` |  | |
|_|   |___| \___/ |___||_|_\|____| /_/ \_\ |_|\_| |___/    \___||____||___||___||_|\_|  |_|
2019-02-01 15:32:46 [            ] UnitE Core version v0.16.3.0-456a7508e-dirty (debug build)
2019-02-01 15:32:46 [            ] InitParameterInteraction: parameter interaction: -whitelistforcerelay=1 -> setting -whitelistrelay=1
2019-02-01 15:32:46 [            ] Assuming ancestors of block 0000000002e9e7b00e1f6dc5123a04aad68dd0f0968d8c7aa45f6640795c37b1 have valid signatures.
2019-02-01 15:32:46 [            ] Setting nMinimumChainWork=00000000000000000000000000000000000000000000002830dab7f76dbb7d63
2019-02-01 15:32:46 [            ] Using the 'sse4' SHA256 implementation
2019-02-01 15:32:46 [            ] Using RdRand as an additional entropy source
2019-02-01 15:32:46 [            ] New: -rewardaddress: Invalid address provided 123
2019-02-01 15:32:46 [            ] Default data directory /Users/kostiantyn/Library/Application Support/UnitE
2019-02-01 15:32:46 [            ] Using data directory /Users/kostiantyn/Library/Application Support/UnitE/testnet3
2019-02-01 15:32:46 [            ] Using config file /Users/kostiantyn/Library/Application Support/UnitE/unite.conf
2019-02-01 15:32:46 [            ] Using at most 125 automatic connections (7168 file descriptors available)
2019-02-01 15:32:46 [            ] Using 16 MiB out of 32/2 requested for signature cache, able to store 524288 elements
2019-02-01 15:32:46 [            ] Using 16 MiB out of 32/2 requested for script execution cache, able to store 524288 elements
2019-02-01 15:32:46 [            ] Using 4 threads for script verification
2019-02-01 15:32:46 [            ] scheduler thread start
2019-02-01 15:32:46 [            ] HTTP: creating work queue of depth 16
2019-02-01 15:32:46 [            ] No rpcpassword set - using random cookie authentication
2019-02-01 15:32:46 [            ] Generated RPC authentication cookie /Users/kostiantyn/Library/Application Support/UnitE/testnet3/.cookie
2019-02-01 15:32:46 [            ] HTTP: starting 4 worker threads
2019-02-01 15:32:46 [            ] Using wallet directory /Users/kostiantyn/Library/Application Support/UnitE/testnet3
2019-02-01 15:32:46 [            ] init message: Verifying wallet(s)...
2019-02-01 15:32:46 [            ] Using BerkeleyDB version Berkeley DB 4.8.30: (April  9, 2010)
2019-02-01 15:32:46 [            ] Using wallet wallet.dat
2019-02-01 15:32:46 [            ] CDBEnv::Open: LogDir=/Users/kostiantyn/Library/Application Support/UnitE/testnet3/database ErrorFile=/Users/kostiantyn/Library/Application Support/UnitE/testnet3/db.log
2019-02-01 15:32:46 [            ] Cache configuration:
2019-02-01 15:32:46 [            ] * Using 2.0MiB for block index database
2019-02-01 15:32:46 [            ] * Using 8.0MiB for chain state database
2019-02-01 15:32:46 [            ] * Using 440.0MiB for in-memory UTXO set (plus up to 286.1MiB of unused mempool space)
2019-02-01 15:32:46 [            ] Shutdown requested. Exiting.
2019-02-01 15:32:46 [            ] Shutdown: In progress...
2019-02-01 15:32:46 [            ] scheduler thread interrupt
2019-02-01 15:32:46 [            ] Shutdown: done
```

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>