### PR TITLE
Init parameters from blockchain::Behavior

### DIFF
--- a/src/blockchain/blockchain_behavior.cpp
+++ b/src/blockchain/blockchain_behavior.cpp
@@ -99,7 +99,7 @@ std::unique_ptr<Behavior> Behavior::NewForNetwork(Network network) {
     case Network::regtest:
       return NewFromParameters(Parameters::RegTest());
   }
-  assert(false && "silence gcc warnings");
+  assert(!"silence gcc warnings");
 }
 
 std::unique_ptr<Behavior> Behavior::NewFromParameters(const Parameters &parameters) {
@@ -113,8 +113,9 @@ namespace {
 std::unique_ptr<Behavior> g_blockchain_behavior;
 }  // namespace
 
-void Behavior::MakeGlobal(Dependency<::ArgsManager> args) {
+Dependency<blockchain::Behavior> Behavior::MakeGlobal(Dependency<::ArgsManager> args) {
   SetGlobal(New(args));
+  return g_blockchain_behavior.get();
 }
 
 void Behavior::SetGlobal(std::unique_ptr<Behavior> &&behavior) {

--- a/src/blockchain/blockchain_behavior.h
+++ b/src/blockchain/blockchain_behavior.h
@@ -88,7 +88,7 @@ class Behavior {
   static std::unique_ptr<Behavior> NewFromParameters(const Parameters &);
 
   //! \brief stopgap to replace global Params() accessor function
-  static void MakeGlobal(Dependency<::ArgsManager>);
+  static Dependency<blockchain::Behavior> MakeGlobal(Dependency<::ArgsManager>);
 
   //! \brief stopgap to replace global Params() accessor function
   static Behavior &GetGlobal();

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -6,9 +6,11 @@
 #ifndef UNITE_CHAINPARAMS_H
 #define UNITE_CHAINPARAMS_H
 
+#include <blockchain/blockchain_behavior.h>
 #include <blockchain/blockchain_parameters.h>
 #include <chainparamsbase.h>
 #include <consensus/params.h>
+#include <dependency.h>
 #include <primitives/block.h>
 #include <protocol.h>
 #include <esperanza/adminparams.h>
@@ -67,7 +69,7 @@ public:
     const blockchain::Parameters parameters;
 
 protected:
-    explicit CChainParams(const blockchain::Parameters& _parameters) : parameters(_parameters) {}
+    explicit CChainParams(const blockchain::Parameters &parameters) : parameters(parameters) {}
 
     Consensus::Params consensus;
     esperanza::FinalizationParams finalization;
@@ -87,6 +89,7 @@ protected:
  * @returns a CChainParams* of the chosen chain.
  * @throws a std::runtime_error if the chain is not supported.
  */
+std::unique_ptr<CChainParams> CreateChainParams(Dependency<blockchain::Behavior>, const std::string& chain);
 std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain);
 
 /**
@@ -99,7 +102,7 @@ const CChainParams &Params();
  * Sets the params returned by Params() to those for the given BIP70 chain name.
  * @throws std::runtime_error when the chain is not supported.
  */
-void SelectParams(const std::string& chain);
+void SelectParams(Dependency<blockchain::Behavior>, const std::string& chain);
 
 /**
  * Allows modifying the Version Bits regtest parameters.

--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -502,7 +502,7 @@ void WalletExtension::VoteIfNeeded(const FinalizationState &state) {
     // TODO: UNIT-E: must not happen once the following issue is implemented:
     // https://github.com/dtr-org/unit-e/issues/570
     // for now only instant finalization is possible for the first epoch
-    assert(false && "recommended target must be set!");
+    assert(!"recommended target must be set!");
   }
 
   const uint32_t target_epoch = state.GetEpoch(*target);

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -151,5 +151,5 @@ bool CTransaction::IsFinalizationTransaction() const {
     case +TxType::COINBASE:
         return false;
     }
-    assert(false && "silence gcc warnings");
+    assert(!"silence gcc warnings");
 }

--- a/src/staking/validation_error.cpp
+++ b/src/staking/validation_error.cpp
@@ -132,7 +132,7 @@ const ValidationError &GetValidationErrorFor(const staking::BlockValidationError
       return err;
     }
   }
-  assert(false && "silence gcc warnings");
+  assert(!"silence gcc warnings");
 }
 
 }  // namespace

--- a/src/test/test_unite.cpp
+++ b/src/test/test_unite.cpp
@@ -83,7 +83,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName) : ReducedTest
 {
         blockchain::Behavior::SetGlobal(blockchain::Behavior::NewForNetwork(blockchain::Network::_from_string(chainName.c_str())));
         UnitEInjector::Init();
-        SelectParams(chainName);
+        SelectParams(GetComponent(BlockchainBehavior), chainName);
 }
 
 fs::path BasicTestingSetup::SetDataDir(const std::string& name)

--- a/src/unite-tx.cpp
+++ b/src/unite-tx.cpp
@@ -46,8 +46,7 @@ static int AppInitRawTx(int argc, char* argv[])
 
     // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
     try {
-        blockchain::Behavior::MakeGlobal(&gArgs);
-        SelectParams(ChainNameFromCommandLine());
+        SelectParams(blockchain::Behavior::MakeGlobal(&gArgs), ChainNameFromCommandLine());
     } catch (const std::exception& e) {
         fprintf(stderr, "Error: %s\n", e.what());
         return EXIT_FAILURE;

--- a/src/united.cpp
+++ b/src/united.cpp
@@ -102,8 +102,7 @@ bool AppInit(int argc, char* argv[])
         }
         // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
         try {
-            blockchain::Behavior::MakeGlobal(&gArgs);
-            SelectParams(ChainNameFromCommandLine());
+            SelectParams(blockchain::Behavior::MakeGlobal(&gArgs), ChainNameFromCommandLine());
         } catch (const std::exception& e) {
             fprintf(stderr, "Error: %s\n", e.what());
             return false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -572,7 +572,7 @@ static BCLog::LogFlags GetTransactionLogCategory(const CTransaction &tx) {
     case +TxType::ADMIN:
         return BCLog::ADMIN;
     }
-    assert(false && "silence gcc warnings");
+    assert(!"silence gcc warnings");
 }
 
 static bool ContextualCheckFinalizationTx(const CTransaction &tx, CValidationState &err_state,


### PR DESCRIPTION
Follow up to #679 – this takes the `blockchain::Parameters` in `CChainParams` from `blockchain::Behavior` which is initialized in the same place as the global chain params, namely where `SelectParams` is invoked (which creates the global chain params).

This is a bit of a patch work, one step in the journey of getting rid of the `CChainParams` in favor of `blockchain::Parameters`.

This is a follow up to #679 as it actually allows to use the injected parameters in tests. #702 activates the new genesis block which will then also be injectable.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>

