### PR TITLE
Wire blockchain parameters into CChainParams as an interim solution to…

### DIFF
--- a/src/blockchain/blockchain_parameters.cpp
+++ b/src/blockchain/blockchain_parameters.cpp
@@ -43,6 +43,9 @@ Parameters BuildMainNetParameters() {
     return tip->nBits;
   };
 
+  // The message start string is designed to be unlikely to occur in normal data.
+  // The characters are rarely used upper ASCII, not valid as UTF-8, and produce
+  // a large 32-bit integer with any alignment. They are different from bitcoin.
   p.message_start_characters[0] = 0xee;
   p.message_start_characters[1] = 0xee;
   p.message_start_characters[2] = 0xae;

--- a/src/blockchain/blockchain_parameters.h
+++ b/src/blockchain/blockchain_parameters.h
@@ -78,7 +78,7 @@ struct Parameters {
   //! \brief a unique identifier for this network.
   //!
   //! The usual predefined identifiers are "main", "test", and "regtest".
-  const char *network_name;
+  std::string network_name;
 
   //! \brief The genesis block of this chain.
   GenesisBlock const *genesis_block;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -241,8 +241,7 @@ void CChainParams::UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64
 
 class CMainParams : public CChainParams {
 public:
-    CMainParams() {
-        strNetworkID = "main";
+    CMainParams() : CChainParams(blockchain::Parameters::MainNet()) {
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -271,15 +270,6 @@ public:
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x0000000000000000005214481d2d96f898e3d5416e43359c145944a909d242e0"); //506067
 
-        /**
-         * The message start string is designed to be unlikely to occur in normal data.
-         * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
-         * a large 32-bit integer with any alignment.
-         */
-        pchMessageStart[0] = 0xee;
-        pchMessageStart[1] = 0xee;
-        pchMessageStart[2] = 0xae;
-        pchMessageStart[3] = 0xc1;
         nDefaultPort = 7182;
         nPruneAfterHeight = 100000;
 
@@ -299,7 +289,6 @@ public:
 
         fDefaultConsistencyChecks = false;
         fRequireStandard = true;
-        fMineBlocksOnDemand = false;
 
         chainTxData = ChainTxData{
             // Data as of block 0000000000000000002d6cca6761c99b3c2e936f9a0e304b7c7651a993f461de (height 506081).
@@ -325,8 +314,7 @@ public:
  */
 class CTestNetParams : public CChainParams {
 public:
-    CTestNetParams() {
-        strNetworkID = "test";
+    CTestNetParams() : CChainParams(blockchain::Parameters::TestNet()) {
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -355,10 +343,6 @@ public:
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x0000000002e9e7b00e1f6dc5123a04aad68dd0f0968d8c7aa45f6640795c37b1"); //1135275
 
-        pchMessageStart[0] = 0xfd;
-        pchMessageStart[1] = 0xfc;
-        pchMessageStart[2] = 0xfb;
-        pchMessageStart[3] = 0xfa;
         nDefaultPort = 17182;
         nPruneAfterHeight = 1000;
 
@@ -376,7 +360,6 @@ public:
 
         fDefaultConsistencyChecks = false;
         fRequireStandard = false;
-        fMineBlocksOnDemand = false;
 
         chainTxData = ChainTxData{
             // Data as of block 000000000000033cfa3c975eb83ecf2bb4aaedf68e6d279f6ed2b427c64caff9 (height 1260526)
@@ -401,8 +384,7 @@ public:
  */
 class CRegTestParams : public CChainParams {
 public:
-    CRegTestParams() {
-        strNetworkID = "regtest";
+    CRegTestParams() : CChainParams(blockchain::Parameters::RegTest()) {
         consensus.nSubsidyHalvingInterval = 150;
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -427,10 +409,6 @@ public:
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x00");
 
-        pchMessageStart[0] = 0xfa;
-        pchMessageStart[1] = 0xbf;
-        pchMessageStart[2] = 0xb5;
-        pchMessageStart[3] = 0xda;
         nDefaultPort = 17292;
         nPruneAfterHeight = 1000;
 
@@ -444,7 +422,6 @@ public:
 
         fDefaultConsistencyChecks = true;
         fRequireStandard = false;
-        fMineBlocksOnDemand = true;
 
         chainTxData = ChainTxData{
             0,
@@ -465,7 +442,7 @@ public:
 
 void CChainParams::UpdateFinalizationParams(esperanza::FinalizationParams &params) {
 
-  if (strNetworkID == "regtest") {
+  if (NetworkIDString() == "regtest") {
     finalization = params;
   }
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -6,6 +6,7 @@
 #ifndef UNITE_CHAINPARAMS_H
 #define UNITE_CHAINPARAMS_H
 
+#include <blockchain/blockchain_parameters.h>
 #include <chainparamsbase.h>
 #include <consensus/params.h>
 #include <primitives/block.h>
@@ -50,7 +51,7 @@ public:
     const esperanza::FinalizationParams& GetFinalization() const { return finalization; }
     const esperanza::AdminParams& GetAdminParams() const { return adminParams; }
     const snapshot::Params& GetSnapshotParams() const { return snapshotParams; }
-    const CMessageHeader::MessageStartChars& MessageStart() const { return pchMessageStart; }
+    const CMessageHeader::MessageStartChars& MessageStart() const { return parameters.message_start_characters; }
     int GetDefaultPort() const { return nDefaultPort; }
 
     const CBlock& GenesisBlock() const { return genesis; }
@@ -60,9 +61,9 @@ public:
     bool RequireStandard() const { return fRequireStandard; }
     uint64_t PruneAfterHeight() const { return nPruneAfterHeight; }
     /** Make miner stop after a block is found. In RPC, don't return until nGenProcLimit blocks are generated */
-    bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
+    bool MineBlocksOnDemand() const { return parameters.mine_blocks_on_demand; }
     /** Return the BIP70 network string (main, test or regtest) */
-    std::string NetworkIDString() const { return strNetworkID; }
+    const std::string NetworkIDString() const { return parameters.network_name; }
     /** Return the list of hostnames to look up for DNS seeds */
     const std::vector<std::string>& DNSSeeds() const { return vSeeds; }
     const std::vector<SeedSpec6>& FixedSeeds() const { return vFixedSeeds; }
@@ -70,23 +71,22 @@ public:
     void UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout);
     void UpdateFinalizationParams(esperanza::FinalizationParams &params);
 
+    const blockchain::Parameters& parameters;
+
 protected:
-    CChainParams() {}
+    explicit CChainParams(const blockchain::Parameters& _parameters) : parameters(_parameters) {}
 
     Consensus::Params consensus;
     esperanza::FinalizationParams finalization;
     esperanza::AdminParams adminParams;
     snapshot::Params snapshotParams;
-    CMessageHeader::MessageStartChars pchMessageStart;
     int nDefaultPort;
     uint64_t nPruneAfterHeight;
     std::vector<std::string> vSeeds;
-    std::string strNetworkID;
     CBlock genesis;
     std::vector<SeedSpec6> vFixedSeeds;
     bool fDefaultConsistencyChecks;
     bool fRequireStandard;
-    bool fMineBlocksOnDemand;
     ChainTxData chainTxData;
 };
 


### PR DESCRIPTION
There's the new `blockchain::Parameters` and the old `CChainParams`. In #212 I went and replaced occurrences of `CChainParams` with `blockchain::Parameters`, but it breaks a lot of things (or at least touches a lot of things and requires touching some more).

This pull request does it the other way around: It integrates `blockchain::Parameters` with `CChainParams` and that's how you can access `blockchain::Parameters` from where ever we have `CChainParams` (mostly in `validation.cpp`), which avoids touching all the call sites.

Eventually more and more things should be migrated from `CChainParams` to `blockchain::Parameters` and once we have `chainparams.parameters.new_parameter` everywhere we can replace `CChainParams` references completely and just have `parameters.new_parameter`.