### PR TITLE
Remove leftover variable

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -169,7 +169,6 @@ public:
 
 static std::unique_ptr<CCoinsViewErrorCatcher> pcoinscatcher;
 static std::unique_ptr<ECCVerifyHandle> globalVerifyHandle;
-static std::unique_ptr<UnitEInjector> injector;
 
 static boost::thread_group threadGroup;
 static CScheduler scheduler;


### PR DESCRIPTION
https://github.com/dtr-org/unit-e/pull/537 moved the injector variable to `injector.cpp` in order to make it globally accessible.

The variable is no longer used and this patch removes it.

This is extracted from #577 

  Signed-off-by: Julian Fleischer <julian@thirdhash.com>