### PR TITLE
Get rid of compile-time warning

### DIFF
--- a/src/blockchain/blockchain_behavior.cpp
+++ b/src/blockchain/blockchain_behavior.cpp
@@ -110,9 +110,9 @@ std::unique_ptr<Behavior> Behavior::NewForNetwork(Network network) {
     case Network::test:
       return NewFromParameters(Parameters::TestNet());
     case Network::regtest:
-    default:
       return NewFromParameters(Parameters::RegTest());
   }
+  assert(false && "silence gcc warnings");
 }
 
 std::unique_ptr<Behavior> Behavior::NewFromParameters(const Parameters &parameters) {


### PR DESCRIPTION
Fixes spurious 'control reaches end of non-void function' warning.