### PR TITLE
Reorder test according to their execution time

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -160,6 +160,7 @@ BASE_SCRIPTS= [
     'interface_unite_cli.py',
     'mempool_resurrect.py',
     'mempool_spend_coinbase.py',
+    'p2p_invalid_stake.py',
     'interface_http.py',
     'rpc_signrawtransaction.py',
     'rpc_decodescript.py',


### PR DESCRIPTION
We have the following recommendation where to put tests:
```
Scripts that are run by the travis build process.
Longest test should go first, to favor running tests in parallel

vv Tests less than 5m vv
vv Tests less than 2m vv
vv Tests less than 60s vv
vv Tests less than 30s vv

Don't append tests at the end to avoid merge conflicts
Put them in a random line within the section that fits their approximate run-time
```

I noticed that I added couple of long-running tests to the end of the list
and some short-running ones to the top which can potentially decrease the
overall time the test_runner.py is running. I used the following link
https://travis-ci.com/dtr-org/unit-e/jobs/185163488 to see where to put my tests
and then noticed that there are a lot of other tests that violate that recommendation
so re-grouped them and added a comment with their expected execution time.

I am not sure we should keep comments but opening this PR as a discussion.
Maybe we can later add a script that will automatically update their execution time
and test_runner.py will use that number to decide in which order to run tests.
And once we see that execution time was changed significantly for a particular
component, we can investigate the reason.

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>