### PR TITLE
Process deposits at a predictable height

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2850,15 +2850,9 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
     // that transactions that are delayed after signing for whatever reason,
     // e.g. high-latency mix networks and some CoinJoin implementations, have
     // better privacy.
-    if (GetRandInt(10) == 0) {
+    if (txType != +TxType::DEPOSIT && GetRandInt(10) == 0) {
         txNew.nLockTime = std::max(0, (int)txNew.nLockTime - GetRandInt(100));
     }
-
-    // don't delay deposits because of re-org
-    if (txType == +TxType::DEPOSIT) {
-        txNew.nLockTime = 0;
-    }
-
     assert(txNew.nLockTime <= (unsigned int)chainActive.Height());
     assert(txNew.nLockTime < LOCKTIME_THRESHOLD);
     FeeCalculation feeCalc;


### PR DESCRIPTION
~~There is no need to delay deposit processing until a particular height is reached.
It can be included at any height if its input is spendable.~~ Always process deposits at a predictable height. 

Also, while working on some tests, noticed that it would be convenient
when two validators using the same mnemonics, spend to the same address
can create the same deposit TX ID. Since this nLockTime is randomized, it's a bit trickier
to emulate this state.

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>
