### PR TITLE
Add stake_amount to block index

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -198,6 +198,11 @@ public:
     //! (memory only) Total amount of work (expected number of hashes) in the chain up to and including this block
     arith_uint256 nChainWork;
 
+    //! \brief The amount of stake that was used to propose this block.
+    //!
+    //! This value is crucial for kernel and difficulty computation.
+    CAmount stake_amount;
+
     //! Number of transactions in this block.
     //! Note: in a potential headers-first mode, this number cannot be relied upon
     unsigned int nTx;
@@ -245,6 +250,7 @@ public:
         nDataPos = 0;
         nUndoPos = 0;
         nChainWork = arith_uint256();
+        stake_amount = 0;
         nTx = 0;
         nChainTx = 0;
         nStatus = 0;
@@ -420,6 +426,7 @@ public:
 
         READWRITE(stake_modifier);
         READWRITE(prevout_stake);
+        READWRITE(VARINT(stake_amount));
         READWRITE(VARINT(money_supply));
 
         if (nStatus & (BLOCK_HAVE_DATA | BLOCK_HAVE_UNDO))

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -283,6 +283,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 pindexNew->nHeight        = diskindex.nHeight;
                 pindexNew->nFile          = diskindex.nFile;
                 pindexNew->stake_modifier = diskindex.stake_modifier;
+                pindexNew->stake_amount   = diskindex.stake_amount;
                 pindexNew->prevout_stake  = diskindex.prevout_stake;
                 pindexNew->money_supply   = diskindex.money_supply;
                 pindexNew->nDataPos       = diskindex.nDataPos;


### PR DESCRIPTION
This adds `stake_amount` to block index. This value is serialized to disk.

When checking a block for validity we need to check the kernel (determines eligibility for proposing) and the difficulty. These values are affected by the amount which was used to stake the block. That amount can only be read from the transaction's CTxOut which was referred in the block's to be checked CTxIn staking input.

Also `nChainWork` is redefined as `chain_stake` and not stored in the block index. It will be recomputed every time a node starts up (just like chain work is calculated now). But in order to do so we might need to lookup CTxOut's which are no longer available (we only have the ones in the current UTXO set).

This adds 1 to 4 bytes (seldomly 5 bytes because of some VARINT overhead) of data to the block index. That's between 2MB and 8MB a year.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
