### PR TITLE
Align interface of CheckStake with that of BlockValidator::CheckXXX

### DIFF
--- a/src/staking/stake_validator.h
+++ b/src/staking/stake_validator.h
@@ -10,6 +10,7 @@
 #include <chain.h>
 #include <dependency.h>
 #include <staking/active_chain.h>
+#include <staking/block_validation_info.h>
 #include <staking/coin.h>
 #include <staking/validation_result.h>
 #include <sync.h>
@@ -69,7 +70,8 @@ class StakeValidator {
   //! - the previos block to compute the stake modifier
   //! - the UTXO which is spent as stake
   virtual BlockValidationResult CheckStake(
-      const CBlock &  //!< [in] The block to check.
+      const CBlock &,        //!< [in] The block to check.
+      BlockValidationInfo *  //!< [in,out] Access to the validation info for this block (optional, nullptr may be passed).
       ) const = 0;
 
   //! \brief Checks whether piece of stake was used as stake before.

--- a/src/test/staking/stake_validator_tests.cpp
+++ b/src/test/staking/stake_validator_tests.cpp
@@ -74,9 +74,7 @@ BOOST_AUTO_TEST_CASE(check_stake) {
   tx.vin = {stake};
 
   LOCK(fixture.active_chain_mock.GetLock());
-  stake_validator->CheckStake(block);
-
-
+  stake_validator->CheckStake(block, nullptr);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/test_unite_mocks.h
+++ b/src/test/test_unite_mocks.h
@@ -176,7 +176,7 @@ class StakeValidatorMock : public staking::StakeValidator {
   uint256 ComputeKernelHash(const CBlockIndex *blockindex, const staking::Coin &coin, blockchain::Time time) const override {
     return computekernelfunc(blockindex, coin, time);
   }
-  staking::BlockValidationResult CheckStake(const CBlock &) const override {
+  staking::BlockValidationResult CheckStake(const CBlock &, staking::BlockValidationInfo*) const override {
     return staking::BlockValidationResult();
   }
   uint256 ComputeStakeModifier(const CBlockIndex *, const uint256 &) const override { return uint256(); }


### PR DESCRIPTION
Aligns the API of `StakeValidator::CheckStake` with the one in `BlockValidator::CheckBlock` and the like. `staking::BlockValidationInfo` was introduced in https://github.com/dtr-org/unit-e/pull/553

Signed-off-by: Julian Fleischer <julian@thirdhash.com>