### PR TITLE
Set the key time to 1 for keys derived from imported seeds

### DIFF
--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -207,6 +207,7 @@ bool WalletExtension::SignCoinbaseTransaction(CMutableTransaction &tx) {
 }
 
 bool WalletExtension::SetMasterKeyFromSeed(const key::mnemonic::Seed &seed,
+                                           bool brand_new,
                                            std::string &error) {
   // Backup existing wallet before invalidating keypool
   BackupWallet();
@@ -217,6 +218,9 @@ bool WalletExtension::SetMasterKeyFromSeed(const key::mnemonic::Seed &seed,
     error = "setting master key failed";
     return false;
   }
+  // If there's a chance that the derived keys could have been used in the
+  // blockchain, set their key time to 1
+  RAIIMockTime timekeeper(1, !brand_new);
   if (!m_enclosing_wallet.NewKeyPool()) {
     error = "could not generate new keypool";
     return false;

--- a/src/esperanza/walletextension.h
+++ b/src/esperanza/walletextension.h
@@ -107,6 +107,7 @@ class WalletExtension : public staking::StakingWallet {
   proposer::State &GetProposerState() override;
 
   bool SetMasterKeyFromSeed(const key::mnemonic::Seed &seed,
+                            bool brand_new,
                             std::string &error);
 
   //! \brief Creates a deposit transaction for the given address and amount.

--- a/src/utiltime.h
+++ b/src/utiltime.h
@@ -30,4 +30,21 @@ void MilliSleep(int64_t n);
 std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime);
 std::string DateTimeToString(const int64_t time, const char* pszFormat = "%Y-%m-%d %H:%M:%S");
 
+class RAIIMockTime {
+private:
+  int64_t m_prev_mock_time;
+
+public:
+  RAIIMockTime(int64_t mock_time, bool set_time) {
+    m_prev_mock_time = GetMockTime();
+    if (set_time) {
+      SetMockTime(mock_time);
+    }
+  }
+
+  ~RAIIMockTime() {
+    SetMockTime(m_prev_mock_time);
+  }
+};
+
 #endif // UNITE_UTILTIME_H


### PR DESCRIPTION
This solves a bug I've encountered while fixing the new coinbase tests:

When importing a new master key mnemonic, the blockchain is rescanned for
transactions that are using the keys derived from this seed.

However, [the creation time](https://github.com/dtr-org/unit-e/blob/9ddab90750cceb5d9df727048d4dda0ee18c40ec/src/wallet/walletdb.h#L113) for the derived keys is still set to the current time, so
if ever we need to rescan for transactions (e.g. when the node is relaunched
with the `-zapwallettxes`), the blockchain [will only be rescanned](https://github.com/dtr-org/unit-e/blob/9ddab90750cceb5d9df727048d4dda0ee18c40ec/src/wallet/wallet.cpp#L4193) up to the
moment when the seed was imported, and any previous balance will remain
unaccounted for.

This patch sets the key time to `1` for the first 1000 keys derived after
importing a master key. The user may pass the `brand_new` parameter to the
`importmnemonic` RPC call to avoid full blockchain rescans in the future.