### PR TITLE
Factor out finalization state check function

### DIFF
--- a/test/functional/feature_fork_choice_finalization.py
+++ b/test/functional/feature_fork_choice_finalization.py
@@ -12,6 +12,7 @@ ForkChoiceFinalizationTest checks:
 from test_framework.test_framework import UnitETestFramework
 from test_framework.util import (
     connect_nodes,
+    check_finalization,
     disconnect_nodes,
     assert_equal,
     sync_blocks,
@@ -98,11 +99,11 @@ class ForkChoiceFinalizationTest(UnitETestFramework):
         #       F     F     F      J                  tip
         node0.generatetoaddress(29, node0.getnewaddress())
         assert_equal(node0.getblockcount(), 30)
-        assert_equal(node0.getfinalizationstate()['currentDynasty'], 4)
-        assert_equal(node0.getfinalizationstate()['currentEpoch'], 6)
-        assert_equal(node0.getfinalizationstate()['lastJustifiedEpoch'], 4)
-        assert_equal(node0.getfinalizationstate()['lastFinalizedEpoch'], 3)
-        assert_equal(node0.getfinalizationstate()['validators'], 1)
+        check_finalization(node0, {'currentDynasty': 4,
+                                   'currentEpoch': 6,
+                                   'lastJustifiedEpoch': 4,
+                                   'lastFinalizedEpoch': 3,
+                                   'validators': 1})
 
         connect_nodes(node0, node1.index)
         connect_nodes(node0, node2.index)
@@ -180,19 +181,19 @@ class ForkChoiceFinalizationTest(UnitETestFramework):
         # leave instant justification
         fork1.generatetoaddress(3 + 5 + 5 + 5 + 5 + 1, fork1.getnewaddress())
         assert_equal(fork1.getblockcount(), 25)
-        assert_equal(fork1.getfinalizationstate()['currentDynasty'], 3)
-        assert_equal(fork1.getfinalizationstate()['currentEpoch'], 5)
-        assert_equal(fork1.getfinalizationstate()['lastJustifiedEpoch'], 4)
-        assert_equal(fork1.getfinalizationstate()['lastFinalizedEpoch'], 3)
-        assert_equal(fork1.getfinalizationstate()['validators'], 1)
+        check_finalization(fork1, {'currentDynasty': 3,
+                                   'currentEpoch': 5,
+                                   'lastJustifiedEpoch': 4,
+                                   'lastFinalizedEpoch': 3,
+                                   'validators': 1})
 
         wait_until(lambda: len(fork1.getrawmempool()) == 1, timeout=10)
         fork1.generatetoaddress(4, fork1.getnewaddress())
         assert_equal(fork1.getblockcount(), 29)
-        assert_equal(fork1.getfinalizationstate()['currentDynasty'], 3)
-        assert_equal(fork1.getfinalizationstate()['currentEpoch'], 5)
-        assert_equal(fork1.getfinalizationstate()['lastJustifiedEpoch'], 4)
-        assert_equal(fork1.getfinalizationstate()['lastFinalizedEpoch'], 3)
+        check_finalization(fork1, {'currentDynasty': 3,
+                                   'currentEpoch': 5,
+                                   'lastJustifiedEpoch': 4,
+                                   'lastFinalizedEpoch': 3})
 
         # justify epoch=5
         # J
@@ -201,10 +202,10 @@ class ForkChoiceFinalizationTest(UnitETestFramework):
         wait_until(lambda: len(fork1.getrawmempool()) == 1, timeout=10)
         fork1.generatetoaddress(4, fork1.getnewaddress())
         assert_equal(fork1.getblockcount(), 34)
-        assert_equal(fork1.getfinalizationstate()['currentDynasty'], 4)
-        assert_equal(fork1.getfinalizationstate()['currentEpoch'], 6)
-        assert_equal(fork1.getfinalizationstate()['lastJustifiedEpoch'], 5)
-        assert_equal(fork1.getfinalizationstate()['lastFinalizedEpoch'], 4)
+        check_finalization(fork1, {'currentDynasty': 4,
+                                   'currentEpoch': 6,
+                                   'lastJustifiedEpoch': 5,
+                                   'lastFinalizedEpoch': 4})
 
         # create two forks at epoch=6 that use the same votes to justify epoch=5
         #             fork3
@@ -220,10 +221,10 @@ class ForkChoiceFinalizationTest(UnitETestFramework):
         for fork in [fork1, fork2]:
             wait_until(lambda: len(fork.getrawmempool()) == 1, timeout=10)
             assert_equal(fork.getblockcount(), 35)
-            assert_equal(fork.getfinalizationstate()['currentDynasty'], 5)
-            assert_equal(fork.getfinalizationstate()['currentEpoch'], 7)
-            assert_equal(fork.getfinalizationstate()['lastJustifiedEpoch'], 5)
-            assert_equal(fork.getfinalizationstate()['lastFinalizedEpoch'], 4)
+            check_finalization(fork, {'currentDynasty': 5,
+                                      'currentEpoch': 7,
+                                      'lastJustifiedEpoch': 5,
+                                      'lastFinalizedEpoch': 4})
 
         disconnect_nodes(fork1, fork2.index)
         vote = fork1.getrawtransaction(fork1.getrawmempool()[0])
@@ -231,10 +232,10 @@ class ForkChoiceFinalizationTest(UnitETestFramework):
         for fork in [fork1, fork2]:
             fork.generatetoaddress(1, fork.getnewaddress())
             assert_equal(fork.getblockcount(), 36)
-            assert_equal(fork.getfinalizationstate()['currentDynasty'], 5)
-            assert_equal(fork.getfinalizationstate()['currentEpoch'], 7)
-            assert_equal(fork.getfinalizationstate()['lastJustifiedEpoch'], 6)
-            assert_equal(fork.getfinalizationstate()['lastFinalizedEpoch'], 5)
+            check_finalization(fork, {'currentDynasty': 5,
+                                      'currentEpoch': 7,
+                                      'lastJustifiedEpoch': 6,
+                                      'lastFinalizedEpoch': 5})
 
         b37 = fork2.generatetoaddress(1, fork2.getnewaddress())[0]
 
@@ -249,10 +250,10 @@ class ForkChoiceFinalizationTest(UnitETestFramework):
 
         assert_equal(fork1.getblockcount(), 37)
         assert_equal(fork1.getblockhash(37), b37)
-        assert_equal(fork1.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(fork1.getfinalizationstate()['currentEpoch'], 7)
-        assert_equal(fork1.getfinalizationstate()['lastJustifiedEpoch'], 6)
-        assert_equal(fork1.getfinalizationstate()['lastFinalizedEpoch'], 5)
+        check_finalization(fork1, {'currentDynasty': 5,
+                                   'currentEpoch': 7,
+                                   'lastJustifiedEpoch': 6,
+                                   'lastFinalizedEpoch': 5})
 
         disconnect_nodes(fork1, fork2.index)
 
@@ -274,10 +275,10 @@ class ForkChoiceFinalizationTest(UnitETestFramework):
 
         assert_equal(fork1.getblockcount(), 39)
         assert_equal(fork1.getblockhash(39), b39)
-        assert_equal(fork1.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(fork1.getfinalizationstate()['currentEpoch'], 7)
-        assert_equal(fork1.getfinalizationstate()['lastJustifiedEpoch'], 6)
-        assert_equal(fork1.getfinalizationstate()['lastFinalizedEpoch'], 5)
+        check_finalization(fork1, {'currentDynasty': 5,
+                                   'currentEpoch': 7,
+                                   'lastJustifiedEpoch': 6,
+                                   'lastFinalizedEpoch': 5})
 
         self.stop_node(fork1.index)
         self.stop_node(fork2.index)

--- a/test/functional/feature_fork_choice_forked_finalize_epoch.py
+++ b/test/functional/feature_fork_choice_forked_finalize_epoch.py
@@ -29,6 +29,7 @@ from test_framework.test_framework import UnitETestFramework
 from test_framework.regtest_mnemonics import regtest_mnemonics
 from test_framework.util import (
     connect_nodes,
+    check_finalization,
     disconnect_nodes,
     sync_blocks,
     assert_equal,
@@ -96,11 +97,11 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         node.generatetoaddress(2 + 5 + 5 + 5 + 5 + 5, node.getnewaddress())
         sync_blocks([node, fork])
         assert_equal(node.getblockcount(), 29)
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 3)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 5)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 4)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 3)
-        assert_equal(node.getfinalizationstate()['validators'], 1)
+        check_finalization(node, {'currentDynasty': 3,
+                                  'currentEpoch': 5,
+                                  'lastJustifiedEpoch': 4,
+                                  'lastFinalizedEpoch': 3,
+                                  'validators': 1})
 
         # create longer justified fork
         # [ e5 ] node
