### PR TITLE
Adjust and reintroduce p2p_segwit.py functional test

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -70,6 +70,7 @@ BASE_SCRIPTS= [
     'feature_bip68_sequence.py',
     'wallet_basic.py',
     'wallet_accounts.py',
+    'p2p_segwit.py',
     'p2p_embargoman_star.py',
     'esperanza_admin_full_cycle.py',
     'p2p_timeouts.py',
@@ -206,7 +207,6 @@ USBDEVICE_SCRIPTS = [
 
 # UNIT-E TODO:
 DISABLED_SCRIPTS = [
-    'p2p_segwit.py',
     'feature_nulldummy.py',
 ]
 


### PR DESCRIPTION
* test_submit_block is no longer needed, as it only checked the functionality of submitblock (automatically adding the nonce).
* in test_block_malleability checking that submitblock RPC call does not accept blocks that are too big is no longer necessary as it only checked verification of data in the RPC call, and does not have to be adjusted. The check for invalid block size is present in feature_block.py.
* test_getblocktemplate_before_lockin was checking that the getblocktemplate RPC call will not return segwit block if the node does not have segwit enabled, even if the tip is a segwit block. This check does not have a counterpart after removing the call. But this also verified the state of activation before further tests, which I recreated.

Addresses #283 #614

Signed-off-by: Mateusz Morusiewicz <mateusz@thirdhash.com>