### PR TITLE
Fix p2p_sendheaders race

### DIFF
--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -314,6 +314,7 @@ class SendHeadersTest(UnitETestFramework):
                 test_node.clear_block_announcements()  # since we requested headers...
             elif i == 2:
                 # this time announce own block via headers
+                inv_node.clear_block_announcements()
                 height = self.nodes[0].getblockcount()
                 last_time = self.nodes[0].getblock(self.nodes[0].getbestblockhash())['time']
                 block_time = last_time + 1
@@ -324,6 +325,7 @@ class SendHeadersTest(UnitETestFramework):
                 test_node.wait_for_getdata([new_block.sha256])
                 test_node.send_message(msg_block(new_block))
                 test_node.sync_with_ping()  # make sure this block is processed
+                wait_until(lambda: inv_node.block_announced, timeout=60, lock=mininode_lock)
                 inv_node.clear_block_announcements()
                 test_node.clear_block_announcements()
 


### PR DESCRIPTION
Fixes #586 
This is a port of https://github.com/bitcoin/bitcoin/pull/13522

There is a race between **inv** messages in p2p connection to the test node.

Test runs:
https://travis-ci.com/dsaveliev/unit-e/builds/103828612
https://travis-ci.com/dsaveliev/unit-e/builds/103830184