@@ -114,10 +115,10 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         fork.generatetoaddress(1, fork.getnewaddress())
         disconnect_nodes(fork, finalizer2.index)
         assert_equal(fork.getblockcount(), 41)
-        assert_equal(fork.getfinalizationstate()['currentDynasty'], 4)
-        assert_equal(fork.getfinalizationstate()['currentEpoch'], 8)
-        assert_equal(fork.getfinalizationstate()['lastJustifiedEpoch'], 7)
-        assert_equal(fork.getfinalizationstate()['lastFinalizedEpoch'], 3)
+        check_finalization(fork, {'currentDynasty': 4,
+                                  'currentEpoch': 8,
+                                  'lastJustifiedEpoch': 7,
+                                  'lastFinalizedEpoch': 3})
 
         # create finalization
         #   J
@@ -131,10 +132,10 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         wait_until(lambda: len(node.getrawmempool()) > 0, timeout=10)
         node.generatetoaddress(4, node.getnewaddress())
         assert_equal(node.getblockcount(), 34)
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 4)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 6)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 5)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 4)
+        check_finalization(node, {'currentDynasty': 4,
+                                  'currentEpoch': 6,
+                                  'lastJustifiedEpoch': 5,
+                                  'lastFinalizedEpoch': 4})
 
         #   F        J
         # [ e5 ] - [ e6 ] - [ e7 ] node
