### PR TITLE
Extract LTOR sorting logic

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -105,6 +105,8 @@ UNITE_CORE_H = \
   compressor.h \
   consensus/consensus.h \
   consensus/tx_verify.h \
+  consensus/ltor.h \
+  consensus/ltor.cpp \
   core_io.h \
   core_memusage.h \
   cuckoocache.h \

--- a/src/consensus/ltor.cpp
+++ b/src/consensus/ltor.cpp
@@ -7,7 +7,7 @@
 
 namespace ltor {
 
-void SortTransactionsWithLTOR(std::vector<CTransactionRef> &transactions) {
+void SortTransactions(std::vector<CTransactionRef>& transactions) {
     if (transactions.size() <= 2) {
         // The first transaction has to be coinbase, and having just one
         // regular transaction does not require sorting neither.

--- a/src/consensus/ltor.h
+++ b/src/consensus/ltor.h
@@ -10,7 +10,7 @@
 
 namespace ltor {
 
-void SortTransactionsWithLTOR(std::vector<CTransactionRef> &transactions);
+void SortTransactions(std::vector<CTransactionRef>& transactions);
 
 }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -159,7 +159,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     int nDescendantsUpdated = 0;
     addPackageTxs(nPackagesSelected, nDescendantsUpdated);
 
-    ltor::SortTransactionsWithLTOR(pblock->vtx);
+    ltor::SortTransactions(pblock->vtx);
 
     int64_t nTime1 = GetTimeMicros();
 

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -45,7 +45,7 @@ static CBlock BuildBlockTestCase() {
     }
     block.vtx[2] = MakeTransactionRef(tx);
 
-    ltor::SortTransactionsWithLTOR(block.vtx);
+    ltor::SortTransactions(block.vtx);
 
     bool mutated;
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -13,7 +13,7 @@
 
 namespace {
 void SortTxs(CBlock &block, bool reverse = false) {
-  ltor::SortTransactionsWithLTOR(block.vtx);
+  ltor::SortTransactions(block.vtx);
   if (reverse) {
     std::reverse(block.vtx.begin() + 1, block.vtx.end());
   }


### PR DESCRIPTION
Extract simple LTOR sorting logic to avoid repeated code.

Signed-off-by: Andres Correa Casablanca <andres@thirdhash.com>