### PR TITLE
Unify gitian verification and skip verification if build is missing

### DIFF
--- a/contrib/test_data/gitian_build/test_verify.log.expected
+++ b/contrib/test_data/gitian_build/test_verify.log.expected
@@ -1,8 +1,6 @@
 Test: test_verify
-chdir('gitian-builder')
-bin/gverify -v -d ../unit-e-sigs/ -r someversion-linux ../unit-e/contrib/gitian-descriptors/gitian-linux.yml
-bin/gverify -v -d ../unit-e-sigs/ -r someversion-win-unsigned ../unit-e/contrib/gitian-descriptors/gitian-win.yml
-bin/gverify -v -d ../unit-e-sigs/ -r someversion-osx-unsigned ../unit-e/contrib/gitian-descriptors/gitian-osx.yml
-bin/gverify -v -d ../unit-e-sigs/ -r someversion-win-signed ../unit-e/contrib/gitian-descriptors/gitian-win-signer.yml
-bin/gverify -v -d ../unit-e-sigs/ -r someversion-osx-signed ../unit-e/contrib/gitian-descriptors/gitian-osx-signer.yml
-chdir('someworkdir')
+bin/gverify -v -d ../unit-e-sigs/ -r someversion-linux ../unit-e/contrib/gitian-descriptors/gitian-linux.yml  cwd=gitian-builder
+bin/gverify -v -d ../unit-e-sigs/ -r someversion-win-unsigned ../unit-e/contrib/gitian-descriptors/gitian-win.yml  cwd=gitian-builder
+bin/gverify -v -d ../unit-e-sigs/ -r someversion-osx-unsigned ../unit-e/contrib/gitian-descriptors/gitian-osx.yml  cwd=gitian-builder
+bin/gverify -v -d ../unit-e-sigs/ -r someversion-win-signed ../unit-e/contrib/gitian-descriptors/gitian-win-signer.yml  cwd=gitian-builder
+bin/gverify -v -d ../unit-e-sigs/ -r someversion-osx-signed ../unit-e/contrib/gitian-descriptors/gitian-osx-signer.yml  cwd=gitian-builder


### PR DESCRIPTION
The --verify target will try to verify all of the builds, and it will notify the user in case signatures are missing.

The verification will still fail in case some of the signatures are missing, but the error will be treated differently from one of the signatures being incorrect.

The reason this change is important, is that it allows the use of --verify for every stage of the gitian build. Previously it would just fail on the first missing signature, and sometimes it's the expected result (e.g. after building and before codesigning or after codesigning of only one of the platforms).

Signed-off-by: Mateusz Morusiewicz <mateusz@thirdhash.com>