@@ -145,10 +146,10 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         wait_until(lambda: len(node.getrawmempool()) > 0, timeout=10)
         node.generatetoaddress(4, node.getnewaddress())
         assert_equal(node.getblockcount(), 39)
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 7)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 6)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 5)
+        check_finalization(node, {'currentDynasty': 5,
+                                  'currentEpoch': 7,
+                                  'lastJustifiedEpoch': 6,
+                                  'lastFinalizedEpoch': 5})
 
         disconnect_nodes(node, finalizer1.index)
 
@@ -157,10 +158,10 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         time.sleep(5)  # give enough time to decide
 
         assert_equal(node.getblockcount(), 39)
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 7)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 6)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 5)
+        check_finalization(node, {'currentDynasty': 5,
+                                  'currentEpoch': 7,
+                                  'lastJustifiedEpoch': 6,
+                                  'lastFinalizedEpoch': 5})
 
         # TODO: UNIT-E: check that slash transaction was created
         # related issue: #680 #652 #686
@@ -168,10 +169,10 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         # test that node has valid state after restart
         self.restart_node(node.index)
         assert_equal(node.getblockcount(), 39)
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 7)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 6)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 5)
+        check_finalization(node, {'currentDynasty': 5,
+                                  'currentEpoch': 7,
+                                  'lastJustifiedEpoch': 6,
+                                  'lastFinalizedEpoch': 5})
 
         # cleanup
         self.stop_node(node.index)
@@ -219,11 +220,11 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         node.generatetoaddress(2 + 5 + 5 + 5 + 5 + 5, node.getnewaddress())
         sync_blocks([node, fork])
         assert_equal(node.getblockcount(), 29)
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 3)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 5)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 4)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 3)
-        assert_equal(node.getfinalizationstate()['validators'], 1)
+        check_finalization(node, {'currentDynasty': 3,
+                                  'currentEpoch': 5,
+                                  'lastJustifiedEpoch': 4,
+                                  'lastFinalizedEpoch': 3,
+                                  'validators': 1})
 
         # justify epoch that will be finalized
         #       F        J
@@ -234,10 +235,10 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         node.generatetoaddress(4, node.getnewaddress())
         sync_blocks([node, fork])
         assert_equal(node.getblockcount(), 34)
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 4)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 6)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 5)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 4)
+        check_finalization(node, {'currentDynasty': 4,
+                                  'currentEpoch': 6,
+                                  'lastJustifiedEpoch': 5,
+                                  'lastFinalizedEpoch': 4})
 
         # create fork that will be longer justified
         #       F        J
@@ -248,10 +249,10 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         disconnect_nodes(node, fork.index)
         fork.generatetoaddress(5 + 5, fork.getnewaddress())
         assert_equal(fork.getblockcount(), 44)
