### PR TITLE
Remove unused import from DoS_tests

### DIFF
--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -8,7 +8,6 @@
 #include <keystore.h>
 #include <net.h>
 #include <net_processing.h>
-#include <pow.h>
 #include <script/sign.h>
 #include <serialize.h>
 #include <util.h>


### PR DESCRIPTION
Include is not used.

Extracted from #577 

Signed-off-by: Julian Fleischer <julian@thirdhash.com>