### PR TITLE
Improve the 'wait_until' error message

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -226,7 +226,6 @@ def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf'), lock=N
         message = "'%s' is still false after %d seconds" % (check_name, timeout)
     raise AssertionError(message)
 
-
 # RPC/P2P connection constants and functions
 ############################################
 


### PR DESCRIPTION
When a `wait_until(...)` check fails in a functional test, the developer is hit by an error message that looks like this:

    2019-02-22 11:27:26.110000 TestFramework (ERROR): Assertion failed
    Traceback (most recent call last):
      File "/home/mihai/work/unit-e/test/functional/test_framework/test_framework.py", line 132, in main
        self.run_test()
      File "test/functional/proposer_multiwallet.py", line 36, in run_test
        wait_until(all_have_switched_away_from_not_proposing_state, timeout=10)
      File "/home/mihai/work/unit-e/test/functional/test_framework/util.py", line 223, in wait_until
        assert_greater_than(timeout, time.time())
      File "/home/mihai/work/unit-e/test/functional/test_framework/util.py", line 43, in assert_greater_than
        raise AssertionError("%s <= %s" % (str(thing1), str(thing2)))
    AssertionError: 1550834846.0744338 <= 1550834846.1103635

I find it pretty confusing. Why are we comparing two numbers? You have to scroll back in the stacktrace to find the true cause of the error.

This PR tries to make the error message more user-friendly. Now it looks something like this:

    2019-02-22 11:49:48.160000 TestFramework (ERROR): Assertion failed
    Traceback (most recent call last):
      File "/home/mihai/work/unit-e/test/functional/test_framework/test_framework.py", line 132, in main
        self.run_test()
      File "test/functional/proposer_multiwallet.py", line 36, in run_test
        wait_until(all_have_switched_away_from_not_proposing_state, timeout=10)
      File "/home/mihai/work/unit-e/test/functional/test_framework/util.py", line 227, in wait_until
        raise AssertionError(message)
    AssertionError: 'all_have_switched_away_from_not_proposing_state' is still false after 10 seconds