-        assert_equal(fork.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(fork.getfinalizationstate()['currentEpoch'], 8)
-        assert_equal(fork.getfinalizationstate()['lastJustifiedEpoch'], 5)
-        assert_equal(fork.getfinalizationstate()['lastFinalizedEpoch'], 4)
+        check_finalization(fork, {'currentDynasty': 5,
+                                  'currentEpoch': 8,
+                                  'lastJustifiedEpoch': 5,
+                                  'lastFinalizedEpoch': 4})
 
         # create longer justification
         #       F        J
@@ -264,10 +265,10 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         wait_until(lambda: len(fork.getrawmempool()) > 0, timeout=10)
         fork.generatetoaddress(4, fork.getnewaddress())
         assert_equal(fork.getblockcount(), 49)
-        assert_equal(fork.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(fork.getfinalizationstate()['currentEpoch'], 9)
-        assert_equal(fork.getfinalizationstate()['lastJustifiedEpoch'], 8)
-        assert_equal(fork.getfinalizationstate()['lastFinalizedEpoch'], 4)
+        check_finalization(fork, {'currentDynasty': 5,
+                                  'currentEpoch': 9,
+                                  'lastJustifiedEpoch': 8,
+                                  'lastFinalizedEpoch': 4})
         disconnect_nodes(fork, finalizer2.index)
 
         # finalize epoch=5 on node
@@ -280,20 +281,20 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         wait_until(lambda: len(node.getrawmempool()) > 0, timeout=10)
         node.generatetoaddress(1, node.getnewaddress())
         assert_equal(node.getblockcount(), 36)
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 7)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 6)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 5)
+        check_finalization(node, {'currentDynasty': 5,
+                                  'currentEpoch': 7,
+                                  'lastJustifiedEpoch': 6,
+                                  'lastFinalizedEpoch': 5})
         disconnect_nodes(node, finalizer1.index)
 
         # node shouldn't switch to fork as it's finalization is behind
         connect_nodes(node, fork.index)
         time.sleep(5)
         assert_equal(node.getblockcount(), 36)
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 7)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 6)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 5)
+        check_finalization(node, {'currentDynasty': 5,
+                                  'currentEpoch': 7,
+                                  'lastJustifiedEpoch': 6,
+                                  'lastFinalizedEpoch': 5})
 
         # TODO: UNIT-E: check that slash transaction was created
         # related issue: #680 #652 #686
@@ -301,10 +302,10 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         # test that node has valid state after restart
         self.restart_node(node.index)
         assert_equal(node.getblockcount(), 36)
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 7)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 6)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 5)
+        check_finalization(node, {'currentDynasty': 5,
+                                  'currentEpoch': 7,
+                                  'lastJustifiedEpoch': 6,
+                                  'lastFinalizedEpoch': 5})
 
         # cleanup
         self.stop_node(node.index)

--- a/test/functional/feature_fork_choice_parallel_justifications.py
+++ b/test/functional/feature_fork_choice_parallel_justifications.py
@@ -20,6 +20,7 @@ from test_framework.mininode import (
 
 from test_framework.util import (
     connect_nodes,
+    check_finalization,
     disconnect_nodes,
     assert_equal,
     sync_blocks,
@@ -138,11 +139,11 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
         #                             fork2
         node.generatetoaddress(26, node.getnewaddress())
         assert_equal(node.getblockcount(), 29)
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 3)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 5)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 4)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 3)
-        assert_equal(node.getfinalizationstate()['validators'], 1)
+        check_finalization(node, {'currentDynasty': 3,
+                                  'currentEpoch': 5,
+                                  'lastJustifiedEpoch': 4,
+                                  'lastFinalizedEpoch': 3,
+                                  'validators': 1})
 
         connect_nodes(node, fork1.index)
         connect_nodes(node, fork2.index)
@@ -162,17 +163,17 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
         # e5 is justified for fork1
         create_justification(fork=fork1, finalizer=finalizer1, after_blocks=2)
         assert_equal(fork1.getblockcount(), 31)
-        assert_equal(fork1.getfinalizationstate()['currentDynasty'], 4)
-        assert_equal(fork1.getfinalizationstate()['currentEpoch'], 6)
-        assert_equal(fork1.getfinalizationstate()['lastJustifiedEpoch'], 5)
-        assert_equal(fork1.getfinalizationstate()['lastFinalizedEpoch'], 4)
+        check_finalization(fork1, {'currentDynasty': 4,
+                                   'currentEpoch': 6,
+                                   'lastJustifiedEpoch': 5,
+                                   'lastFinalizedEpoch': 4})
 
         sync_node_to_fork(node, fork1)
 
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 4)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 6)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 5)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 4)
+        check_finalization(node, {'currentDynasty': 4,
+                                  'currentEpoch': 6,
+                                  'lastJustifiedEpoch': 5,
+                                  'lastFinalizedEpoch': 4})
 
         self.log.info('node successfully switched to the justified fork')
 
