### PR TITLE
Widen accepted difficulty values

### DIFF
--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -193,7 +193,7 @@ class BlockchainTest(UnitETestFramework):
         assert isinstance(header['nonce'], int)
         assert isinstance(header['version'], int)
         assert isinstance(int(header['versionHex'], 16), int)
-        assert isinstance(header['difficulty'], Decimal)
+        assert isinstance(header['difficulty'], Decimal) or isinstance(header['difficulty'], int)
 
     def _test_getdifficulty(self):
         difficulty = self.nodes[0].getdifficulty()


### PR DESCRIPTION
When the difficulty is actually an integer then this test fails, as the type will be `int`, not `Decimal`.

That is: if the difficulty is, for example, „1.0“ (a realistic value), then the python json parser will create an „int“ from it, not a „Decimal“. It might be that core / univalue actually emits „1“ (no trailing zeroes) and that’s the reason, but this test can spuriously fail.

The difficulty of the genesis block, for instance, is „1.0“ exactly.

Extracted from #577 

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
