### PR TITLE
Make UnitEInjector globally accessible

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -291,6 +291,7 @@ libunite_server_a_SOURCES = \
   httprpc.cpp \
   httpserver.cpp \
   init.cpp \
+  injector.cpp \
   dbwrapper.cpp \
   merkleblock.cpp \
   miner.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -207,7 +207,7 @@ void Shutdown()
     StopHTTPServer();
 
     // stop all injected components, including proposer and validator
-    injector.reset();
+    UnitEInjector::Destroy();
 
 #ifdef ENABLE_WALLET
     FlushWallets();
@@ -1293,8 +1293,7 @@ bool AppInitLockDataDirectory()
 
 bool AppInitMain()
 {
-    injector = MakeUnique<UnitEInjector>();
-    injector->Initialize();
+    UnitEInjector::Init();
 
     const CChainParams& chainparams = Params();
 
@@ -1730,7 +1729,7 @@ bool AppInitMain()
 
     // ********************************************************* Step 8: load wallet
 #ifdef ENABLE_WALLET
-    esperanza::WalletExtensionDeps deps(*injector);
+    esperanza::WalletExtensionDeps deps(GetInjector());
     if (!OpenWallets(deps)) {
         return false;
     }
@@ -1897,8 +1896,8 @@ bool AppInitMain()
     // ********************************************************* Step 13: start proposer
 
 #ifdef ENABLE_WALLET
-    injector->GetProposer()->Start();
-    SetProposerRPC(injector->GetProposerRPC());
+    GetComponent(Proposer)->Start();
+    SetProposerRPC(GetComponent(ProposerRPC));
 #endif
 
     LogPrintf("Started up.\n");

--- a/src/injector.cpp
+++ b/src/injector.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <injector.h>
+
+namespace {
+std::unique_ptr<UnitEInjector> injector = nullptr;
+}
+
+void UnitEInjector::Init() {
+  assert(!injector);
+  injector = MakeUnique<UnitEInjector>();
+  injector->Initialize();
+}
+
+void UnitEInjector::Destroy() {
+  assert(injector);
+  injector.reset();
+}
+
+UnitEInjector &GetInjector() {
+  assert(injector);
+  return *injector;
+}

--- a/src/injector.h
+++ b/src/injector.h
@@ -81,6 +81,25 @@ class UnitEInjector : public Injector<UnitEInjector> {
             proposer::Logic)
 
 #endif
+
+  //! \brief Initializes a globally available instance of the injector.
+  static void Init();
+
+  //! \brief Destructs the injector and all components managed by it.
+  static void Destroy();
 };
+
+//! \brief Retrieves the globally available instance of the injector.
+//!
+//! This mechanism solely exists such that old bitcoin code which is not
+//! part of the component framework can access components. It must never
+//! be invoked from within any function that lives in a component.
+//!
+//! It is actually an instance of the Service Locator pattern, which is
+//! considered an anti-pattern (by the author of this comment), but a
+//! necessary evil to interface legacy code with the component based design.
+UnitEInjector &GetInjector();
+
+#define GetComponent(NAME) (GetInjector().Get##NAME())
 
 #endif  // UNIT_E_INJECTOR_H

--- a/src/test/test_unite.cpp
+++ b/src/test/test_unite.cpp
@@ -10,6 +10,7 @@
 #include <crypto/sha256.h>
 #include <esperanza/finalizationstate.h>
 #include <finalization/vote_recorder.h>
+#include <injector.h>
 #include <validation.h>
 #include <miner.h>
 #include <net_processing.h>
@@ -78,22 +79,11 @@ ReducedTestingSetup::~ReducedTestingSetup()
   snapshot::DestroySecp256k1Context();
 }
 
-BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
+BasicTestingSetup::BasicTestingSetup(const std::string& chainName) : ReducedTestingSetup(chainName)
 {
-        SHA256AutoDetect();
-        RandomInit();
-        ECC_Start();
-        assert(snapshot::InitSecp256k1Context());
-        snapshot::SnapshotIndex::Clear();
-        SetupEnvironment();
-        SetupNetworking();
-        InitSignatureCache();
-        InitScriptExecutionCache();
-        fPrintToDebugLog = false; // don't want to write to debug.log file
-        fCheckBlockIndex = true;
         blockchain::Behavior::SetGlobal(blockchain::Behavior::NewForNetwork(blockchain::Network::_from_string(chainName.c_str())));
+        UnitEInjector::Init();
         SelectParams(chainName);
-        noui_connect();
 }
 
 fs::path BasicTestingSetup::SetDataDir(const std::string& name)
@@ -106,8 +96,7 @@ fs::path BasicTestingSetup::SetDataDir(const std::string& name)
 
 BasicTestingSetup::~BasicTestingSetup()
 {
-        ECC_Stop();
-        snapshot::DestroySecp256k1Context();
+        UnitEInjector::Destroy();
 }
 
 TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(chainName)

--- a/src/test/test_unite.h
+++ b/src/test/test_unite.h
@@ -62,7 +62,7 @@ struct ReducedTestingSetup {
 /** Basic testing setup.
  * This just configures logging and chain parameters.
  */
-struct BasicTestingSetup {
+struct BasicTestingSetup : public ReducedTestingSetup {
     ECCVerifyHandle globalVerifyHandle;
 
     explicit BasicTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);


### PR DESCRIPTION
Extracted and polished from #433 

This makes the UnitEInjector globally accessible and introduces a shorthand for accessing components. This is necessary in order to allow components (net processing, parts of validation) which are not part of the component framework to access functionality from these.

This also cleans up the functions as compared to #433 which were a bit more confusing (as pointed out in a review comment). There was actually a defect with regards to setting up / tearing down tests.

Also cleans up the relation between `BasicTestingSetup` and `ReducedTestingSetup`. `BasicTestingSetup` now extends `ReducedTestingSetup`. The `BasicTestingTestup` is the sort-of full setup, whereas `ReducedTestingSetup` does not prepare an injector or chain parameters.