@@ -186,24 +187,24 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
         #                             - e6 - e7 - e8 fork2, node
         create_justification(fork=fork2, finalizer=finalizer2, after_blocks=2)
         assert_equal(fork2.getblockcount(), 31)
-        assert_equal(fork2.getfinalizationstate()['currentDynasty'], 4)
-        assert_equal(fork2.getfinalizationstate()['currentEpoch'], 6)
-        assert_equal(fork2.getfinalizationstate()['lastJustifiedEpoch'], 5)
-        assert_equal(fork2.getfinalizationstate()['lastFinalizedEpoch'], 4)
+        check_finalization(fork2, {'currentDynasty': 4,
+                                   'currentEpoch': 6,
+                                   'lastJustifiedEpoch': 5,
+                                   'lastFinalizedEpoch': 4})
 
         create_justification(fork=fork2, finalizer=finalizer2, after_blocks=10)
         assert_equal(fork2.getblockcount(), 41)
-        assert_equal(fork2.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(fork2.getfinalizationstate()['currentEpoch'], 8)
-        assert_equal(fork2.getfinalizationstate()['lastJustifiedEpoch'], 7)
-        assert_equal(fork2.getfinalizationstate()['lastFinalizedEpoch'], 4)
+        check_finalization(fork2, {'currentDynasty': 5,
+                                   'currentEpoch': 8,
+                                   'lastJustifiedEpoch': 7,
+                                   'lastFinalizedEpoch': 4})
 
         sync_node_to_fork(node, fork2)
 
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 8)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 7)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 4)
+        check_finalization(node, {'currentDynasty': 5,
+                                   'currentEpoch': 8,
+                                   'lastJustifiedEpoch': 7,
+                                   'lastFinalizedEpoch': 4})
 
         self.log.info('node successfully switched to the longest justified fork')
 
@@ -217,17 +218,17 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
         #                             - e6 - e7 - e8 fork2
         create_justification(fork=fork1, finalizer=finalizer1, after_blocks=16)
         assert_equal(fork1.getblockcount(), 47)
-        assert_equal(fork1.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(fork1.getfinalizationstate()['currentEpoch'], 9)
-        assert_equal(fork1.getfinalizationstate()['lastJustifiedEpoch'], 8)
-        assert_equal(fork1.getfinalizationstate()['lastFinalizedEpoch'], 4)
+        check_finalization(fork1, {'currentDynasty': 5,
+                                   'currentEpoch': 9,
+                                   'lastJustifiedEpoch': 8,
+                                   'lastFinalizedEpoch': 4})
 
         sync_node_to_fork(node, fork1)
 
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 9)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 8)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 4)
+        check_finalization(node, {'currentDynasty': 5,
+                                  'currentEpoch': 9,
+                                  'lastJustifiedEpoch': 8,
+                                  'lastFinalizedEpoch': 4})
 
         self.log.info('node successfully switched back to the longest justified fork')
 
@@ -247,10 +248,10 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
         create_justification(fork=fork1, finalizer=finalizer1, after_blocks=14)
 
         assert_equal(fork1.getblockcount(), 61)
-        assert_equal(fork1.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(fork1.getfinalizationstate()['currentEpoch'], 12)
-        assert_equal(fork1.getfinalizationstate()['lastJustifiedEpoch'], 11)
-        assert_equal(fork1.getfinalizationstate()['lastFinalizedEpoch'], 4)
+        check_finalization(fork1, {'currentDynasty': 5,
+                                   'currentEpoch': 12,
+                                   'lastJustifiedEpoch': 11,
+                                   'lastFinalizedEpoch': 4})
 
         attacker = node.add_p2p_connection(BaseNode())
         network_thread_start()
@@ -266,10 +267,10 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
             wait_until(lambda: node.getblockcount() == node_blocks, timeout=15)
 
         assert_equal(node.getblockcount(), 60)
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 12)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 8)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 4)
+        check_finalization(node, {'currentDynasty': 5,
+                                  'currentEpoch': 12,
+                                  'lastJustifiedEpoch': 8,
+                                  'lastFinalizedEpoch': 4})
 
         # create finalization
         #                                         J               J
