### PR TITLE
Fix unused imports in test_gitian-build.py

### DIFF
--- a/contrib/test_gitian-build.py
+++ b/contrib/test_gitian-build.py
@@ -5,10 +5,7 @@
 # Run tests with `pytest`, requires `pytest-mock` to be installed.
 
 
-from unittest.mock import call
 from pytest import raises
-
-import os
 
 from pathlib import Path
 


### PR DESCRIPTION
While fixing unused imports in #738 I accidentally also fixed imports in`test_gitian-build.py`(which is not relevant to coinbase PR). In order to minimize #738 I am extracting this minor fix here.

NOTE: this PR is not removing _all_ lint warnings, because I don't want unrelated merge conflicts with #738

Signed-off-by: Aleksandr Mikhailov <aleksandr@thirdhash.com>