### PR TITLE
Fix int type, removes a compiler warning

### DIFF
--- a/src/blockchain/blockchain_parameters.cpp
+++ b/src/blockchain/blockchain_parameters.cpp
@@ -32,7 +32,7 @@ Parameters BuildMainNetParameters() {
   p.maximum_supply = 2718275100 * UNIT;  // e billion UTE
   assert(p.maximum_supply == p.initial_supply + std::accumulate(p.reward_schedule.begin(), p.reward_schedule.end(), CAmount(0)) * p.period_blocks);
   p.reward_function = [](const Parameters &p, Height h) -> CAmount {
-    const uint64_t period = h / p.period_blocks;
+    const std::uint32_t period = h / p.period_blocks;
     if (period >= p.reward_schedule.size()) {
       return 0;
     }


### PR DESCRIPTION
`blockchain::Parameters::period_blocks` is declared as `std::uint32_t` ( https://github.com/dtr-org/unit-e/blob/master/src/blockchain/blockchain_parameters.h#L158 ), as is `blockchain::Height`.

This eliminates a compiler warning.

Extracted from #577 

Signed-off-by: Julian Fleischer <julian@thirdhash.com>