### PR TITLE
Remove unused variables and members the compiler warns about.

### DIFF
--- a/src/injector.h
+++ b/src/injector.h
@@ -37,11 +37,9 @@ class UnitEInjector : public Injector<UnitEInjector> {
 
   COMPONENT(Network, staking::Network, staking::Network::New)
 
-  COMPONENT(ActiveChain, staking::ActiveChain, staking::ActiveChain::New,
-            blockchain::Behavior)
+  COMPONENT(ActiveChain, staking::ActiveChain, staking::ActiveChain::New)
 
-  COMPONENT(StakeValidator, staking::StakeValidator, staking::StakeValidator::New,
-            blockchain::Behavior)
+  COMPONENT(StakeValidator, staking::StakeValidator, staking::StakeValidator::New)
 
   COMPONENT(BlockValidator, staking::BlockValidator, staking::BlockValidator::New,
             blockchain::Behavior)

--- a/src/proposer/proposer.cpp
+++ b/src/proposer/proposer.cpp
@@ -30,7 +30,6 @@ class ProposerImpl : public Proposer {
  private:
   static constexpr const char *THREAD_NAME = "unite-proposer";
 
-  Dependency<Settings> m_settings;
   Dependency<blockchain::Behavior> m_blockchain_behavior;
   Dependency<MultiWallet> m_multi_wallet;
   Dependency<staking::Network> m_network;
@@ -135,16 +134,14 @@ class ProposerImpl : public Proposer {
   }
 
  public:
-  ProposerImpl(Dependency<Settings> settings,
-               Dependency<blockchain::Behavior> blockchain_behavior,
+  ProposerImpl(Dependency<blockchain::Behavior> blockchain_behavior,
                Dependency<MultiWallet> multi_wallet,
                Dependency<staking::Network> network,
                Dependency<staking::ActiveChain> active_chain,
                Dependency<staking::TransactionPicker> transaction_picker,
                Dependency<proposer::BlockBuilder> block_builder,
                Dependency<proposer::Logic> proposer_logic)
-      : m_settings(settings),
-        m_blockchain_behavior(blockchain_behavior),
+      : m_blockchain_behavior(blockchain_behavior),
         m_multi_wallet(multi_wallet),
         m_network(network),
         m_active_chain(active_chain),
@@ -189,7 +186,7 @@ std::unique_ptr<Proposer> Proposer::New(
     Dependency<proposer::BlockBuilder> block_builder,
     Dependency<proposer::Logic> proposer_logic) {
   if (settings->node_is_proposer) {
-    return std::unique_ptr<Proposer>(new ProposerImpl(settings, behavior, multi_wallet, network, active_chain, transaction_picker, block_builder, proposer_logic));
+    return std::unique_ptr<Proposer>(new ProposerImpl(behavior, multi_wallet, network, active_chain, transaction_picker, block_builder, proposer_logic));
   } else {
     return std::unique_ptr<Proposer>(new ProposerStub());
   }

--- a/src/staking/active_chain.cpp
+++ b/src/staking/active_chain.cpp
@@ -13,12 +13,8 @@ namespace staking {
 
 class ActiveChainAdapter final : public ActiveChain {
 
- private:
-  Dependency<blockchain::Behavior> m_blockchain_behavior;
-
  public:
-  explicit ActiveChainAdapter(Dependency<blockchain::Behavior> blockchain_behavior)
-      : m_blockchain_behavior(blockchain_behavior) {}
+  explicit ActiveChainAdapter() {}
 
   CCriticalSection &GetLock() const override { return cs_main; }
 
@@ -57,9 +53,8 @@ class ActiveChainAdapter final : public ActiveChain {
   }
 };
 
-std::unique_ptr<ActiveChain> ActiveChain::New(
-    Dependency<blockchain::Behavior> blockchain_behavior) {
-  return std::unique_ptr<ActiveChain>(new ActiveChainAdapter(blockchain_behavior));
+std::unique_ptr<ActiveChain> ActiveChain::New() {
+  return std::unique_ptr<ActiveChain>(new ActiveChainAdapter());
 }
 
 }  // namespace staking

--- a/src/staking/active_chain.h
+++ b/src/staking/active_chain.h
@@ -81,7 +81,7 @@ class ActiveChain : public blockchain::ChainAccess {
   ~ActiveChain() override = default;
 
   //! \brief Factory method for creating a Chain.
-  static std::unique_ptr<ActiveChain> New(Dependency<blockchain::Behavior>);
+  static std::unique_ptr<ActiveChain> New();
 };
 
 }  // namespace staking

--- a/src/staking/stake_validator.cpp
+++ b/src/staking/stake_validator.cpp
@@ -17,14 +17,11 @@ namespace staking {
 class StakeValidatorImpl : public StakeValidator {
 
  private:
-  Dependency<blockchain::Behavior> m_blockchain_behavior;
-
   CCriticalSection m_cs;
   std::set<uint256> m_kernel_seen;
 
  public:
-  StakeValidatorImpl(Dependency<blockchain::Behavior> blockchain_behavior)
-      : m_blockchain_behavior(blockchain_behavior) {}
+  StakeValidatorImpl() {}
 
   CCriticalSection &GetLock() override {
     return m_cs;
@@ -110,9 +107,8 @@ class StakeValidatorImpl : public StakeValidator {
   }
 };
 
-std::unique_ptr<StakeValidator> StakeValidator::New(
-    Dependency<blockchain::Behavior> blockchain_behavior) {
-  return std::unique_ptr<StakeValidator>(new StakeValidatorImpl(blockchain_behavior));
+std::unique_ptr<StakeValidator> StakeValidator::New() {
+  return std::unique_ptr<StakeValidator>(new StakeValidatorImpl());
 }
 
 }  // namespace staking

--- a/src/staking/stake_validator.h
+++ b/src/staking/stake_validator.h
@@ -75,7 +75,7 @@ class StakeValidator {
 
   virtual ~StakeValidator() = default;
 
-  static std::unique_ptr<StakeValidator> New(Dependency<blockchain::Behavior>);
+  static std::unique_ptr<StakeValidator> New();
 };
 
 }  // namespace staking

--- a/src/test/staking/stake_validator_tests.cpp
+++ b/src/test/staking/stake_validator_tests.cpp
@@ -22,21 +22,21 @@ std::unique_ptr<blockchain::Behavior> b =
 BOOST_AUTO_TEST_SUITE(stake_validator_tests)
 
 BOOST_AUTO_TEST_CASE(check_kernel) {
-  const auto stake_validator = staking::StakeValidator::New(b.get());
+  const auto stake_validator = staking::StakeValidator::New();
   const uint256 kernel;
   const auto difficulty = blockchain::GenesisBlockBuilder().Build(p).nBits;
   BOOST_CHECK(stake_validator->CheckKernel(1, kernel, difficulty));
 }
 
 BOOST_AUTO_TEST_CASE(check_kernel_fail) {
-  const auto stake_validator = staking::StakeValidator::New(b.get());
+  const auto stake_validator = staking::StakeValidator::New();
   const uint256 kernel = uint256S("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
   const auto difficulty = blockchain::GenesisBlockBuilder().Build(p).nBits;
   BOOST_CHECK(!stake_validator->CheckKernel(1, kernel, difficulty));
 }
 
 BOOST_AUTO_TEST_CASE(remember_and_forget) {
-  const auto stake_validator = staking::StakeValidator::New(b.get());
+  const auto stake_validator = staking::StakeValidator::New();
   const uint256 kernel = uint256S("000000000000000000000000e6b8347d447e02ed383a3e96986815d576fb2a5a");
   LOCK(stake_validator->GetLock());
   BOOST_CHECK(!stake_validator->IsKernelKnown(kernel));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3323,7 +3323,6 @@ std::vector<unsigned char> GenerateCoinbaseCommitment(CBlock& block, const CBloc
 static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const CChainParams& params, const CBlockIndex* pindexPrev, int64_t nAdjustedTime)
 {
     assert(pindexPrev != nullptr);
-    const int nHeight = pindexPrev->nHeight + 1;
 
     // Check proof of work
     const Consensus::Params& consensusParams = params.GetConsensus();


### PR DESCRIPTION
This removes some unused variables which were causing compiler warnings.

It is extracted from #433 to make it more easily reviewable.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
