### PR TITLE
Remove unnecessary const_cast

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4426,7 +4426,7 @@ bool CChainState::LoadGenesisBlock(const CChainParams& chainparams)
         return true;
 
     try {
-        CBlock &block = const_cast<CBlock&>(chainparams.GenesisBlock());
+        const CBlock &block = chainparams.GenesisBlock();
         CDiskBlockPos blockPos = SaveBlockToDisk(block, 0, chainparams, nullptr);
         if (blockPos.IsNull())
             return error("%s: writing genesis block to disk failed", __func__);


### PR DESCRIPTION
The const_cast

```C++
CBlock &block = const_cast<CBlock&>(chainparams.GenesisBlock());
```

is not necessary as all the functions invoked form this block receive a `const CBlock&` anyway. Simply add the `const` to `block`:

```C++
const CBlock& block = chainparams.GenesisBlock();
```

Casting away `const`, especially from something as precious as the genesis block, feels really weird to me as a reader of bitcoin-core source code.

This is extracted from #577 

This refactoring is being backported to bitcoin also:
https://github.com/bitcoin/bitcoin/pull/15389

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
