### PR TITLE
Adjust and reintroduce rpc_preciousblock.py functional test

### DIFF
--- a/test/functional/rpc_preciousblock.py
+++ b/test/functional/rpc_preciousblock.py
@@ -10,6 +10,12 @@ from test_framework.util import (
     connect_nodes_bi,
     sync_chain,
     sync_blocks,
+    wait_until,
+    hex_str_to_bytes,
+)
+from test_framework.mininode import (
+    network_thread_start,
+    P2PInterface,
 )
 
 def unidirectional_node_sync_via_rpc(node_src, node_dest):
@@ -22,10 +28,12 @@ def unidirectional_node_sync_via_rpc(node_src, node_dest):
         except:
             blocks_to_copy.append(blockhash)
             blockhash = node_src.getblockheader(blockhash, True)['previousblockhash']
+
     blocks_to_copy.reverse()
     for blockhash in blocks_to_copy:
         blockdata = node_src.getblock(blockhash, False)
-        assert(node_dest.submitblock(blockdata) in (None, 'inconclusive'))
+        node_dest.p2p.send_data(b'block', hex_str_to_bytes(blockdata))
+        node_dest.p2p.sync_with_ping()
 
 def node_sync_via_rpc(nodes):
     for node_src in nodes:
@@ -43,6 +51,12 @@ class PreciousTest(UnitETestFramework):
         self.setup_nodes()
 
     def run_test(self):
+        for i in range(self.num_nodes):
+            self.nodes[i].add_p2p_connection(P2PInterface())
+        network_thread_start()
+
+        wait_until(lambda: all(self.nodes[i].p2p.got_verack() for i in range(self.num_nodes)), timeout=10)
+
         self.log.info("Ensure submitblock can in principle reorg to a competing chain")
         self.nodes[0].generate(1)
         assert_equal(self.nodes[0].getblockcount(), 1)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -131,6 +131,7 @@ BASE_SCRIPTS= [
     'p2p_invalid_block.py',
     'p2p_invalid_tx.py',
     'feature_versionbits_warning.py',
+    'rpc_preciousblock.py',
     'wallet_importprunedfunds.py',
     'rpc_signmessage.py',
     'feature_spend_genesis.py',
@@ -207,7 +208,6 @@ DISABLED_SCRIPTS = [
     'p2p_segwit.py',
     'feature_nulldummy.py',
     'p2p_compactblocks.py',
-    'rpc_preciousblock.py',
 ]
 
 # Place EXTENDED_SCRIPTS first since it has the 3 longest running tests


### PR DESCRIPTION
Adjusts the test to use p2p msg_block message instead of submitblock RPC call.

Addresses #283 #614

Signed-off-by: Mateusz Morusiewicz <mateusz@thirdhash.com>
