### PR TITLE
Add configuration for clonemachine

### DIFF
--- a/.clonemachine
+++ b/.clonemachine
@@ -1,0 +1,9 @@
+# Configuration for clonemachine (https://github.com/dtr-org/clonemachine)
+
+appropriated_files:
+- contrib/gitian-build.py
+- contrib/gitian-keys/keys.txt
+- doc/gitian-building.md
+
+removed_files:
+- contrib/gitian-descriptors/gitian-osx-signer.yml


### PR DESCRIPTION
This configuration file contains configuration for clonemachine
(https://github.com/dtr-org/clonemachine) helping with the upstream
sync.

It lists files which have been removed or replaced by files from
unit-e where no merge is done with upstream.

Having this configuration in the unit-e repository has the big
advantage that changes in unit-e which need special handling of files
by clonemachine can include the changes of the configuration
without having to do changes in clonemachine itself so they are in
one commit and don't need two commits synced across repositories.

This commit adds the configuration for handling the gitian builder
files. This fixes dtr-org/clonemachine#24.
