### PR TITLE
Make flaky test wallet_encryption.py a bit less flaky

### DIFF
--- a/test/functional/wallet_encryption.py
+++ b/test/functional/wallet_encryption.py
@@ -44,7 +44,7 @@ class WalletEncryptionTest(UnitETestFramework):
         assert_equal(privkey, self.nodes[0].dumpprivkey(address))
 
         # Check that the timeout is right
-        time.sleep(2)
+        time.sleep(2.1)
         assert_raises_rpc_error(-13, "Please enter the wallet passphrase with walletpassphrase first", self.nodes[0].dumpprivkey, address)
 
         # Test wrong passphrase


### PR DESCRIPTION
The test used to fail sometimes, since it checked that the wallet
auto-locks itself after a timeout by sleeping for that amount of time
and then running an RPC call. The problem is that, when two processes
(the test and the daemon) sleep for the exact same amount of time, it's a
toss-up which one of them gets woken up first.

This commit increases the sleep time for the test by 0.1 seconds, which
should be enought of a safety margin for the check to pass always.