### PR TITLE
Fix p2p_segwit.py test

### DIFF
--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -334,12 +334,12 @@ class SegWitTest(UnitETestFramework):
         self.update_witness_block_with_transactions(block, [parent_tx, child_tx])
 
         # Calculate exact additional bytes (get_virtual_size would round it)
-        additional_bytes = 4 * MAX_BLOCK_BASE_SIZE - (3 * len(block.serialize(with_witness=False)) + len(block.serialize(with_witness=True)))
+        additional_bytes = 1 + (4 * MAX_BLOCK_BASE_SIZE) - (3 * len(block.serialize(with_witness=False)) + len(block.serialize(with_witness=True)))
 
         i = 0
-        while additional_bytes >= 0:
+        while additional_bytes > 0:
             # Add some more bytes to each input until we hit MAX_BLOCK_BASE_SIZE+1
-            extra_bytes = min(additional_bytes+1, 55)
+            extra_bytes = min(additional_bytes, 55)
             child_tx.wit.vtxinwit[int(i/(2*NUM_DROPS))].scriptWitness.stack[i%(2*NUM_DROPS)] = b'a'*(195+extra_bytes)
             additional_bytes -= extra_bytes
             i += 1


### PR DESCRIPTION
Since there is tail update in `additional_bytes`, if `additional_bytes % 55 = 0`, it will not add the +1 byte needed to pass `assert_equal(vsize, MAX_BLOCK_BASE_SIZE + 1)`.
The algorithm needs to do one last pass, that will happen if `additional_bytes % 55 = 0`, where it will add `min(0+1, 55)` `extra_bytes`. If `additional_bytes % 55 > 0`, after the update `additional_bytes` will be < 0 and skip the last pass.
This has been discovered because the coinbase scriptSig changed from 71 to 72 bytes (due to changed coinbase reward in https://github.com/dtr-org/unit-e/pull/794), causing the total block size to be % 55 with no remainder.