### PR TITLE
Set block_stake_timestamp_interval_seconds to 4

### DIFF
--- a/src/blockchain/blockchain_parameters.cpp
+++ b/src/blockchain/blockchain_parameters.cpp
@@ -15,7 +15,7 @@ Parameters Parameters::MainNet() noexcept {
   Parameters p{};  // designated initializers would be so nice here
   p.network_name = "main";
 
-  p.block_stake_timestamp_interval_seconds = 16;
+  p.block_stake_timestamp_interval_seconds = 4;
   p.block_time_seconds = 16;
   p.max_future_block_time_seconds = 2 * 60 * 60;
   p.relay_non_standard_transactions = false;

--- a/src/blockchain/blockchain_parameters.h
+++ b/src/blockchain/blockchain_parameters.h
@@ -97,7 +97,7 @@ struct Parameters {
   //! \brief The usable staking timestamps
   //!
   //! The kernel protocol for Proof of Stake masks timestamps such that a proposer
-  //! can use the same stake only every blockStakeTimestampIntervalSeconds. That is:
+  //! can use the same stake only every block_stake_timestamp_interval_seconds. That is:
   //! The blocktime used to compute the kernel hash is always:
   //!
   //! kernel_hash_ingredient = current_time - (current_time % block_stake_timestamp_interval_seconds)


### PR DESCRIPTION
It can be easily proved that having `block_stake_timestamp_interval_seconds` being equal to `block_time_seconds` implies that the number of forks will be all the time equal to the number of ~proposers~ staked coins.

There are two ways to arrive to this conclusion:
1. The empirical time between blocks will be always equal or greater than `block_time_seconds`, hence the difficulty adjustment mechanism will lower the difficulty to a level where every proposer will be able to propose, independently of their stake size.

2. In the simplified case of propagation delay equal to 0, it is easy to tie the probability of being able to propose to the number of ~proposers~ staked coins (`C`) and to `m = block_time_seconds / block_stake_timestamp_interval_seconds`, the formula is `P = 1 - (1 - 1/m)^(1/C)`. The expected number of proposals per every period of `block_stake_timestamp_interval_seconds` seconds is `C * P = C * (1 - (1 - 1/m)^(1/C))`, that equals to `C` when `m == 1`.

I substituted the value by 4, although this solves the stated problem, it's still completely arbitrary. Ideally, `block_stake_timestamp_interval_seconds` should depend on the propagation delay, but it's not practical to do that because that value is too volatile and depends on a lot of external factors.

Signed-off-by: Andres Correa Casablanca <andres@thirdhash.com>