### PR TITLE
Fix IsSpent for PoS coinbase

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -682,7 +682,7 @@ bool CWallet::IsSpent(const uint256& hash, unsigned int n) const
         std::map<uint256, CWalletTx>::const_iterator mit = mapWallet.find(wtxid);
         if (mit != mapWallet.end()) {
             int depth = mit->second.GetDepthInMainChain();
-            if (depth > 0  || (depth == 0 && !mit->second.isAbandoned())) {
+            if (depth > 0  || (depth == 0 && !mit->second.isAbandoned() && !mit->second.IsCoinBase())) {
                 return true; // Spent
             }
         }


### PR DESCRIPTION
In case of a reorg, the coinbases were not handled properly.

In bitcoin it does not matter, as the coinbase never spends anything.

Once we start having inputs in coinbases, this check fails when the
depth is 0 (block that the coinbase in question is in is no longer part
of the current chain), as it marks coins as spent by this coinbase,
even though it should not, as the coinbase will not be applied as
the transactions in mempool (previous isAbandoned check).

Signed-off-by: Mateusz Morusiewicz <mateusz@thirdhash.com>