### PR TITLE
Unify UIP names in code and comments

### DIFF
--- a/src/finalization/p2p.h
+++ b/src/finalization/p2p.h
@@ -8,7 +8,7 @@
 #include <serialize.h>
 
 /*
- * Implementation of UIP-21.
+ * Implementation of UIP21.
  */
 
 class CNode;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -304,7 +304,7 @@ enum ServiceFlags : uint64_t {
 
     // NODE_SNAPSHOT means that node generates periodically snapshots
     // and is capable of responding to the getsnapshot protocol request.
-    // See UIP-11 for details
+    // See UIP11 for details
     NODE_SNAPSHOT = (1 << 15),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that


### PR DESCRIPTION
The reason for using the format UIP<number> everywhere is that
by a single pattern, you can find all the related information about the UIP.

If we search "BIP", it's the same format in the code and comments.

This commit is like an ADR, once it's accepted, we should pay attention
to comments as we will soon have more references to UIPs in the code.

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>