### PR TITLE
Remove unused fIncludeWitness

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -129,7 +129,6 @@ private:
     CBlock* pblock;
 
     // Configuration parameters for the block size
-    bool fIncludeWitness;
     unsigned int nBlockMaxWeight;
     CFeeRate blockMinFeeRate;
 


### PR DESCRIPTION
Seems like leftover after we enabled segwit https://github.com/dtr-org/unit-e/pull/746

Fixes the warning:
```
In file included from miner.cpp:8:
./miner.h:132:10: warning: private field 'fIncludeWitness' is not used [-Wunused-private-field]
    bool fIncludeWitness;
         ^
```

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>