### PR TITLE
Remove money_supply and prevout_stake

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -231,12 +231,6 @@ public:
     //! Proof-of-Stake: the stake modifier is a hash of some entropy bits to make pre-computing blocks more difficult
     uint256 stake_modifier;
 
-    //! Proof-of-Stake: the previous stake (used for kernel hash and stake modifier)
-    COutPoint prevout_stake;
-
-    //! Proof-of-Stake: total money supply in the chain up to this point (used to calculate PoS-Reward)
-    CAmount money_supply;
-
     //! Vector of commits. If it's not set, node hasn't received commits for this block header
     boost::optional<std::vector<CTransactionRef>> commits;
 
@@ -425,9 +419,7 @@ public:
         READWRITE(VARINT(nTx));
 
         READWRITE(stake_modifier);
-        READWRITE(prevout_stake);
         READWRITE(VARINT(stake_amount));
-        READWRITE(VARINT(money_supply));
 
         if (nStatus & (BLOCK_HAVE_DATA | BLOCK_HAVE_UNDO))
             READWRITE(VARINT(nFile));

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -284,8 +284,6 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 pindexNew->nFile          = diskindex.nFile;
                 pindexNew->stake_modifier = diskindex.stake_modifier;
                 pindexNew->stake_amount   = diskindex.stake_amount;
-                pindexNew->prevout_stake  = diskindex.prevout_stake;
-                pindexNew->money_supply   = diskindex.money_supply;
                 pindexNew->nDataPos       = diskindex.nDataPos;
                 pindexNew->nUndoPos       = diskindex.nUndoPos;
                 pindexNew->nVersion       = diskindex.nVersion;


### PR DESCRIPTION
`money_supply` was added to block index to aid support for inflationary reward functions, like particl's. This feature (to even be able to take `MoneySupply` into consideration) was removed in https://github.com/dtr-org/unit-e/pull/423

`prevout_stake` was ported from particl. We do not need it, as we compute the stake modifier when accepting a new block and we have amount for validating (#624) and the previous blocks stake modifier (`stake_modifier` is still part of the block index and there's a ticket to recompute it in the future – https://github.com/dtr-org/unit-e/issues/535 – and we have already added it to snapshots: https://github.com/dtr-org/unit-e/pull/225)

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
