### PR TITLE
Adjust wallet_txn_doublespend.py to avoid sendfrom

### DIFF
--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -7,6 +7,21 @@
 from test_framework.test_framework import UnitETestFramework
 from test_framework.util import *
 
+
+def create_and_sign_tx(node, inputs, outputs):
+    """Create and sign transaction using node's RPC
+
+    Args:
+        node (TestNode): the node to sign transaction with
+        inputs (list(dict)): utxos to use as inputs in the form [{"txid": txid, "vout": vout}]
+        outputs (dict): outputs, where keys are the addresses and values the amounts
+    """
+    rawtx = node.createrawtransaction(inputs, outputs)
+    signresult = node.signrawtransaction(rawtx)
+    assert_equal(signresult["complete"], True)
+    return signresult["hex"]
+
+
 class TxnMallTest(UnitETestFramework):
     def set_test_params(self):
         self.num_nodes = 4
@@ -28,42 +43,42 @@ class TxnMallTest(UnitETestFramework):
             assert_equal(self.nodes[i].getbalance(), starting_balance)
             self.nodes[i].getnewaddress("")  # bug workaround, coins generated assigned to first getnewaddress!
 
+        foo_fund = 1219
+        bar_fund = 29
+        doublespend_amount = 1240
+        tx_fee = Decimal('-.02')
+
         # Assign coins to foo and bar accounts:
         node0_address_foo = self.nodes[0].getnewaddress("foo")
-        fund_foo_txid = self.nodes[0].sendfrom("", node0_address_foo, 1219)
+        fund_foo_txid = self.nodes[0].sendtoaddress(node0_address_foo, foo_fund)
         fund_foo_tx = self.nodes[0].gettransaction(fund_foo_txid)
 
         node0_address_bar = self.nodes[0].getnewaddress("bar")
-        fund_bar_txid = self.nodes[0].sendfrom("", node0_address_bar, 29)
+        fund_bar_txid = self.nodes[0].sendtoaddress(node0_address_bar, bar_fund)
         fund_bar_tx = self.nodes[0].gettransaction(fund_bar_txid)
 
         assert_equal(self.nodes[0].getbalance(""),
-                     starting_balance - 1219 - 29 + fund_foo_tx["fee"] + fund_bar_tx["fee"])
+                     starting_balance - foo_fund - bar_fund + fund_foo_tx["fee"] + fund_bar_tx["fee"])
 
         # Coins are sent to node1_address
         node1_address = self.nodes[1].getnewaddress("from0")
 
-        # First: use raw transaction API to send 1240 UTE to node1_address,
-        # but don't broadcast:
-        doublespend_fee = Decimal('-.02')
-        rawtx_input_0 = {}
-        rawtx_input_0["txid"] = fund_foo_txid
-        rawtx_input_0["vout"] = find_output(self.nodes[0], fund_foo_txid, 1219)
-        rawtx_input_1 = {}
-        rawtx_input_1["txid"] = fund_bar_txid
-        rawtx_input_1["vout"] = find_output(self.nodes[0], fund_bar_txid, 29)
-        inputs = [rawtx_input_0, rawtx_input_1]
-        change_address = self.nodes[0].getnewaddress()
-        outputs = {}
-        outputs[node1_address] = 1240
-        outputs[change_address] = 1248 - 1240 + doublespend_fee
-        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-        doublespend = self.nodes[0].signrawtransaction(rawtx)
-        assert_equal(doublespend["complete"], True)
+        # Make sure doublespend uses the same coins as tx1 and tx2
+        foo_coin = {"txid": fund_foo_txid, "vout": find_output(self.nodes[0], fund_foo_txid, foo_fund)}
+        bar_coin = {"txid": fund_bar_txid, "vout": find_output(self.nodes[0], fund_bar_txid, bar_fund)}
 
-        # Create two spends using 1 50 UTE coin each
-        txid1 = self.nodes[0].sendfrom("foo", node1_address, 40, 0)
-        txid2 = self.nodes[0].sendfrom("bar", node1_address, 20, 0)
+        # Use raw transaction API to send doublespend_amount UTE to node1_address, but don't broadcast:
+        inputs = [foo_coin, bar_coin]
+        change_address = self.nodes[0].getnewaddress()
+        outputs = {node1_address: doublespend_amount, change_address: foo_fund + bar_fund - doublespend_amount + tx_fee}
+        doublespend_hex = create_and_sign_tx(self.nodes[0], inputs, outputs)
+
+        # Spend the same two coins and send those transactions to node0
+        tx1_hex = create_and_sign_tx(self.nodes[0], [foo_coin], {node1_address: foo_fund + tx_fee})
+        txid1 = self.nodes[0].sendrawtransaction(tx1_hex)
+
+        tx2_hex = create_and_sign_tx(self.nodes[0], [bar_coin], {node1_address: bar_fund + tx_fee})
+        txid2 = self.nodes[0].sendrawtransaction(tx2_hex)
 
         # Have node0 mine a block:
         if (self.options.mine_block):
