### PR TITLE
Use Unit-e bech32 prefixes as defined in SLIP 173

### DIFF
--- a/src/blockchain/blockchain_parameters.cpp
+++ b/src/blockchain/blockchain_parameters.cpp
@@ -54,7 +54,7 @@ Parameters BuildMainNetParameters() {
   p.base58_prefixes[Base58Type::EXT_PUBLIC_KEY] = {0x04, 0x88, 0xB2, 0x1E};
   p.base58_prefixes[Base58Type::EXT_SECRET_KEY] = {0x04, 0x88, 0xAD, 0xE4};
 
-  p.bech32_human_readable_prefix = "bc";
+  p.bech32_human_readable_prefix = "ue";
 
   p.deployment_confirmation_period = 2016;
   p.rule_change_activation_threshold = 1916;

--- a/src/test/data/base58_keys_invalid.json
+++ b/src/test/data/base58_keys_invalid.json
@@ -153,16 +153,16 @@
         "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty"
     ],
     [
-        "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5"
+        "ue1qw508d6qejxtdg4y5r3zarvary0c5xw7khtkwrx"
     ],
     [
         "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2"
     ],
     [
-        "bc1rw5uspcuh"
+        "ue1rw50x8lk8"
     ],
     [
-        "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90"
+        "ue10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw52pelvs"
     ],
     [
         "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P"
@@ -171,12 +171,12 @@
         "tue1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qg8g0xn"
     ],
     [
-        "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du"
+        "ue1zw508d6qejxtdg4y5r3zarvaryvqjw8uqh"
     ],
     [
         "tue1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3p43u6mf"
     ],
     [
-        "bc1gmk9yu"
+        "ue1kqh25z"
     ]
 ]

--- a/src/test/data/base58_keys_valid.json
+++ b/src/test/data/base58_keys_valid.json
@@ -459,7 +459,7 @@
         }
     ],
     [
-        "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+        "ue1qw508d6qejxtdg4y5r3zarvary0c5xw7khtkwrz",
         "0014751e76e8199196d454941c45d1b3a323f1433bd6",
         {
             "isPrivkey": false,
@@ -486,7 +486,7 @@
         }
     ],
     [
-        "bc1zw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k0vt50h",
+        "ue1zw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kr7jlml",
         "5228751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
         {
             "isPrivkey": false,
@@ -495,7 +495,7 @@
         }
     ],
     [
-        "bc1sw50qa3jx3s",
+        "ue1sw50q9ryj39",
         "6002751e",
         {
             "isPrivkey": false,
@@ -504,7 +504,7 @@
         }
     ],
     [
-        "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj",
+        "ue1zw508d6qejxtdg4y5r3zarvaryvhxkc54",
         "5210751e76e8199196d454941c45d1b3a323",
         {
             "isPrivkey": false,

--- a/src/test/proposer/block_builder_tests.cpp
+++ b/src/test/proposer/block_builder_tests.cpp
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(split_amount) {
 
 BOOST_AUTO_TEST_CASE(check_reward_destination) {
 
-  const std::string address("bc1q2znaq2pnwqg92lpsc9sf7p5z0drluu27jn2a92");
+  const std::string address("ue1q2znaq2pnwqg92lpsc9sf7p5z0drluu27fl4zda");
   const CTxDestination expected_reward_dest = DecodeDestination(address);
   Fixture f{tfm::format("-rewardaddress=%s", address)};
   std::unique_ptr<staking::BlockValidator> validator = f.MakeBlockValidator();

--- a/test/functional/test_framework/address.py
+++ b/test/functional/test_framework/address.py
@@ -57,7 +57,7 @@ def program_to_witness(version, program, main = False):
     assert 0 <= version <= 16
     assert 2 <= len(program) <= 40
     assert version > 0 or len(program) in [20, 32]
-    return segwit_addr.encode("bc" if main else "uert", version, program)
+    return segwit_addr.encode("ue" if main else "uert", version, program)
 
 def script_to_p2wsh(script, main = False):
     script = check_script(script)

--- a/test/util/data/txcreatemultisig3.json
+++ b/test/util/data/txcreatemultisig3.json
@@ -18,7 +18,7 @@
                 "reqSigs": 1,
                 "type": "witness_v0_scripthash",
                 "addresses": [
-                    "bc1qu9dgdg330r6r84g5mw7wqshg04exv2uttmw2elfwx74h5tgntuzs44gyfg"
+                    "ue1qu9dgdg330r6r84g5mw7wqshg04exv2uttmw2elfwx74h5tgntuzsynmhjd"
                 ]
             }
         }

--- a/test/util/data/txcreateoutpubkey2.json
+++ b/test/util/data/txcreateoutpubkey2.json
@@ -18,7 +18,7 @@
                 "reqSigs": 1,
                 "type": "witness_v0_keyhash",
                 "addresses": [
-                    "bc1q5fgkuac9s2ry56jka5s6zqsyfcugcchry5cwu0"
+                    "ue1q5fgkuac9s2ry56jka5s6zqsyfcugcchrlc835c"
                 ]
             }
         }

--- a/test/util/data/txcreatescript3.json
+++ b/test/util/data/txcreatescript3.json
@@ -18,7 +18,7 @@
                 "reqSigs": 1,
                 "type": "witness_v0_scripthash",
                 "addresses": [
-                    "bc1qp0lfxhnscvsu0j36l36uurgv5tuck4pzuqytkvwqp3kh78cupttqyf705v"
+                    "ue1qp0lfxhnscvsu0j36l36uurgv5tuck4pzuqytkvwqp3kh78cupttq40du0f"
                 ]
             }
         }


### PR DESCRIPTION
This PR changes the base32 prefixes as defined in https://github.com/dtr-org/unit-e/issues/463.

* Mainnet prefix becomes `ue`
* Testnet prefix becomes `tue`
* Regtest prefix becomes `uert`

Takes https://github.com/dtr-org/unit-e/issues/463 into effect.