### PR TITLE
tests: Allow closed http server in assert_start_raises_init_error

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -126,7 +126,9 @@ class TestNode():
                 if e.errno != errno.ECONNREFUSED:  # Port not yet open?
                     raise  # unknown IO error
             except JSONRPCException as e:  # Initialization phase
-                if e.error['code'] != -28:  # RPC in warmup?
+                # -28 RPC in warmup
+                # -342 Service unavailable, RPC server started but is shutting down due to error
+                if e.error['code'] != -28 and e.error['code'] != -342:
                     raise  # unknown JSON RPC exception
             except ValueError as e:  # cookie file not found and no rpcuser or rpcassword. united still starting
                 if "No RPC credentials" not in str(e):


### PR DESCRIPTION
Fixes #708
This is a port of [bitcoin/bitcoin#14413](https://github.com/bitcoin/bitcoin/pull/14275)

This fix allows an HTTP server to ignore unregistered RPC handler.

Test run: https://travis-ci.com/dsaveliev/unit-e/builds/102838255

Signed-off-by: Dmitry Saveliev [dima@thirdhash.com](mailto:dima@thirdhash.com)