@@ -280,24 +281,24 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
         #                             - e6 - e7 - e8 - e9 - e10 - e11 - e12[60, 61] fork2
         create_justification(fork=fork2, finalizer=finalizer2, after_blocks=11)
         assert_equal(fork2.getblockcount(), 52)
-        assert_equal(fork2.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(fork2.getfinalizationstate()['currentEpoch'], 10)
-        assert_equal(fork2.getfinalizationstate()['lastJustifiedEpoch'], 9)
-        assert_equal(fork2.getfinalizationstate()['lastFinalizedEpoch'], 4)
+        check_finalization(fork2, {'currentDynasty': 5,
+                                   'currentEpoch': 10,
+                                   'lastJustifiedEpoch': 9,
+                                   'lastFinalizedEpoch': 4})
 
         create_justification(fork=fork2, finalizer=finalizer2, after_blocks=6)
         assert_equal(fork2.getblockcount(), 58)
-        assert_equal(fork2.getfinalizationstate()['currentDynasty'], 5)
-        assert_equal(fork2.getfinalizationstate()['currentEpoch'], 11)
-        assert_equal(fork2.getfinalizationstate()['lastJustifiedEpoch'], 10)
-        assert_equal(fork2.getfinalizationstate()['lastFinalizedEpoch'], 9)
+        check_finalization(fork2, {'currentDynasty': 5,
+                                   'currentEpoch': 11,
+                                   'lastJustifiedEpoch': 10,
+                                   'lastFinalizedEpoch': 9})
 
         fork2.generatetoaddress(3, fork2.getnewaddress())
         assert_equal(fork2.getblockcount(), 61)
-        assert_equal(fork2.getfinalizationstate()['currentDynasty'], 6)
-        assert_equal(fork2.getfinalizationstate()['currentEpoch'], 12)
-        assert_equal(fork2.getfinalizationstate()['lastJustifiedEpoch'], 10)
-        assert_equal(fork2.getfinalizationstate()['lastFinalizedEpoch'], 9)
+        check_finalization(fork2, {'currentDynasty': 6,
+                                   'currentEpoch': 12,
+                                   'lastJustifiedEpoch': 10,
+                                   'lastFinalizedEpoch': 9})
 
         # node follows longer finalization
         #                                         J               J
@@ -310,10 +311,10 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
         sync_node_to_fork(node, fork2)
 
         assert_equal(node.getblockcount(), 61)
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 6)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 12)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 10)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 9)
+        check_finalization(node, {'currentDynasty': 6,
+                                  'currentEpoch': 12,
+                                  'lastJustifiedEpoch': 10,
+                                  'lastFinalizedEpoch': 9})
 
         # send block with surrounded vote that justifies longer fork
         # node's view:
@@ -333,10 +334,10 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
         wait_for_reject(attacker, b'bad-fork-dynasty', block.sha256)
         assert_equal(node.getblockcount(), 61)
         assert_equal(node.getblockhash(61), tip)
-        assert_equal(node.getfinalizationstate()['currentDynasty'], 6)
-        assert_equal(node.getfinalizationstate()['currentEpoch'], 12)
-        assert_equal(node.getfinalizationstate()['lastJustifiedEpoch'], 10)
-        assert_equal(node.getfinalizationstate()['lastFinalizedEpoch'], 9)
+        check_finalization(node, {'currentDynasty': 6,
+                                  'currentEpoch': 12,
+                                  'lastJustifiedEpoch': 10,
+                                  'lastFinalizedEpoch': 9})
 
         self.log.info('node did not re-org before finalization')
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -450,6 +450,11 @@ def sync_mempools(rpc_connections, *, wait=1, timeout=150, flush_scheduler=True)
     raise AssertionError("Mempool sync failed:%s" % "".join(
         ["\nNode %d: %s" % entry for entry in mempools.items()]))
 
+def check_finalization(node, expected):
+    state = node.getfinalizationstate()
+    for key in expected:
+        assert_equal(state[key], expected[key])
+
 # Transaction/Block functions
 #############################
 


### PR DESCRIPTION
As @castarco pointed out https://github.com/dtr-org/unit-e/pull/744#discussion_r264218197, we have multiple `getfinalizationstate` RPC calls to inspect one state. This PR optimizes multiple invocations and provides a helper function `uitl.check_finalization`.

Signed-off-by: Stanislav Frolov <stanislav@thirdhash.com>