### PR TITLE
Disable transaction_tests/tx_valid by other means than boost::disabled()

### DIFF
--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -95,10 +95,8 @@ BOOST_FIXTURE_TEST_SUITE(transaction_tests, ReducedTestingSetup)
 
 BOOST_AUTO_TEST_CASE(tx_valid)
 {
-    if (false) { // poor mans boost;:unit_test::disabled() which is not available on all platforms
-        //UNIT-E TODO: Re enable the test after having properly changed tx_valid.json
-        return;
-    }
+    //UNIT-E TODO: Re enable the test after having properly changed tx_valid.json
+    return;
 
     // Read tests from test/data/tx_valid.json
     // Format is an array of arrays


### PR DESCRIPTION
The cron job in our CI failed: https://travis-ci.com/dtr-org/unit-e/jobs/182622706 . It builds a build using system libs which contain an older version of boost which does not provide the `disabled()` decorator.

`transaction_tests/tx_valid` was disabled using the boost unit test `disabled()` decorator in https://github.com/dtr-org/unit-e/pull/714 . There is a ticket for fixing and enabling the test: #725

In the pull request discussion the debate was whether to comment out the test using a combination of `/*` and `*/` or each line by `//`. It is my belief that code should never be commented out. Either remove it or don't. Tests are sometimes to be disabled, but also then commenting it out might just lead to it getting broken even more by static code changes which are no longer checked for commented out code. Hence my desire to disable it.

boost provides such functionality but it is (a) not available in the system libs in one particular travis build which only runs in CRON and (b) it is ignored when running just that test suite using `--run_test`, so gives misleading results.

As an interim I'm just skipping out of the test. It's supposed to be enabled soon anyway.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>