### PR TITLE
Remove nPruneAfterHeight

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -281,7 +281,6 @@ public:
         pchMessageStart[2] = 0xae;
         pchMessageStart[3] = 0xc1;
         nDefaultPort = 7182;
-        nPruneAfterHeight = 100000;
 
         genesis = CreateGenesisBlock(1231006505, 2083236893, 0x1d00ffff, 1, 50 * UNIT);
         consensus.hashGenesisBlock = genesis.GetHash();
@@ -360,7 +359,6 @@ public:
         pchMessageStart[2] = 0xfb;
         pchMessageStart[3] = 0xfa;
         nDefaultPort = 17182;
-        nPruneAfterHeight = 1000;
 
         genesis = CreateGenesisBlock(1296688602, 414098458, 0x1d00ffff, 1, 50 * UNIT);
         consensus.hashGenesisBlock = genesis.GetHash();
@@ -432,7 +430,6 @@ public:
         pchMessageStart[2] = 0xb5;
         pchMessageStart[3] = 0xda;
         nDefaultPort = 17292;
-        nPruneAfterHeight = 1000;
 
         genesis = CreateGenesisBlockRegTest(1296688602, 7, 0x207fffff, 1, 50 * UNIT);
         consensus.hashGenesisBlock = genesis.GetHash();

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -58,7 +58,6 @@ public:
     bool DefaultConsistencyChecks() const { return fDefaultConsistencyChecks; }
     /** Policy: Filter transactions that do not match well-defined patterns */
     bool RequireStandard() const { return fRequireStandard; }
-    uint64_t PruneAfterHeight() const { return nPruneAfterHeight; }
     /** Make miner stop after a block is found. In RPC, don't return until nGenProcLimit blocks are generated */
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
     /** Return the BIP70 network string (main, test or regtest) */
@@ -79,7 +78,6 @@ protected:
     snapshot::Params snapshotParams;
     CMessageHeader::MessageStartChars pchMessageStart;
     int nDefaultPort;
-    uint64_t nPruneAfterHeight;
     std::vector<std::string> vSeeds;
     std::string strNetworkID;
     CBlock genesis;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -930,7 +930,7 @@ UniValue pruneblockchain(const JSONRPCRequest& request)
 
     unsigned int height = (unsigned int) heightParam;
     unsigned int chainHeight = (unsigned int) chainActive.Height();
-    if (chainHeight < Params().PruneAfterHeight())
+    if (chainHeight <= 0)
         throw JSONRPCError(RPC_MISC_ERROR, "Blockchain is too short for pruning.");
     else if (height > chainHeight)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Blockchain is shorter than the attempted prune height.");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -304,7 +304,7 @@ enum class FlushStateMode {
 // See definition for documentation
 static bool FlushStateToDisk(const CChainParams& chainParams, CValidationState &state, FlushStateMode mode, int nManualPruneHeight=0);
 static void FindFilesToPruneManual(std::set<int>& setFilesToPrune, int nManualPruneHeight);
-static void FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPruneAfterHeight);
+static void FindFilesToPrune(std::set<int>& setFilesToPrune);
 bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheSigStore, bool cacheFullScriptStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks = nullptr);
 static FILE* OpenUndoFile(const CDiskBlockPos &pos, bool fReadOnly = false);
 
@@ -2233,7 +2233,7 @@ bool static FlushStateToDisk(const CChainParams& chainparams, CValidationState &
             if (nManualPruneHeight > 0) {
                 FindFilesToPruneManual(setFilesToPrune, nManualPruneHeight);
             } else {
-                FindFilesToPrune(setFilesToPrune, chainparams.PruneAfterHeight());
+                FindFilesToPrune(setFilesToPrune);
                 fCheckForPruning = false;
             }
             if (!setFilesToPrune.empty()) {
@@ -3792,13 +3792,14 @@ void PruneBlockFilesManual(int nManualPruneHeight)
  *
  * @param[out]   setFilesToPrune   The set of file indices that can be unlinked will be returned
  */
-static void FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPruneAfterHeight)
+static void FindFilesToPrune(std::set<int>& setFilesToPrune)
 {
     LOCK2(cs_main, cs_LastBlockFile);
     if (chainActive.Tip() == nullptr || nPruneTarget == 0) {
         return;
     }
-    if ((uint64_t)chainActive.Tip()->nHeight <= nPruneAfterHeight) {
+    if ((uint64_t)chainActive.Tip()->nHeight <= 0) {
+        // exclude genesis block
         return;
     }
 


### PR DESCRIPTION
`nPruneAfterHeight` is a parameter which does not prune before the given amount of blocks have passed. This is a bitcoin feature which is mostly present as it does not make any sense to prune the first few thousands blocks as they are mostly empty (so there's nothing to prune anyway).

See this Q&A: https://bitcoin.stackexchange.com/questions/57121/new-params-of-chainparams-cpp-what-put-on-them-and-how-generate

This is part of using `blockchain::Parameters` instead of `CChainParams`. If it does not exist, we don't have to port.