### PR TITLE
Fix flaky feature_fork_choice_parallel_justifications.py

### DIFF
--- a/test/functional/feature_fork_choice_parallel_justifications.py
+++ b/test/functional/feature_fork_choice_parallel_justifications.py
@@ -110,6 +110,9 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
         node.generatetoaddress(2, node.getnewaddress())
         sync_blocks([node, fork1, fork2, finalizer1, finalizer2])
 
+        # Do not let finalizer2 to see deposit from finalizer1
+        disconnect_nodes(node, fork2.index)
+
         payto = finalizer1.getnewaddress('', 'legacy')
         txid1 = finalizer1.deposit(payto, 10000)
         finalizer2.setaccount(payto, '')
@@ -120,6 +123,9 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
             print(tx1)
             print(tx2)
             assert_equal(txid1, txid2)
+
+        # Connect back
+        connect_nodes(node, fork2.index)
 
         self.wait_for_transaction(txid1, timeout=150)
 


### PR DESCRIPTION
It flaked only once in #738, but I think new coinbase has nothing to do with it:
```
2019-03-13 14:02:59.031000 TestFramework (ERROR): JSONRPC error
Traceback (most recent call last):
  File "/home/mmorusiewicz/DTR/scravy-unit-e/test/functional/test_framework/test_framework.py", line 152, in main
    self.run_test()
  File "/home/mmorusiewicz/DTR/scravy-unit-e/test/functional/feature_fork_choice_parallel_justifications.py", line 118, in run_test
    txid2 = finalizer2.deposit(payto, 10000)
  File "/home/mmorusiewicz/DTR/scravy-unit-e/test/functional/test_framework/coverage.py", line 47, in __call__
    return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
  File "/home/mmorusiewicz/DTR/scravy-unit-e/test/functional/test_framework/authproxy.py", line 138, in __call__
    raise JSONRPCException(response['error'])
test_framework.authproxy.JSONRPCException: Cannot create deposit. (-25)
```

As suggested by @Ruteri if you add a several second sleep after the first deposit, but before the second - you will get 100% reproduction rate. So this suggests that deposit from the first finalizer was seen by second before it created his own. This PR just disconnects finalizers when they are making their deposits

Signed-off-by: Aleksandr Mikhailov <aleksandr@thirdhash.com>