### PR TITLE
Sync nodes before the tests

### DIFF
--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -148,6 +148,8 @@ class CompactBlocksTest(UnitETestFramework):
         self.test_node.send_and_ping(msg_block(block2))
         assert_equal(int(self.nodes[0].getbestblockhash(), 16), block2.sha256)
         self.utxos.extend([[tx.sha256, i, out_value] for i in range(10)])
+
+        sync_blocks(self.nodes)
         return
 
     # Test "sendcmpct" (between peers preferring the same version):


### PR DESCRIPTION
Fixes #761

Long story short - the **p2p_compactblocks** test heavily relies on [this transaction](https://github.com/dtr-org/unit-e/blob/master/test/functional/p2p_compactblocks.py#L141) - we use UTXOs from it in order to create a bunch of test transactions [here](https://github.com/dtr-org/unit-e/blob/master/test/functional/p2p_compactblocks.py#L433). It's important to note that the block is added just to the first node (Node0).

I found out that sometimes [the block with this first transaction](https://github.com/dtr-org/unit-e/blob/master/test/functional/p2p_compactblocks.py#L147) disappears from the node's chain and the first transaction pops out in the mempool. As result, we have an invalid transaction:
```
 ERROR: ConnectBlock: Consensus::CheckTxInputs: a638e9878dbfe6f3ae5492521d7e0142ae187f4b8666fc3ccf7fea09bd4ce453,
bad-txns-inputs-missingorspent, CheckTxInputs: inputs missing/spent (code 16)
```

It happens due to the nodes sync - Node1 generates own blocks [here](https://github.com/dtr-org/unit-e/blob/master/test/functional/p2p_compactblocks.py#L789) and our block rejected from the Node0 chain.
   To fix it I force sync between nodes after UTXOs creation.

Signed-off-by: Dmitry Saveliev <dima@thirdhash.com>
