### PR TITLE
Remove `has adr` label

### DIFF
--- a/.github/labels/dtr-org-unit-e-labels.svg
+++ b/.github/labels/dtr-org-unit-e-labels.svg
@@ -27,27 +27,21 @@
       needs design
     </text>
   </g>
-  <rect x="500" y="90" width="130" height="40" fill="#aaaaaa" rx="5"/>
-  <g font-size="14" font-family="arial" fill="white">
-    <text x="513" y="116">
-      has adr
-    </text>
-  </g>
-  <rect x="650" y="90" width="130" height="40" fill="#cccccc" rx="5"/>
+  <rect x="500" y="90" width="130" height="40" fill="#cccccc" rx="5"/>
   <g font-size="14" font-family="arial" fill="black">
-    <text x="663" y="116">
+    <text x="513" y="116">
       brainstorming
     </text>
   </g>
-  <rect x="200" y="150" width="130" height="40" fill="#f7ca96" rx="5"/>
+  <rect x="650" y="90" width="130" height="40" fill="#f7ca96" rx="5"/>
   <g font-size="14" font-family="arial" fill="black">
-    <text x="213" y="176">
+    <text x="663" y="116">
       backport
     </text>
   </g>
-  <rect x="350" y="150" width="130" height="40" fill="#f7931a" rx="5"/>
+  <rect x="200" y="150" width="130" height="40" fill="#f7931a" rx="5"/>
   <g font-size="14" font-family="arial" fill="white">
-    <text x="363" y="176">
+    <text x="213" y="176">
       backported
     </text>
   </g>

--- a/.github/labels/dtr-org-unit-e-labels.yaml
+++ b/.github/labels/dtr-org-unit-e-labels.yaml
@@ -11,10 +11,6 @@ categories:
     color: '888888'
     description: 'Needs a design (possibly in a UIP) before it can be implemented'
     id: 1134722696
-  - name: has adr
-    color: 'aaaaaa'
-    description: ''
-    id: 1134741914
   - name: brainstorming
     color: 'cccccc'
     description: Needs input, ideas are welcome


### PR DESCRIPTION
There is not a clear definition of what this label means and it only was used for a few issues. So to avoid confusion let's remove the label.

I tried to come up with a clearer definition but there are so many details with things which are decided in ADRs, which go into UIPs or are just brought through pull requests that it seems to be clearer to use links to ADRs or other documents and pull requests and express what is needed in the title and text of issues.
