### PR TITLE
Eliminate the IBD state in 'wallet_txn_doublespend.py' test

### DIFF
--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -25,6 +25,7 @@ def create_and_sign_tx(node, inputs, outputs):
 class TxnMallTest(UnitETestFramework):
     def set_test_params(self):
         self.num_nodes = 4
+        self.extra_args = [['-maxtipage=1000000000']] * self.num_nodes
 
     def add_options(self, parser):
         parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",


### PR DESCRIPTION
Fixes #505 

The problem with this test is that nodes sometimes fall into IBD and hence ignore all "getheaders" messages durign block sync:
```
 node0 2019-03-04 16:24:46.451494 [         net] initial getheaders (199) to peer=0 (startheight:200) 
 node0 2019-03-04 16:24:46.451537 [         net] sending getheaders (645 bytes) peer=0 
 node1 2019-03-04 16:24:46.452196 [         net] initial getheaders (199) to peer=0 (startheight:200) 
 node1 2019-03-04 16:24:46.452245 [         net] sending getheaders (645 bytes) peer=0 
 node1 2019-03-04 16:24:46.452862 [         net] received: getheaders (645 bytes) peer=0 
 node1 2019-03-04 16:24:46.452893 [         net] Ignoring getheaders from peer=0 because node is in initial block download 
 node0 2019-03-04 16:24:46.453559 [         net] received: getheaders (645 bytes) peer=0 
 node0 2019-03-04 16:24:46.453592 [         net] Ignoring getheaders from peer=0 because node is in initial block download 
 ...
```
It happens when the local chain cache becomes old enough and nodes try to actualize their chain.

The bitcoin codebase contains a bugfix for this issue - https://github.com/bitcoin/bitcoin/pull/15419,
but it involves **submitblock** call, which was deleted from unit-e by https://github.com/dtr-org/unit-e/pull/273

As an alternative solution, I've increased **maxtipage** param to escape IBD.

Test runs: 
https://travis-ci.com/dsaveliev/unit-e/builds/103394223
https://travis-ci.com/dsaveliev/unit-e/builds/103395976
https://travis-ci.com/dsaveliev/unit-e/builds/103396008
https://travis-ci.com/dsaveliev/unit-e/builds/103396043

Signed-off-by: Dmitry Saveliev <dima@thirdhash.com>