### PR TITLE
Don't delete fully downloaded snapshot after the restart

### DIFF
--- a/src/snapshot/initialization.cpp
+++ b/src/snapshot/initialization.cpp
@@ -74,8 +74,8 @@ void Deinitialize() {
   }
   DestroySecp256k1Context();
   Creator::Deinit();
-  SaveSnapshotIndex();
   DeinitP2P();
+  SaveSnapshotIndex();
 }
 
 }  // namespace snapshot

--- a/src/snapshot/p2p_processing.cpp
+++ b/src/snapshot/p2p_processing.cpp
@@ -595,10 +595,12 @@ void P2PState::DeleteUnlinkedSnapshot() {
   // as it will be unlinked and be never deleted
   uint256 finalized_hash;
   GetLatestFinalizedSnapshotHash(finalized_hash);
-  if (m_downloading_snapshot.snapshot_hash != LoadCandidateBlockHash() &&
+  if (m_downloading_snapshot.block_hash != LoadCandidateBlockHash() &&
       m_downloading_snapshot.snapshot_hash != finalized_hash) {
     LOCK(cs_snapshot);
-    Indexer::Delete(m_downloading_snapshot.snapshot_hash);
+    SnapshotIndex::DeleteSnapshot(m_downloading_snapshot.snapshot_hash);
+    LogPrint(BCLog::SNAPSHOT, "downloaded snapshot %s is deleted\n",
+             m_downloading_snapshot.snapshot_hash.GetHex());
   }
 }
 


### PR DESCRIPTION
It was a bug in the code which caused the node to delete the downloaded
snapshot and it wasn't caught in tests as after the restart
c++ node synced again with the mininode.

I extended tests to catch this scenario.

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>