### PR TITLE
Reintroduce unconfirmed outputs check in wallet_bumpfee.py functional test

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -85,6 +85,7 @@ BASE_SCRIPTS= [
     'wallet_zapwallettxes.py',
     'esperanza_expired_vote_conflict.py',
     'wallet_importmulti.py',
+    'wallet_bumpfee.py',
     'mempool_limit.py',
     'rpc_txoutproof.py',
     'wallet_listreceivedby.py',
@@ -203,7 +204,6 @@ USBDEVICE_SCRIPTS = [
 
 # UNIT-E TODO:
 DISABLED_SCRIPTS = [
-    'wallet_bumpfee.py',
     'p2p_segwit.py',
     'feature_nulldummy.py',
     'p2p_compactblocks.py',


### PR DESCRIPTION
Test now uses msg_block p2p message instead of submitblock.

Addresses #283 #614

Signed-off-by: Mateusz Morusiewicz <mateusz@thirdhash.com>