### PR TITLE
Don't set epochLength=5 in regtest as it's a default value

### DIFF
--- a/test/functional/esperanza_vote.py
+++ b/test/functional/esperanza_vote.py
@@ -19,20 +19,12 @@ class EsperanzaVoteTest(UnitETestFramework):
     def set_test_params(self):
         self.num_nodes = 4
 
-        esperanza_config = '-esperanzaconfig={"epochLength":5,"minDepositSize":1500}'
-        finalizer_node_params = [
-            '-validating=1',
-            '-debug=all',
-            '-whitelist=127.0.0.1',
-            esperanza_config,
+        self.extra_args = [
+            [],
+            ['-validating=1'],
+            ['-validating=1'],
+            ['-validating=1'],
         ]
-        proposer_node_params = ['-debug=all', '-whitelist=127.0.0.1', esperanza_config]
-
-        self.extra_args = [proposer_node_params,
-                           finalizer_node_params,
-                           finalizer_node_params,
-                           finalizer_node_params,
-                           ]
         self.setup_clean_chain = True
 
     def setup_network(self):

--- a/test/functional/feature_fork_choice_finalization.py
+++ b/test/functional/feature_fork_choice_finalization.py
@@ -26,19 +26,18 @@ class ForkChoiceFinalizationTest(UnitETestFramework):
         self.num_nodes = 8
         self.setup_clean_chain = True
 
-        esperanza_config = '-esperanzaconfig={"epochLength":5}'
         self.extra_args = [
             # test_justification_over_chain_work
-            [esperanza_config],
-            [esperanza_config],
-            [esperanza_config],
-            [esperanza_config, '-validating=1'],
+            [],
+            [],
+            [],
+            ['-validating=1'],
 
             # test_longer_justification
-            [esperanza_config],
-            [esperanza_config],
-            [esperanza_config],
-            [esperanza_config, '-validating=1'],
+            [],
+            [],
+            [],
+            ['-validating=1'],
         ]
 
     def setup_network(self):

--- a/test/functional/feature_fork_choice_forked_finalize_epoch.py
+++ b/test/functional/feature_fork_choice_forked_finalize_epoch.py
@@ -43,17 +43,16 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         self.num_nodes = 8
         self.setup_clean_chain = True
 
-        esperanza_config = '-esperanzaconfig={"epochLength":5}'
         self.extra_args = [
-            ['-proposing=0', esperanza_config],
-            ['-proposing=0', esperanza_config],
-            ['-proposing=0', esperanza_config, '-validating=1'],
-            ['-proposing=0', esperanza_config, '-validating=1'],
+            ['-proposing=0', ],
+            ['-proposing=0', ],
+            ['-proposing=0', '-validating=1'],
+            ['-proposing=0', '-validating=1'],
 
-            ['-proposing=0', esperanza_config],
-            ['-proposing=0', esperanza_config],
-            ['-proposing=0', esperanza_config, '-validating=1'],
-            ['-proposing=0', esperanza_config, '-validating=1'],
+            ['-proposing=0'],
+            ['-proposing=0'],
+            ['-proposing=0', '-validating=1'],
+            ['-proposing=0', '-validating=1'],
         ]
 
     def setup_network(self):

--- a/test/functional/feature_fork_choice_parallel_justifications.py
+++ b/test/functional/feature_fork_choice_parallel_justifications.py
@@ -54,13 +54,12 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
         self.num_nodes = 5
         self.setup_clean_chain = True
 
-        esperanza_config = '-esperanzaconfig={"epochLength":5}'
         self.extra_args = [
-            ['-proposing=0', esperanza_config],
-            ['-proposing=0', esperanza_config],
-            ['-proposing=0', esperanza_config],
-            ['-proposing=0', esperanza_config, '-validating=1'],
-            ['-proposing=0', esperanza_config, '-validating=1'],
+            ['-proposing=0', ],
+            ['-proposing=0', ],
+            ['-proposing=0', ],
+            ['-proposing=0', '-validating=1'],
+            ['-proposing=0', '-validating=1'],
         ]
 
     def setup_network(self):

--- a/test/functional/feature_snapshot_creation.py
+++ b/test/functional/feature_snapshot_creation.py
@@ -24,13 +24,8 @@ class SnapshotCreationTest(UnitETestFramework):
         self.setup_clean_chain = True
 
         self.extra_args = [
-            [
-                '-validating=1',
-                '-esperanzaconfig={"epochLength":5}',
-            ],
-            [
-                '-esperanzaconfig={"epochLength":5}',
-            ],
+            ['-validating=1'],
+            [],
         ]
         self.num_nodes = len(self.extra_args)
 

--- a/test/functional/rpc_finalization.py
+++ b/test/functional/rpc_finalization.py
@@ -23,11 +23,10 @@ class RpcFinalizationTest(UnitETestFramework):
         self.num_nodes = 3
         self.setup_clean_chain = True
 
-        esperanza_config = '-esperanzaconfig={"epochLength":5}'
         self.extra_args = [
-            [esperanza_config],
-            [esperanza_config, '-validating=1'],
-            [esperanza_config, '-validating=1'],
+            [],
+            ['-validating=1'],
+            ['-validating=1'],
         ]
 
     def setup_network(self):


### PR DESCRIPTION
The reason for dropping this parameter is to show clearly
which parameters are required to be changed.

In the follow-up PR I'll adjust other tests to default epochLength=5
where it's not required to have a longer one. The reason is
to reduce the debug.log in case the test fails.

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>