@@ -74,16 +89,19 @@ class TxnMallTest(UnitETestFramework):
         tx2 = self.nodes[0].gettransaction(txid2)
 
         # Node0's balance should be starting balance, plus 50UTE for another
-        # matured block, minus 40, minus 20, and minus transaction fees:
+        # matured block, minus what was sent to node1, and minus transaction fees:
         expected = starting_balance + fund_foo_tx["fee"] + fund_bar_tx["fee"]
         if self.options.mine_block: expected += 50
         expected += tx1["amount"] + tx1["fee"]
         expected += tx2["amount"] + tx2["fee"]
         assert_equal(self.nodes[0].getbalance(), expected)
 
-        # foo and bar accounts should be debited:
-        assert_equal(self.nodes[0].getbalance("foo", 0), 1219+tx1["amount"]+tx1["fee"])
-        assert_equal(self.nodes[0].getbalance("bar", 0), 29+tx2["amount"]+tx2["fee"])
+        # Verify that node1 has the correct funds
+        expected = starting_balance
+        if self.options.mine_block:
+            # Amounts are negative as they come from node0
+            expected -= tx1["amount"] + tx2["amount"]
+        assert_equal(self.nodes[1].getbalance(), expected)
 
         if self.options.mine_block:
             assert_equal(tx1["confirmations"], 1)
@@ -97,7 +115,7 @@ class TxnMallTest(UnitETestFramework):
         # Now give doublespend and its parents to miner:
         self.nodes[2].sendrawtransaction(fund_foo_tx["hex"])
         self.nodes[2].sendrawtransaction(fund_bar_tx["hex"])
-        doublespend_txid = self.nodes[2].sendrawtransaction(doublespend["hex"])
+        doublespend_txid = self.nodes[2].sendrawtransaction(doublespend_hex)
         # ... mine a block...
         self.nodes[2].generate(1)
 
@@ -111,32 +129,24 @@ class TxnMallTest(UnitETestFramework):
         tx1 = self.nodes[0].gettransaction(txid1)
         tx2 = self.nodes[0].gettransaction(txid2)
 
-        # Both transactions should be conflicted
+        # Both transactions should be conflicted, as they spend the same coins as doublespend, that node2 mined
         assert_equal(tx1["confirmations"], -2)
         assert_equal(tx2["confirmations"], -2)
 
         # Node0's total balance should be starting balance, plus 100UTE for
-        # two more matured blocks, minus 1240 for the double-spend, plus fees (which are
-        # negative):
-        expected = starting_balance + 100 - 1240 + fund_foo_tx["fee"] + fund_bar_tx["fee"] + doublespend_fee
+        # two more matured blocks (COINBASE_MATURITY deep), minus 1240 for the double-spend,
+        # plus fees (which are negative):
+        expected = starting_balance + 100 - doublespend_amount + fund_foo_tx["fee"] + fund_bar_tx["fee"] + tx_fee
         assert_equal(self.nodes[0].getbalance(), expected)
         assert_equal(self.nodes[0].getbalance("*"), expected)
 
-        # Final "" balance is starting_balance - amount moved to accounts - doublespend + subsidies +
-        # fees (which are negative)
-        assert_equal(self.nodes[0].getbalance("foo"), 1219)
-        assert_equal(self.nodes[0].getbalance("bar"), 29)
-        assert_equal(self.nodes[0].getbalance(""), starting_balance
-                                                              -1219
-                                                              -  29
-                                                              -1240
-                                                              + 100
-                                                              + fund_foo_tx["fee"]
-                                                              + fund_bar_tx["fee"]
-                                                              + doublespend_fee)
+        # Final "" balance is the node's total balance minus funds sent to "foo" and "bar"
+        assert_equal(self.nodes[0].getbalance("foo"), foo_fund)
+        assert_equal(self.nodes[0].getbalance("bar"), bar_fund)
+        assert_equal(self.nodes[0].getbalance(""), expected - foo_fund - bar_fund)
 
         # Node1's "from0" account balance should be just the doublespend:
-        assert_equal(self.nodes[1].getbalance("from0"), 1240)
+        assert_equal(self.nodes[1].getbalance("from0"), doublespend_amount)
 
 if __name__ == '__main__':
     TxnMallTest().main()


### PR DESCRIPTION
sendfrom does not guarantee anything when used with accounts and
this test heavily depends on a specific coins to be used.

The transactions should be made manually. 

Signed-off-by: Mateusz Morusiewicz <mateusz@thirdhash.com>