### PR TITLE
Use BlockValidator::ContextualCheckBlockHeader

### DIFF
--- a/src/staking/validation_error.cpp
+++ b/src/staking/validation_error.cpp
@@ -10,9 +10,9 @@ std::string GetRejectionMessageFor(const BlockValidationError error) {
     case BlockValidationError::BLOCK_SIGNATURE_VERIFICATION_FAILED:
       return "bad-blk-signature";
     case BlockValidationError::BLOCKTIME_TOO_EARLY:
-      return "time-too-new";
-    case BlockValidationError::BLOCKTIME_TOO_FAR_INTO_FUTURE:
       return "time-too-old";
+    case BlockValidationError::BLOCKTIME_TOO_FAR_INTO_FUTURE:
+      return "time-too-new";
     case BlockValidationError::COINBASE_TRANSACTION_AT_POSITION_OTHER_THAN_FIRST:
       return "bad-cp-out-of-order";
     case BlockValidationError::COINBASE_TRANSACTION_WITHOUT_OUTPUT:

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -357,6 +357,8 @@ BOOST_AUTO_TEST_CASE(contextualcheckblockheader_time) {
     CBlock block;
     block.nTime = 2001; // 1 unit more than the median
 
+    prev_2.phashBlock = &block.hashPrevBlock;
+
     CValidationState state;
     BOOST_CHECK(ContextualCheckBlockHeader(block, state, Params(), &prev_2, adjusted_time));
 
@@ -371,6 +373,8 @@ BOOST_AUTO_TEST_CASE(contextualcheckblockheader_time) {
     CBlockIndex prev;
     CBlock block;
     block.nTime = adjusted_time + MAX_FUTURE_BLOCK_TIME;
+
+    prev.phashBlock = &block.hashPrevBlock;
 
     CValidationState state;
     BOOST_CHECK(ContextualCheckBlockHeader(block, state, Params(), &prev, adjusted_time));

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -820,14 +820,6 @@ class FullBlockTest(ComparisonTestFramework):
         yield rejected(RejectResult(16, b'bad-txnmrklroot'))
         comp_snapshot_hash(44)
 
-        # A block with an incorrect POW limit
-        tip(44)
-        b50 = block(50)
-        b50.nBits = b50.nBits - 1
-        b50.solve()
-        yield rejected(RejectResult(16, b'bad-diffbits'))
-        comp_snapshot_hash(44)
-
         # A block with two coinbase txns
         tip(44)
         snapshot_hash = self.block_snapshot_meta[self.tip.sha256].hash


### PR DESCRIPTION
Extracted from #577.

This uses `BlockValidator::ContextualCheckBlockHeader` as a drop-in replacement in `ContextualCheckBlockHeader`. Thanks to the tests which were added by @Gnappuraz in #579 the very same tests will also check the new contextual check block.

This does remove one PoW check. All other PoW checks are still there, especially in `CheckBlockHeader`.

The new `BlockValidator::ContextualCheckBlockHeader` does invoke `BlockValidator::CheckBlockHeader` if the validation context passed in `ValidationInfo` does not know that it succeeded already. The new `BlockValidator::CheckBlockHeader` does not do a `PoW` check but it checks that the timestamp is well-formed. This check is bypassed and there's UNIT-E TODO slapped on to it.