### PR TITLE
Disable a few travis builds to speed us up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,16 +82,17 @@ jobs:
         GOAL="install"
         UNITE_CONFIG="--enable-reduce-exports --with-gui=no --enable-usbdevice"
 
-#    - stage: test
-#      name: "System libs (unit and functional tests)"
-#      env: >-
-#        HOST=x86_64-unknown-linux-gnu
-#        PACKAGES="python3-zmq libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libdb5.1++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev xvfb libhidapi-dev"
-#        NO_DEPENDS=1
-#        NEED_XVFB=1
-#        RUN_TESTS=true
-#        GOAL="install"
-#        UNITE_CONFIG="--enable-zmq --with-incompatible-bdb --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER --with-gui=no --enable-usbdevice"
+    - stage: test
+      name: "System libs (unit and functional tests)"
+      if: type = cron
+      env: >-
+        HOST=x86_64-unknown-linux-gnu
+        PACKAGES="python3-zmq libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libdb5.1++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev xvfb libhidapi-dev"
+        NO_DEPENDS=1
+        NEED_XVFB=1
+        RUN_TESTS=true
+        GOAL="install"
+        UNITE_CONFIG="--enable-zmq --with-incompatible-bdb --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER --with-gui=no --enable-usbdevice"
 
     - stage: test
       name: "32-bit + dash (unit and functional tests)"
@@ -105,16 +106,17 @@ jobs:
         UNITE_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++ --with-gui=no --enable-usbdevice"
         USE_SHELL="/bin/dash"
 
-#    - stage: test
-#      name: "Win64 (unit tests)"
-#      env: >-
-#        HOST=x86_64-w64-mingw32
-#        DPKG_ADD_ARCH="i386"
-#        DEP_OPTS="NO_QT=1"
-#        PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6"
-#        RUN_TESTS=true
-#        GOAL="install"
-#        UNITE_CONFIG="--enable-reduce-exports --with-gui=no --enable-usbdevice"
+    - stage: test
+      name: "Win64 (unit tests)"
+      if: type = cron
+      env: >-
+        HOST=x86_64-w64-mingw32
+        DPKG_ADD_ARCH="i386"
+        DEP_OPTS="NO_QT=1"
+        PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6"
+        RUN_TESTS=true
+        GOAL="install"
+        UNITE_CONFIG="--enable-reduce-exports --with-gui=no --enable-usbdevice"
 
     - stage: test
       name: "x86_64 Linux (unit and functional tests)"


### PR DESCRIPTION
Disables two travis builds and runs them in the daily cron job (at night) only.

- The windows 64 bit one (win32 bit should be sufficiently similar to the win64 bit build and sufficiently different form our 64-bit linux/unix machines).
- One of the builds which run functional tests. There's still a 32-bit and a 64-bit build running functional tests on linux.

Here's the documentation on conditional builds in travis:
- https://docs.travis-ci.com/user/conditional-builds-stages-jobs/

And here's the documentation on the available conditions:
- https://docs.travis-ci.com/user/conditions-v1

This is to tackle our long travis queue.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>