### PR TITLE
Extract header size as a local constant

### DIFF
--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -4,7 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the REST API."""
 
-from test_framework.test_framework import UnitETestFramework, PROPOSER_REWARD
+from test_framework.test_framework import UnitETestFramework, PROPOSER_REWARD, BLOCK_HEADER_LENGTH
 from test_framework.util import *
 from struct import *
 from io import BytesIO
@@ -203,8 +203,6 @@ class RESTTest (UnitETestFramework):
         ################
         # /rest/block/ #
         ################
-
-        BLOCK_HEADER_LENGTH = 112
 
         # check binary format
         response = http_get_call(url.hostname, url.port, '/rest/block/'+bb_hash+self.FORMAT_SEPARATOR+"bin", True)

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -7,7 +7,7 @@ import configparser
 import os
 import struct
 
-from test_framework.test_framework import UnitETestFramework, SkipTest
+from test_framework.test_framework import UnitETestFramework, SkipTest, BLOCK_HEADER_LENGTH
 from test_framework.mininode import CTransaction
 from test_framework.util import (assert_equal,
                                  bytes_to_hex_str,
@@ -108,7 +108,7 @@ class ZMQTest (UnitETestFramework):
 
             # Should receive the generated raw block.
             block = self.rawblock.receive()
-            assert_equal(genhashes[x], bytes_to_hex_str(hash256(block[:112])))
+            assert_equal(genhashes[x], bytes_to_hex_str(hash256(block[:BLOCK_HEADER_LENGTH])))  # skip the header
 
         self.log.info("Wait for tx from second node")
         payment_txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1.0)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -55,6 +55,8 @@ COINBASE_MATURITY = 100  # Should match the value from consensus.h
 STAKE_SPLIT_THRESHOLD = 1000  # Should match the value from blockchain_parameters.cpp
 PROPOSER_REWARD = Decimal('3.75')  # Will not decrease as tests don't generate enough blocks
 
+BLOCK_HEADER_LENGTH = 112
+
 # This parameter simulates the scenario that the node "never" reaches finalization.
 # The purpose of it is to adapt Bitcoin tests to Unit-e which contradict with the finalization
 # so the existing tests will perform the check within one dynasty.


### PR DESCRIPTION
Extracting this constant makes it easier to change the size of the header in the future (for example when we remove the `nonce` field once we got rid of PoW, or in case of us adding the commits merkle hash, or removing segwit merkle tree again, should that ever be necessary).

Signed-off-by: Julian Fleischer <julian@thirdhash.com>