### PR TITLE
Add unit tests for finalization transactions validation (#480)

### DIFF
--- a/src/esperanza/checks.cpp
+++ b/src/esperanza/checks.cpp
@@ -83,10 +83,10 @@ bool CheckDepositTx(const CTransaction &tx, CValidationState &err_state,
 
   std::vector<std::vector<unsigned char>> solutions;
   txnouttype type_ret;
-  if (!Solver(tx.vout[0].scriptPubKey, type_ret, solutions)) {
-    return err_state.DoS(10, false, REJECT_INVALID,
-                         "bad-deposit-script-not-solvable");
-  }
+  const bool ok = Solver(tx.vout[0].scriptPubKey, type_ret, solutions);
+
+  // Solver must return True value on PayVoteSlash type script.
+  assert(ok);
 
   if (!CheckValidatorAddress(tx, validator_address_out)) {
     return err_state.DoS(10, false, REJECT_INVALID,
@@ -449,6 +449,12 @@ bool CheckAdminTx(const CTransaction &tx, CValidationState &err_state,
     keys_out = &keys_tmp;
   }
 
+  // stack is expected to look like:
+  // empty
+  // signature
+  // ...
+  // signature
+  // <OP_N> <PubKey> ... <PubKey> <OP_M> <OP_CHECKMULTISIG>
   if (witness.stack.size() != ADMIN_MULTISIG_SIGNATURES + 2 ||
       !CScript::ExtractAdminKeysFromWitness(witness, *keys_out) ||
       keys_out->size() != ADMIN_MULTISIG_KEYS) {

--- a/src/test/esperanza/adminstate_tests.cpp
+++ b/src/test/esperanza/adminstate_tests.cpp
@@ -11,16 +11,6 @@
 
 BOOST_FIXTURE_TEST_SUITE(adminstate_tests, ReducedTestingSetup)
 
-CPubKey MakePubKey() {
-  CKey key;
-  key.MakeNewKey(true);
-  return key.GetPubKey();
-}
-
-esperanza::AdminKeySet MakeKeySet() {
-  return {{MakePubKey(), MakePubKey(), MakePubKey()}};
-}
-
 BOOST_AUTO_TEST_CASE(empty_params_mean_no_admin) {
   esperanza::AdminParams emptyParams;
   esperanza::AdminState state(emptyParams);

--- a/src/test/esperanza/checks_tests.cpp
+++ b/src/test/esperanza/checks_tests.cpp
@@ -19,88 +19,247 @@ using namespace esperanza;
 
 BOOST_FIXTURE_TEST_SUITE(finalization_checks_tests, TestingSetup)
 
-BOOST_AUTO_TEST_CASE(IsVoteExpired_test) {
+CTransaction CreateAdminTx(const AdminKeySet &key_set) {
 
-  FinalizationState *esperanza = FinalizationState::GetState();
+  CMutableTransaction mtx;
+  mtx.SetType(TxType::ADMIN);
+  mtx.vin.resize(1);
+  mtx.vout.resize(1);
 
-  const auto &params = CreateChainParams(CBaseChainParams::TESTNET)->GetFinalization();
-  const auto min_deposit = params.min_deposit_size;
-  const auto epoch_length = params.epoch_length;
+  AdminCommand cmd(AdminCommandType::END_PERMISSIONING, {});
+  CScript script = EncodeAdminCommand(cmd);
+  mtx.vout = {CTxOut(1, script)};
 
-  CKey k;
-  InsecureNewKey(k, true);
-  uint160 validatorAddress = k.GetPubKey().GetID();
+  CScript witness_script = CScript() << 1 << ToByteVector(key_set[0]) << ToByteVector(key_set[1])
+                                     << ToByteVector(key_set[2]) << 3 << OP_CHECKMULTISIG;
+  CTxIn input(GetRandHash(), 0);
+  input.scriptWitness.stack.resize(3);
+  input.scriptWitness.stack.push_back(std::vector<unsigned char>(witness_script.begin(), witness_script.end()));
+  mtx.vin = {input};
 
-  BOOST_CHECK_EQUAL(
-      esperanza->ValidateDeposit(validatorAddress, min_deposit),
-      +Result::SUCCESS);
+  return CTransaction(mtx);
+}
 
-  esperanza->ProcessDeposit(validatorAddress, min_deposit);
+CTransaction CreateSlashTx(const CPubKey &pub_key, const Vote &vote1, const Vote &vote2) {
 
-  // Initialize few epoch - since epoch 4 we don't have instant finalization
-  for (int i = 1; i < 6; ++i) {
-    BOOST_CHECK_EQUAL(esperanza->InitializeEpoch(i * epoch_length),
-                      +Result::SUCCESS);
+  CScript vout_script = CScript::CreatePayVoteSlashScript(pub_key);
+
+  CMutableTransaction mtx;
+  mtx.SetType(TxType::SLASH);
+  mtx.vin.resize(1);
+  mtx.vout.resize(1);
+  mtx.vout = {CTxOut(1, vout_script)};
+
+  CScript encoded_vote1 = CScript::EncodeVote(vote1, ToByteVector(GetRandHash()));
+  std::vector<unsigned char> vote1_vector(encoded_vote1.begin(), encoded_vote1.end());
+
+  CScript encoded_vote2 = CScript::EncodeVote(vote2, ToByteVector(GetRandHash()));
+  std::vector<unsigned char> vote2_vector(encoded_vote2.begin(), encoded_vote2.end());
+
+  CScript vinScript = CScript() << ToByteVector(GetRandHash()) << vote1_vector << vote2_vector;
+
+  mtx.vin = {CTxIn(GetRandHash(), 0, vinScript)};
+
+  return CTransaction(mtx);
+}
+
+FinalizationParams CreateFinalizationParams() {
+  FinalizationParams params;
+
+  params.epoch_length = 10;
+  params.min_deposit_size = 10;
+  params.withdrawal_epoch_delay = 0;
+  params.bounty_fraction_denominator = 2;
+  params.base_interest_factor = 700000000;
+
+  return params;
+}
+
+BOOST_AUTO_TEST_CASE(CheckAdminTx_test) {
+  AdminCommand cmd(AdminCommandType::END_PERMISSIONING, {});
+  CScript valid_script = EncodeAdminCommand(cmd);
+  CScript invalid_script(valid_script.begin(), valid_script.begin() + 1);
+
+  CMutableTransaction mtx;
+  mtx.SetType(TxType::ADMIN);
+
+  {
+    // Check vin of transaction
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    std::vector<CPubKey> keys_out;
+
+    CheckAdminTx(tx, err_state, &keys_out);
+    BOOST_CHECK_EQUAL("admin-vin-empty", err_state.GetRejectReason());
   }
 
-  uint256 targetHash = uint256();
+  mtx.vin.resize(1);
 
-  Vote expired{RandValidatorAddr(), targetHash, 0, 2};
-  BOOST_CHECK_EQUAL(IsVoteExpired(CreateVoteTx(expired, k)), true);
+  {
+    // Check vout of transaction
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    std::vector<CPubKey> keys_out;
 
-  Vote current{RandValidatorAddr(), targetHash, 0, 5};
-  BOOST_CHECK_EQUAL(IsVoteExpired(CreateVoteTx(current, k)), false);
+    CheckAdminTx(tx, err_state, &keys_out);
+    BOOST_CHECK_EQUAL("admin-vout-empty", err_state.GetRejectReason());
+  }
 
-  Vote afterLastFinalization{RandValidatorAddr(), targetHash, 0, 3};
-  BOOST_CHECK_EQUAL(IsVoteExpired(CreateVoteTx(afterLastFinalization, k)), true);
+  mtx.vout.resize(2);
 
-  Vote future{RandValidatorAddr(), targetHash, 0, 12};
-  BOOST_CHECK_EQUAL(IsVoteExpired(CreateVoteTx(future, k)), false);
+  {
+    // Check for admin commands
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    std::vector<CPubKey> keys_out;
 
-  Vote currentOtherFork{RandValidatorAddr(), GetRandHash(), 0, 5};
-  BOOST_CHECK_EQUAL(IsVoteExpired(CreateVoteTx(currentOtherFork, k)), false);
+    CheckAdminTx(tx, err_state, &keys_out);
+    BOOST_CHECK_EQUAL("admin-no-commands", err_state.GetRejectReason());
+  }
+
+  mtx.vout = {CTxOut(1, invalid_script)};
+
+  {
+    // Validate admin command
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    std::vector<CPubKey> keys_out;
+
+    CheckAdminTx(tx, err_state, &keys_out);
+    BOOST_CHECK_EQUAL("admin-invalid-command", err_state.GetRejectReason());
+  }
+
+  mtx.vout = {CTxOut(1, valid_script), CTxOut(1, valid_script)};
+
+  {
+    // Check double permissioning
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    std::vector<CPubKey> keys_out;
+
+    CheckAdminTx(tx, err_state, &keys_out);
+    BOOST_CHECK_EQUAL("admin-double-disable", err_state.GetRejectReason());
+  }
+
+  {
+    AdminKeySet key_set = MakeKeySet();
+    CTransaction tx = CreateAdminTx(key_set);
+    CValidationState err_state;
+    std::vector<CPubKey> keys_out;
+
+    CheckAdminTx(tx, err_state, &keys_out);
+    BOOST_CHECK(err_state.IsValid());
+  }
 }
 
-BOOST_AUTO_TEST_CASE(CheckVoteTransaction_malformed_vote) {
+BOOST_AUTO_TEST_CASE(ContextualCheckAdminTx_test) {
+  {
+    // Check admin's permissioning
+    CTransaction tx = CreateAdminTx(MakeKeySet());
 
+    FinalizationStateSpy spy(FinalizationParams{}, AdminParams{});
+    CValidationState err_state;
+
+    bool ok = ContextualCheckAdminTx(tx, err_state, spy);
+    BOOST_CHECK(!ok);
+    BOOST_CHECK_EQUAL(err_state.GetRejectReason(), "admin-disabled");
+
+    int dos = 0;
+    err_state.IsInvalid(dos);
+    BOOST_CHECK_EQUAL(dos, 10);
+  }
+
+  {
+    // Check authorization
+    AdminKeySet key_set = MakeKeySet();
+    CTransaction tx = CreateAdminTx(key_set);
+
+    AdminParams admin_params;
+    admin_params.m_block_to_admin_keys.emplace(0, key_set);
+
+    FinalizationStateSpy spy(FinalizationParams{}, admin_params);
+    CValidationState err_state;
+
+    bool ok = ContextualCheckAdminTx(tx, err_state, spy);
+    BOOST_CHECK(!ok);
+    BOOST_CHECK_EQUAL(err_state.GetRejectReason(), "admin-not-authorized");
+  }
+
+  {
+    AdminKeySet key_set = MakeKeySet();
+    CTransaction tx = CreateAdminTx(key_set);
+
+    AdminParams admin_params;
+    admin_params.m_block_to_admin_keys.emplace(0, key_set);
+
+    FinalizationStateSpy spy(FinalizationParams{}, admin_params);
+    CValidationState err_state;
+
+    // Save admin key set in FinalizationState
+    CBlockIndex bi = CBlockIndex();
+    const uint256 block_hash = GetRandHash();
+    bi.nHeight = 0;
+    bi.phashBlock = &block_hash;
+    spy.ProcessNewCommits(bi, {});
+
+    bool ok = ContextualCheckAdminTx(tx, err_state, spy);
+    BOOST_CHECK(ok);
+    BOOST_CHECK(err_state.IsValid());
+  }
+}
+
+BOOST_AUTO_TEST_CASE(CheckDepositTx_test) {
   CKey key;
-  key.MakeNewKey(true);
-  Vote vote = Vote{key.GetPubKey().GetID(), GetRandHash(), 0, 2};
-  CTransaction tx = CreateVoteTx(vote, key);
-  CMutableTransaction mutedTx(tx);
+  InsecureNewKey(key, true);
 
-  // Replace the vote with something meaningless
-  mutedTx.vin[0].scriptSig = CScript() << 1337;
+  CMutableTransaction mtx;
+  mtx.SetType(TxType::DEPOSIT);
 
-  CTransaction invalidVote(mutedTx);
-  Consensus::Params params = Params().GetConsensus();
-  CValidationState err_state;
-  BOOST_CHECK(CheckFinalizationTx(invalidVote, err_state) == false);
-  const auto &fin_state = *esperanza::FinalizationState::GetState(chainActive.Tip());
-  BOOST_CHECK(ContextualCheckVoteTx(invalidVote, err_state, params, fin_state) == false);
+  {
+    // Check vin of transaction
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    uint160 va_out;
 
-  BOOST_CHECK_EQUAL("bad-vote-data-format", err_state.GetRejectReason());
+    CheckDepositTx(tx, err_state, &va_out);
+    BOOST_CHECK_EQUAL("bad-deposit-malformed", err_state.GetRejectReason());
+  }
+
+  mtx.vin.resize(1);
+
+  {
+    // Check vout of transaction
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    uint160 va_out;
+
+    CheckDepositTx(tx, err_state, &va_out);
+    BOOST_CHECK_EQUAL("bad-deposit-malformed", err_state.GetRejectReason());
+  }
+
+  mtx.vout.resize(1);
+
+  {
+    // Validate vout script type
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    uint160 va_out;
+
+    CheckDepositTx(tx, err_state, &va_out);
+    BOOST_CHECK_EQUAL("bad-deposit-vout-script", err_state.GetRejectReason());
+  }
+
+  {
+    CTransaction tx = CreateDepositTx(CTransaction(mtx), key, 1);
+    CValidationState err_state;
+    uint160 va_out;
+
+    CheckDepositTx(tx, err_state, &va_out);
+    BOOST_CHECK(err_state.IsValid());
+  }
 }
 
-BOOST_AUTO_TEST_CASE(ExtractValidatorIndex_deposit) {
-
-  CKey k;
-  InsecureNewKey(k, true);
-
-  CMutableTransaction tx;
-  tx.SetType(TxType::DEPOSIT);
-  tx.vin.resize(1);
-  tx.vout.resize(1);
-  CTransaction prevTx(tx);
-
-  CTransaction deposit = CreateDepositTx(prevTx, k, 10000);
-  uint160 validatorAddress = uint160();
-  BOOST_CHECK(ExtractValidatorAddress(deposit, validatorAddress));
-
-  BOOST_CHECK_EQUAL(k.GetPubKey().GetID().GetHex(), validatorAddress.GetHex());
-}
-
-BOOST_AUTO_TEST_CASE(contextual_check_deposit_tx) {
+BOOST_AUTO_TEST_CASE(ContextualCheckDepositTx_test) {
   CKey key;
   InsecureNewKey(key, true);
 
@@ -152,6 +311,637 @@ BOOST_AUTO_TEST_CASE(contextual_check_deposit_tx) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(CheckLogoutTx_test) {
+  CKey key;
+  InsecureNewKey(key, true);
+
+  CMutableTransaction mtx;
+  mtx.SetType(TxType::LOGOUT);
+
+  {
+    // Check vin of transaction
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    uint160 va_out;
+
+    CheckLogoutTx(tx, err_state, &va_out);
+    BOOST_CHECK_EQUAL("bad-logout-malformed", err_state.GetRejectReason());
+  }
+
+  mtx.vin.resize(1);
+
+  {
+    // Check vout of transaction
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    uint160 va_out;
+
+    CheckLogoutTx(tx, err_state, &va_out);
+    BOOST_CHECK_EQUAL("bad-logout-malformed", err_state.GetRejectReason());
+  }
+
+  mtx.vout.resize(1);
+
+  {
+    // Validate vout script type
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    uint160 va_out;
+
+    CheckLogoutTx(tx, err_state, &va_out);
+    BOOST_CHECK_EQUAL("bad-logout-vout-script", err_state.GetRejectReason());
+  }
+
+  {
+    CTransaction tx = CreateLogoutTx(CTransaction(mtx), key, 1);
+    CValidationState err_state;
+    uint160 va_out;
+
+    CheckLogoutTx(tx, err_state, &va_out);
+    BOOST_CHECK(err_state.IsValid());
+  }
+}
+
+BOOST_AUTO_TEST_CASE(ContextualCheckLogoutTx_test) {
+  CKey key;
+  InsecureNewKey(key, true);
+  CPubKey pkey = key.GetPubKey();
+  uint160 validator_address = pkey.GetID();
+
+  CScript script = CScript::CreatePayVoteSlashScript(pkey);
+
+  CMutableTransaction mtx;
+  mtx.SetType(TxType::DEPOSIT);
+  mtx.vin.resize(1);
+  mtx.vout.resize(1);
+  mtx.vout = {CTxOut(1, script)};
+  CTransaction prev_tx(mtx);
+
+  {
+    CTransaction tx = CreateLogoutTx(prev_tx, key, 1);
+    CValidationState err_state;
+    Consensus::Params params = Params().GetConsensus();
+    FinalizationStateSpy spy(FinalizationParams{}, AdminParams{});
+
+    bool ok = ContextualCheckLogoutTx(tx, err_state, params, spy);
+    BOOST_CHECK(!ok);
+    BOOST_CHECK_EQUAL(err_state.GetRejectReason(), "bad-logout-invalid-state");
+
+    int dos = 0;
+    err_state.IsInvalid(dos);
+    BOOST_CHECK_EQUAL(dos, 10);
+  }
+
+  {
+    CTransaction tx = CreateLogoutTx(prev_tx, key, 1);
+    CValidationState err_state;
+    Consensus::Params params = Params().GetConsensus();
+
+    FinalizationStateSpy spy;
+    CAmount deposit_size = spy.MinDepositSize();
+
+    uint256 target_hash = GetRandHash();
+    CBlockIndex block_index;
+    block_index.phashBlock = &target_hash;
+    spy.SetRecommendedTarget(block_index);
+
+    BOOST_CHECK_EQUAL(spy.ValidateDeposit(validator_address, deposit_size),
+                      +Result::SUCCESS);
+    spy.ProcessDeposit(validator_address, deposit_size);
+    for (size_t i = 1; i < 6; ++i) {
+      spy.InitializeEpoch(i * spy.EpochLength());
+    }
+
+    bool ok = ContextualCheckLogoutTx(tx, err_state, params, spy);
+    BOOST_CHECK(!ok);
+    BOOST_CHECK_EQUAL(err_state.GetRejectReason(), "bad-logout-no-prev-tx-found");
+
+    int dos = 0;
+    err_state.IsInvalid(dos);
+    BOOST_CHECK_EQUAL(dos, 10);
+  }
+
+  {
+    CTransaction tx = CreateLogoutTx(prev_tx, key, 10000);
+
+    TestMemPoolEntryHelper entry;
+    mempool.addUnchecked(prev_tx.GetHash(),
+                         entry.Fee(1000).Time(GetTime()).SpendsCoinbase(true).FromTx(prev_tx));
+
+    CValidationState err_state;
+    Consensus::Params params = Params().GetConsensus();
+
+    FinalizationStateSpy spy;
+    CAmount deposit_size = spy.MinDepositSize();
+
+    uint256 target_hash = GetRandHash();
+    CBlockIndex block_index;
+    block_index.phashBlock = &target_hash;
+    spy.SetRecommendedTarget(block_index);
+
+    BOOST_CHECK_EQUAL(spy.ValidateDeposit(validator_address, deposit_size),
+                      +Result::SUCCESS);
+    spy.ProcessDeposit(validator_address, deposit_size);
+    for (size_t i = 1; i < 6; ++i) {
+      spy.InitializeEpoch(i * spy.EpochLength());
+    }
+
+    bool ok = ContextualCheckLogoutTx(tx, err_state, params, spy);
+    BOOST_CHECK(ok);
+    BOOST_CHECK(err_state.IsValid());
+  }
+}
+
+BOOST_AUTO_TEST_CASE(CheckSlashTx_test) {
+  CKey key;
+  InsecureNewKey(key, true);
+  CPubKey pub_key = key.GetPubKey();
+
+  CMutableTransaction mtx;
+  mtx.SetType(TxType::SLASH);
+
+  {
+    // Check vin of transaction
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    Vote vote1;
+    Vote vote2;
+
+    CheckSlashTx(tx, err_state, &vote1, &vote2);
+    BOOST_CHECK_EQUAL("bad-slash-malformed", err_state.GetRejectReason());
+  }
+
+  mtx.vin.resize(1);
+
+  {
+    // Check vout of transaction
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    Vote vote1;
+    Vote vote2;
+
+    CheckSlashTx(tx, err_state, &vote1, &vote2);
+    BOOST_CHECK_EQUAL("bad-slash-malformed", err_state.GetRejectReason());
+  }
+
+  mtx.vout.resize(1);
+
+  {
+    // Check slash data format
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    Vote vote1;
+    Vote vote2;
+
+    CheckSlashTx(tx, err_state, &vote1, &vote2);
+    BOOST_CHECK_EQUAL("bad-slash-data-format", err_state.GetRejectReason());
+  }
+
+  {
+    Vote vote1;
+    Vote vote2;
+
+    CTransaction tx = CreateSlashTx(pub_key, vote1, vote2);
+    CValidationState err_state;
+
+    CheckSlashTx(tx, err_state, &vote1, &vote2);
+    BOOST_CHECK(err_state.IsValid());
+  }
+}
+
+BOOST_AUTO_TEST_CASE(ContextualCheckSlashTx_test) {
+  CKey key;
+  InsecureNewKey(key, true);
+  CPubKey pub_key = key.GetPubKey();
+  uint160 validator_address = pub_key.GetID();
+
+  {
+    Vote vote1;
+    Vote vote2;
+
+    CTransaction tx = CreateSlashTx(pub_key, vote1, vote2);
+    CValidationState err_state;
+    Consensus::Params params = Params().GetConsensus();
+    FinalizationState fin_state(FinalizationParams{}, AdminParams{});
+
+    bool ok = ContextualCheckSlashTx(tx, err_state, params, fin_state);
+    BOOST_CHECK(!ok);
+    BOOST_CHECK_EQUAL(err_state.GetRejectReason(), "bad-slash-not-slashable");
+
+    int dos = 0;
+    err_state.IsInvalid(dos);
+    BOOST_CHECK_EQUAL(dos, 10);
+  }
+
+  {
+    Vote vote1{validator_address, GetRandHash(), 10, 100};
+    Vote vote2{validator_address, GetRandHash(), 10, 100};
+
+    CTransaction tx = CreateSlashTx(pub_key, vote1, vote2);
+    CValidationState err_state;
+    Consensus::Params params = Params().GetConsensus();
+    FinalizationStateSpy spy;
+
+    CAmount deposit_size = spy.MinDepositSize();
+
+    uint256 target_hash = GetRandHash();
+    CBlockIndex block_index;
+    block_index.phashBlock = &target_hash;
+    spy.SetRecommendedTarget(block_index);
+
+    BOOST_CHECK_EQUAL(spy.ValidateDeposit(validator_address, deposit_size),
+                      +Result::SUCCESS);
+    spy.ProcessDeposit(validator_address, deposit_size);
+    for (size_t i = 1; i < 6; ++i) {
+      spy.InitializeEpoch(i * spy.EpochLength());
+    }
+
+    bool ok = ContextualCheckSlashTx(tx, err_state, params, spy);
+    BOOST_CHECK(ok);
+    BOOST_CHECK(err_state.IsValid());
+  }
+}
+
+BOOST_AUTO_TEST_CASE(CheckVoteTx_test) {
+  CKey key;
+  InsecureNewKey(key, true);
+
+  CMutableTransaction mtx;
+  mtx.SetType(TxType::VOTE);
+
+  {
+    // Check vin of transaction
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    Vote vote_out;
+    std::vector<unsigned char> vote_sig_out;
+
+    CheckVoteTx(tx, err_state, &vote_out, &vote_sig_out);
+    BOOST_CHECK_EQUAL("bad-vote-malformed", err_state.GetRejectReason());
+  }
+
+  mtx.vin.resize(1);
+
+  {
+    // Check vout of transaction
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    Vote vote_out;
+    std::vector<unsigned char> vote_sig_out;
+
+    CheckVoteTx(tx, err_state, &vote_out, &vote_sig_out);
+    BOOST_CHECK_EQUAL("bad-vote-malformed", err_state.GetRejectReason());
+  }
+
+  mtx.vout.resize(1);
+
+  {
+    // Check vote vout script
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    Vote vote_out;
+    std::vector<unsigned char> vote_sig_out;
+
+    CheckVoteTx(tx, err_state, &vote_out, &vote_sig_out);
+    BOOST_CHECK_EQUAL("bad-vote-vout-script", err_state.GetRejectReason());
+  }
+
+  {
+    CScript script = CScript::CreatePayVoteSlashScript(key.GetPubKey());
+    mtx.vout = {CTxOut(1, script)};
+
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    Vote vote_out;
+    std::vector<unsigned char> vote_sig_out;
+
+    CheckVoteTx(tx, err_state, &vote_out, &vote_sig_out);
+    BOOST_CHECK_EQUAL("bad-vote-data-format", err_state.GetRejectReason());
+  }
+
+  {
+    Vote vote;
+
+    CScript encoded_vote = CScript::EncodeVote(vote, ToByteVector(GetRandHash()));
+    std::vector<unsigned char> voteVector(encoded_vote.begin(), encoded_vote.end());
+
+    CScript script = (CScript() << ToByteVector(GetRandHash())) << voteVector;
+    mtx.vin = {CTxIn(GetRandHash(), 0, script)};
+
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    Vote vote_out;
+    std::vector<unsigned char> vote_sig_out;
+
+    CheckVoteTx(tx, err_state, &vote_out, &vote_sig_out);
+    BOOST_CHECK_EQUAL("bad-vote-signature", err_state.GetRejectReason());
+  }
+
+  {
+    CTransaction prev_tx;
+
+    CBasicKeyStore keystore;
+    CKey key;
+    InsecureNewKey(key, true);
+    keystore.AddKey(key);
+    CPubKey pub_key = key.GetPubKey();
+
+    Vote vote_out{pub_key.GetID(), GetRandHash(), 10, 100};
+
+    std::vector<unsigned char> vote_sig_out;
+    BOOST_CHECK(Vote::CreateSignature(&keystore, vote_out, vote_sig_out));
+
+    CTransaction tx = CreateVoteTx(prev_tx, key, vote_out, vote_sig_out);
+    CValidationState err_state;
+
+    CheckVoteTx(tx, err_state, &vote_out, &vote_sig_out);
+    BOOST_CHECK(err_state.IsValid());
+  }
+}
+
+BOOST_AUTO_TEST_CASE(ContextualCheckVoteTx_test) {
+  uint256 target_hash = GetRandHash();
+
+  CBasicKeyStore keystore;
+  CKey key;
+  InsecureNewKey(key, true);
+  keystore.AddKey(key);
+  CPubKey pub_key = key.GetPubKey();
+  uint160 validator_address = pub_key.GetID();
+
+  Vote vote_out{pub_key.GetID(), target_hash, 0, 4};
+
+  std::vector<unsigned char> vote_sig_out;
+  BOOST_CHECK(Vote::CreateSignature(&keystore, vote_out, vote_sig_out));
+
+  CMutableTransaction mt;
+  mt.SetType(TxType::DEPOSIT);
+  mt.vin.resize(1);
+  mt.vout.resize(1);
+  mt.vout = {CTxOut(1, CScript::CreatePayVoteSlashScript(pub_key))};
+  CTransaction prev_tx(mt);
+
+  {
+    CTransaction tx = CreateVoteTx(prev_tx, key, vote_out, vote_sig_out);
+    CValidationState err_state;
+    Consensus::Params params = Params().GetConsensus();
+    FinalizationStateSpy spy;
+
+    CAmount deposit_size = spy.MinDepositSize();
+
+    CBlockIndex block_index;
+    block_index.phashBlock = &target_hash;
+    spy.SetRecommendedTarget(block_index);
+
+    BOOST_CHECK_EQUAL(spy.ValidateDeposit(validator_address, deposit_size),
+                      +Result::SUCCESS);
+    spy.ProcessDeposit(validator_address, deposit_size);
+    for (size_t i = 1; i < 6; ++i) {
+      spy.InitializeEpoch(i * spy.EpochLength());
+    }
+
+    bool ok = ContextualCheckVoteTx(tx, err_state, params, spy);
+    BOOST_CHECK(!ok);
+    BOOST_CHECK_EQUAL(err_state.GetRejectReason(), "bad-vote-no-prev-tx-found");
+  }
+
+  {
+    TestMemPoolEntryHelper entry;
+    mempool.addUnchecked(prev_tx.GetHash(), entry.Fee(1000).Time(GetTime()).SpendsCoinbase(true).FromTx(prev_tx));
+
+    FinalizationStateSpy spy;
+    CAmount deposit_size = spy.MinDepositSize();
+
+    CBlockIndex block_index;
+    block_index.phashBlock = &target_hash;
+    spy.SetRecommendedTarget(block_index);
+
+    BOOST_CHECK_EQUAL(spy.ValidateDeposit(validator_address, deposit_size),
+                      +Result::SUCCESS);
+    spy.ProcessDeposit(validator_address, deposit_size);
+    for (size_t i = 1; i < 6; ++i) {
+      spy.InitializeEpoch(i * spy.EpochLength());
+    }
+
+    CTransaction tx = CreateVoteTx(prev_tx, key, vote_out, vote_sig_out);
+    CValidationState err_state;
+    Consensus::Params params = Params().GetConsensus();
+
+    bool ok = ContextualCheckVoteTx(tx, err_state, params, spy);
+    BOOST_CHECK(ok);
+    BOOST_CHECK(err_state.IsValid());
+  }
+}
+
+BOOST_AUTO_TEST_CASE(CheckWithdrawTx_test) {
+  CKey key;
+  InsecureNewKey(key, true);
+
+  CMutableTransaction mtx;
+  mtx.SetType(TxType::WITHDRAW);
+
+  mtx.vout.resize(4);
+
+  {
+    // Check vout of transaction
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    uint160 va_out;
+
+    CheckWithdrawTx(tx, err_state, &va_out);
+    BOOST_CHECK_EQUAL("bad-withdraw-malformed", err_state.GetRejectReason());
+  }
+
+  mtx.vout.resize(1);
+
+  {
+    // Check vin of transaction
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    uint160 va_out;
+
+    CheckWithdrawTx(tx, err_state, &va_out);
+    BOOST_CHECK_EQUAL("bad-withdraw-malformed", err_state.GetRejectReason());
+  }
+
+  mtx.vin.resize(1);
+
+  {
+    // Check P2PKH script
+    CTransaction tx(mtx);
+    CValidationState err_state;
+    uint160 va_out;
+
+    CheckWithdrawTx(tx, err_state, &va_out);
+    BOOST_CHECK_EQUAL("bad-withdraw-vout-script-invalid-p2pkh", err_state.GetRejectReason());
+  }
+
+  {
+    CTransaction tx = CreateWithdrawTx(CTransaction(mtx), key, 1);
+    CValidationState err_state;
+    uint160 va_out;
+
+    CheckWithdrawTx(tx, err_state, &va_out);
+    BOOST_CHECK(err_state.IsValid());
+  }
+}
+
+BOOST_AUTO_TEST_CASE(ContextualCheckWithdrawTx_test) {
+
+  uint256 target_hash = GetRandHash();
+
+  CKey key;
+  InsecureNewKey(key, true);
+  CPubKey pub_key = key.GetPubKey();
+  uint160 validator_address = pub_key.GetID();
+
+  CMutableTransaction mt;
+  mt.SetType(TxType::LOGOUT);
+  mt.vin.resize(1);
+  mt.vout.resize(1);
+  mt.vout = {CTxOut(1, CScript::CreatePayVoteSlashScript(pub_key))};
+  CTransaction prev_tx(mt);
+
+  {
+    CBlockIndex block_index;
+    block_index.phashBlock = &target_hash;
+
+    FinalizationStateSpy spy;
+    CAmount deposit_size = spy.MinDepositSize();
+    spy.SetRecommendedTarget(block_index);
+
+    BOOST_CHECK_EQUAL(spy.ValidateDeposit(validator_address, deposit_size),
+                      +Result::SUCCESS);
+    spy.ProcessDeposit(validator_address, deposit_size);
+    for (size_t i = 1; i < 6; ++i) {
+      spy.InitializeEpoch(i * spy.EpochLength());
+    }
+
+    CTransaction tx = CreateWithdrawTx(prev_tx, key, 1);
+    CValidationState err_state;
+    Consensus::Params params = Params().GetConsensus();
+
+    bool ok = ContextualCheckWithdrawTx(tx, err_state, params, spy);
+    BOOST_CHECK(!ok);
+    BOOST_CHECK_EQUAL(err_state.GetRejectReason(), "bad-withdraw-no-prev-tx-found");
+  }
+
+  {
+    TestMemPoolEntryHelper entry;
+    mempool.addUnchecked(prev_tx.GetHash(), entry.Fee(1000).Time(GetTime()).SpendsCoinbase(true).FromTx(prev_tx));
+
+    CBlockIndex block_index;
+    block_index.phashBlock = &target_hash;
+
+    FinalizationParams fin_params = CreateFinalizationParams();
+    FinalizationStateSpy spy(fin_params, AdminParams{});
+    CAmount deposit_size = spy.MinDepositSize();
+    spy.SetRecommendedTarget(block_index);
+
+    BOOST_CHECK_EQUAL(spy.ValidateDeposit(validator_address, deposit_size),
+                      +Result::SUCCESS);
+    spy.ProcessDeposit(validator_address, deposit_size);
+    for (size_t i = 1; i < 8; ++i) {
+      spy.InitializeEpoch(i * spy.EpochLength());
+    }
+
+    BOOST_CHECK_EQUAL(spy.ValidateLogout(validator_address), +Result::SUCCESS);
+    spy.ProcessLogout(validator_address);
+
+    Validator *validator = &(*spy.pValidators())[validator_address];
+    validator->m_end_dynasty = 0;
+
+    CTransaction tx = CreateWithdrawTx(prev_tx, key, 1);
+    CValidationState err_state;
+    Consensus::Params params = Params().GetConsensus();
+
+    bool ok = ContextualCheckWithdrawTx(tx, err_state, params, spy);
+    BOOST_CHECK(ok);
+    BOOST_CHECK(err_state.IsValid());
+  }
+}
+
+BOOST_AUTO_TEST_CASE(IsVoteExpired_test) {
+
+  FinalizationState *esperanza = FinalizationState::GetState();
+
+  const auto &params = CreateChainParams(CBaseChainParams::TESTNET)->GetFinalization();
+  const auto min_deposit = params.min_deposit_size;
+  const auto epoch_length = params.epoch_length;
+
+  CKey k;
+  InsecureNewKey(k, true);
+  uint160 validator_address = k.GetPubKey().GetID();
+
+  BOOST_CHECK_EQUAL(
+      esperanza->ValidateDeposit(validator_address, min_deposit),
+      +Result::SUCCESS);
+
+  esperanza->ProcessDeposit(validator_address, min_deposit);
+
+  // Initialize few epoch - since epoch 4 we don't have instant finalization
+  for (int i = 1; i < 6; ++i) {
+    BOOST_CHECK_EQUAL(esperanza->InitializeEpoch(i * epoch_length),
+                      +Result::SUCCESS);
+  }
+
+  uint256 target_hash = uint256();
+
+  Vote expired{RandValidatorAddr(), target_hash, 0, 2};
+  BOOST_CHECK_EQUAL(IsVoteExpired(CreateVoteTx(expired, k)), true);
+
+  Vote current{RandValidatorAddr(), target_hash, 0, 5};
+  BOOST_CHECK_EQUAL(IsVoteExpired(CreateVoteTx(current, k)), false);
+
+  Vote afterLastFinalization{RandValidatorAddr(), target_hash, 0, 3};
+  BOOST_CHECK_EQUAL(IsVoteExpired(CreateVoteTx(afterLastFinalization, k)), true);
+
+  Vote future{RandValidatorAddr(), target_hash, 0, 12};
+  BOOST_CHECK_EQUAL(IsVoteExpired(CreateVoteTx(future, k)), false);
+
+  Vote currentOtherFork{RandValidatorAddr(), GetRandHash(), 0, 5};
+  BOOST_CHECK_EQUAL(IsVoteExpired(CreateVoteTx(currentOtherFork, k)), false);
+}
+
+BOOST_AUTO_TEST_CASE(CheckVoteTransaction_malformed_vote) {
+
+  CKey key;
+  key.MakeNewKey(true);
+  Vote vote = Vote{key.GetPubKey().GetID(), GetRandHash(), 0, 2};
+  CTransaction tx = CreateVoteTx(vote, key);
+  CMutableTransaction mutedTx(tx);
+
+  // Replace the vote with something meaningless
+  mutedTx.vin[0].scriptSig = CScript() << 1337;
+
+  CTransaction invalidVote(mutedTx);
+  Consensus::Params params = Params().GetConsensus();
+  CValidationState err_state;
+  BOOST_CHECK(CheckFinalizationTx(invalidVote, err_state) == false);
+  const auto &fin_state = *esperanza::FinalizationState::GetState(chainActive.Tip());
+  BOOST_CHECK(ContextualCheckVoteTx(invalidVote, err_state, params, fin_state) == false);
+
+  BOOST_CHECK_EQUAL("bad-vote-data-format", err_state.GetRejectReason());
+}
+
+BOOST_AUTO_TEST_CASE(ExtractValidatorIndex_deposit) {
+
+  CKey k;
+  InsecureNewKey(k, true);
+
+  CMutableTransaction tx;
+  tx.SetType(TxType::DEPOSIT);
+  tx.vin.resize(1);
+  tx.vout.resize(1);
+  CTransaction prev_tx(tx);
+
+  CTransaction deposit = CreateDepositTx(prev_tx, k, 10000);
+  uint160 validator_address = uint160();
+  BOOST_CHECK(ExtractValidatorAddress(deposit, validator_address));
+
+  BOOST_CHECK_EQUAL(k.GetPubKey().GetID().GetHex(), validator_address.GetHex());
+}
+
 BOOST_AUTO_TEST_CASE(ExtractValidatorIndex_logout) {
 
   CKey k;
@@ -161,13 +951,13 @@ BOOST_AUTO_TEST_CASE(ExtractValidatorIndex_logout) {
   tx.SetType(TxType::DEPOSIT);
   tx.vin.resize(1);
   tx.vout.resize(1);
-  CTransaction prevTx(tx);
+  CTransaction prev_tx(tx);
 
-  CTransaction logout = CreateLogoutTx(prevTx, k, 10000);
-  uint160 validatorAddress = uint160();
-  BOOST_CHECK(ExtractValidatorAddress(logout, validatorAddress));
+  CTransaction logout = CreateLogoutTx(prev_tx, k, 10000);
+  uint160 validator_address = uint160();
+  BOOST_CHECK(ExtractValidatorAddress(logout, validator_address));
 
-  BOOST_CHECK_EQUAL(k.GetPubKey().GetID().GetHex(), validatorAddress.GetHex());
+  BOOST_CHECK_EQUAL(k.GetPubKey().GetID().GetHex(), validator_address.GetHex());
 }
 
 BOOST_AUTO_TEST_CASE(ExtractValidatorIndex_withdraw) {
@@ -179,13 +969,13 @@ BOOST_AUTO_TEST_CASE(ExtractValidatorIndex_withdraw) {
   tx.SetType(TxType::LOGOUT);
   tx.vin.resize(1);
   tx.vout.resize(1);
-  CTransaction prevTx(tx);
+  CTransaction prev_tx(tx);
 
-  CTransaction withdraw = CreateWithdrawTx(prevTx, k, 10000);
-  uint160 validatorAddress = uint160();
-  BOOST_CHECK(ExtractValidatorAddress(withdraw, validatorAddress));
+  CTransaction withdraw = CreateWithdrawTx(prev_tx, k, 10000);
+  uint160 validator_address = uint160();
+  BOOST_CHECK(ExtractValidatorAddress(withdraw, validator_address));
 
-  BOOST_CHECK_EQUAL(k.GetPubKey().GetID().GetHex(), validatorAddress.GetHex());
+  BOOST_CHECK_EQUAL(k.GetPubKey().GetID().GetHex(), validator_address.GetHex());
 }
 
 BOOST_AUTO_TEST_CASE(ExtractValidatorIndex_p2pkh_fails) {
@@ -197,11 +987,11 @@ BOOST_AUTO_TEST_CASE(ExtractValidatorIndex_p2pkh_fails) {
   tx.SetType(TxType::REGULAR);
   tx.vin.resize(1);
   tx.vout.resize(1);
-  CTransaction prevTx(tx);
+  CTransaction prev_tx(tx);
 
-  CTransaction p2pkh = CreateP2PKHTx(prevTx, k, 10000);
-  uint160 validatorAddress = uint160();
-  BOOST_CHECK(ExtractValidatorAddress(p2pkh, validatorAddress) == false);
+  CTransaction p2pkh = CreateP2PKHTx(prev_tx, k, 10000);
+  uint160 validator_address = uint160();
+  BOOST_CHECK(ExtractValidatorAddress(p2pkh, validator_address) == false);
 }
 
 BOOST_AUTO_TEST_CASE(ExtractValidatorIndex_vote_fails) {
@@ -212,8 +1002,8 @@ BOOST_AUTO_TEST_CASE(ExtractValidatorIndex_vote_fails) {
   InsecureNewKey(k, true);
 
   CTransaction p2pkh = CreateVoteTx(vote, k);
-  uint160 validatorAddress = uint160();
-  BOOST_CHECK(ExtractValidatorAddress(p2pkh, validatorAddress) == false);
+  uint160 validator_address = uint160();
+  BOOST_CHECK(ExtractValidatorAddress(p2pkh, validator_address) == false);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/esperanza/finalization_utils.cpp
+++ b/src/test/esperanza/finalization_utils.cpp
@@ -7,101 +7,106 @@
 #include <test/esperanza/finalization_utils.h>
 #include <boost/test/unit_test.hpp>
 
-CTransaction CreateBaseTransaction(const CTransaction &spendableTx,
-                                   const CKey &spendableKey, CAmount amount,
+CTransaction CreateBaseTransaction(const CTransaction &spendable_tx,
+                                   const CKey &spendable_key, CAmount amount,
                                    const TxType type,
-                                   const CScript &scriptPubKey) {
+                                   const CScript &script_pub_key) {
 
   CBasicKeyStore keystore;
-  keystore.AddKey(spendableKey);
+  keystore.AddKey(spendable_key);
 
-  CMutableTransaction mutTx;
-  mutTx.SetType(type);
+  CMutableTransaction mtx;
+  mtx.SetType(type);
 
-  mutTx.vin.resize(1);
-  mutTx.vin[0].prevout.hash = spendableTx.GetHash();
-  mutTx.vin[0].prevout.n = 0;
+  mtx.vin.resize(1);
+  mtx.vin[0].prevout.hash = spendable_tx.GetHash();
+  mtx.vin[0].prevout.n = 0;
 
-  CTxOut out(amount, scriptPubKey);
-  mutTx.vout.push_back(out);
+  CTxOut out(amount, script_pub_key);
+  mtx.vout.push_back(out);
 
   // Sign
-  std::vector<unsigned char> vchSig;
-  uint256 hash = SignatureHash(spendableTx.vout[0].scriptPubKey, mutTx, 0,
+  std::vector<unsigned char> vch_sig;
+  uint256 hash = SignatureHash(spendable_tx.vout[0].scriptPubKey, mtx, 0,
                                SIGHASH_ALL, amount, SigVersion::BASE);
 
-  BOOST_CHECK(spendableKey.Sign(hash, vchSig));
-  vchSig.push_back((unsigned char)SIGHASH_ALL);
+  BOOST_CHECK(spendable_key.Sign(hash, vch_sig));
+  vch_sig.push_back((unsigned char)SIGHASH_ALL);
 
-  mutTx.vin[0].scriptSig = CScript() << ToByteVector(vchSig)
-                                     << ToByteVector(spendableKey.GetPubKey());
+  mtx.vin[0].scriptSig = CScript() << ToByteVector(vch_sig)
+                                   << ToByteVector(spendable_key.GetPubKey());
 
-  return CTransaction(mutTx);
+  return CTransaction(mtx);
 }
 
-CTransaction CreateVoteTx(esperanza::Vote &vote, const CKey &spendableKey) {
+CTransaction CreateVoteTx(const CTransaction &spendable_tx, const CKey &spendable_key,
+                          const esperanza::Vote &vote, const std::vector<unsigned char> &vote_sig) {
 
-  CMutableTransaction mutTx;
-  mutTx.SetType(TxType::VOTE);
+  CMutableTransaction mtx;
+  mtx.SetType(TxType::VOTE);
+  mtx.vin.resize(1);
+  mtx.vout.resize(1);
 
-  mutTx.vin.resize(1);
-  uint256 signature = GetRandHash();
+  CScript vote_script = CScript::EncodeVote(vote, vote_sig);
+  std::vector<unsigned char> voteVector(vote_script.begin(), vote_script.end());
 
-  std::vector<unsigned char> voteSig;
-  BOOST_CHECK(spendableKey.Sign(vote.GetHash(), voteSig));
+  CScript script_sig = (CScript() << vote_sig) << voteVector;
+  mtx.vin[0] = CTxIn(GetRandHash(), 0, script_sig);
 
-  CScript voteScript = CScript::EncodeVote(vote, voteSig);
-  std::vector<unsigned char> voteVector(voteScript.begin(), voteScript.end());
+  CScript script_pub_key = CScript::CreatePayVoteSlashScript(spendable_key.GetPubKey());
+  mtx.vout[0] = CTxOut(10000, script_pub_key);
 
-  CScript scriptSig = (CScript() << ToByteVector(signature)) << voteVector;
-  mutTx.vin[0] = (CTxIn(GetRandHash(), 0, scriptSig));
+  mtx.vin[0].prevout.hash = spendable_tx.GetHash();
+  mtx.vin[0].prevout.n = 0;
 
-  uint256 keyHash = GetRandHash();
-  CKey k;
-  k.Set(keyHash.begin(), keyHash.end(), true);
-  CScript scriptPubKey = CScript::CreatePayVoteSlashScript(k.GetPubKey());
-
-  CTxOut out{10000, scriptPubKey};
-  mutTx.vout.push_back(out);
-
-  return CTransaction(mutTx);
+  return CTransaction(mtx);
 }
 
-CTransaction CreateDepositTx(const CTransaction &spendableTx,
-                             const CKey &spendableKey, CAmount amount) {
-  CScript scriptPubKey =
-      CScript::CreatePayVoteSlashScript(spendableKey.GetPubKey());
+CTransaction CreateVoteTx(const esperanza::Vote &vote, const CKey &spendable_key) {
 
-  return CreateBaseTransaction(spendableTx, spendableKey, amount,
-                               TxType::DEPOSIT, scriptPubKey);
+  CTransaction spendable_tx;
+
+  std::vector<unsigned char> vote_sig;
+  BOOST_CHECK(spendable_key.Sign(vote.GetHash(), vote_sig));
+
+  return CreateVoteTx(spendable_tx, spendable_key, vote, vote_sig);
 }
 
-CTransaction CreateLogoutTx(const CTransaction &spendableTx,
-                            const CKey &spendableKey, CAmount amount) {
+CTransaction CreateDepositTx(const CTransaction &spendable_tx,
+                             const CKey &spendable_key, CAmount amount) {
+  CScript script_pub_key =
+      CScript::CreatePayVoteSlashScript(spendable_key.GetPubKey());
 
-  CScript scriptPubKey =
-      CScript::CreatePayVoteSlashScript(spendableKey.GetPubKey());
-
-  return CreateBaseTransaction(spendableTx, spendableKey, amount,
-                               TxType::LOGOUT, scriptPubKey);
+  return CreateBaseTransaction(spendable_tx, spendable_key, amount,
+                               TxType::DEPOSIT, script_pub_key);
 }
 
-CTransaction CreateWithdrawTx(const CTransaction &spendableTx,
-                              const CKey &spendableKey, CAmount amount) {
+CTransaction CreateLogoutTx(const CTransaction &spendable_tx,
+                            const CKey &spendable_key, CAmount amount) {
 
-  CScript scriptPubKey = CScript::CreateP2PKHScript(
-      ToByteVector(spendableKey.GetPubKey().GetID()));
+  CScript script_pub_key =
+      CScript::CreatePayVoteSlashScript(spendable_key.GetPubKey());
 
-  return CreateBaseTransaction(spendableTx, spendableKey, amount,
-                               TxType::WITHDRAW, scriptPubKey);
+  return CreateBaseTransaction(spendable_tx, spendable_key, amount,
+                               TxType::LOGOUT, script_pub_key);
 }
 
-CTransaction CreateP2PKHTx(const CTransaction &spendableTx,
-                           const CKey &spendableKey, CAmount amount) {
+CTransaction CreateWithdrawTx(const CTransaction &spendable_tx,
+                              const CKey &spendable_key, CAmount amount) {
 
-  CScript scriptPubKey = CScript::CreateP2PKHScript(
-      ToByteVector(spendableKey.GetPubKey().GetID()));
+  CScript script_pub_key = CScript::CreateP2PKHScript(
+      ToByteVector(spendable_key.GetPubKey().GetID()));
 
-  return CreateBaseTransaction(spendableTx, spendableKey, amount,
-                               TxType::REGULAR, scriptPubKey);
+  return CreateBaseTransaction(spendable_tx, spendable_key, amount,
+                               TxType::WITHDRAW, script_pub_key);
+}
+
+CTransaction CreateP2PKHTx(const CTransaction &spendable_tx,
+                           const CKey &spendable_key, CAmount amount) {
+
+  CScript script_pub_key = CScript::CreateP2PKHScript(
+      ToByteVector(spendable_key.GetPubKey().GetID()));
+
+  return CreateBaseTransaction(spendable_tx, spendable_key, amount,
+                               TxType::REGULAR, script_pub_key);
 }

--- a/src/test/esperanza/finalization_utils.h
+++ b/src/test/esperanza/finalization_utils.h
@@ -9,18 +9,21 @@
 #ifndef UNIT_E_TESTS_ESPERANZA_FINALIZATION_UTILS_H
 #define UNIT_E_TESTS_ESPERANZA_FINALIZATION_UTILS_H
 
-CTransaction CreateVoteTx(esperanza::Vote &vote, const CKey &spendableKey);
+CTransaction CreateVoteTx(const esperanza::Vote &vote, const CKey &spendable_key);
 
-CTransaction CreateDepositTx(const CTransaction &spendableTx,
-                             const CKey &spendableKey, CAmount amount);
+CTransaction CreateVoteTx(const CTransaction &spendable_tx, const CKey &spendable_key,
+                          const esperanza::Vote &vote, const std::vector<unsigned char> &vote_sig);
 
-CTransaction CreateLogoutTx(const CTransaction &spendableTx,
-                            const CKey &spendableKey, CAmount amount);
+CTransaction CreateDepositTx(const CTransaction &spendable_tx,
+                             const CKey &spendable_key, CAmount amount);
 
-CTransaction CreateWithdrawTx(const CTransaction &spendableTx,
-                              const CKey &spendableKey, CAmount amount);
+CTransaction CreateLogoutTx(const CTransaction &spendable_tx,
+                            const CKey &spendable_key, CAmount amount);
 
-CTransaction CreateP2PKHTx(const CTransaction &spendableTx,
-                           const CKey &spendableKey, CAmount amount);
+CTransaction CreateWithdrawTx(const CTransaction &spendable_tx,
+                              const CKey &spendable_key, CAmount amount);
+
+CTransaction CreateP2PKHTx(const CTransaction &spendable_tx,
+                           const CKey &spendable_key, CAmount amount);
 
 #endif  // UNIT_E_TESTS_ESPERANZA_FINALIZATION_UTILS_H

--- a/src/test/esperanza/finalizationstate_utils.cpp
+++ b/src/test/esperanza/finalizationstate_utils.cpp
@@ -9,3 +9,13 @@ uint160 RandValidatorAddr() {
   key.MakeNewKey(true);
   return key.GetPubKey().GetID();
 }
+
+CPubKey MakePubKey() {
+  CKey key;
+  key.MakeNewKey(true);
+  return key.GetPubKey();
+}
+
+esperanza::AdminKeySet MakeKeySet() {
+  return {{MakePubKey(), MakePubKey(), MakePubKey()}};
+}

--- a/src/test/esperanza/finalizationstate_utils.h
+++ b/src/test/esperanza/finalizationstate_utils.h
@@ -18,6 +18,9 @@ class FinalizationStateSpy : public FinalizationState {
   const FinalizationParams params = CreateChainParams(CBaseChainParams::TESTNET)->GetFinalization();
 
  public:
+  FinalizationStateSpy(const FinalizationParams &_params,
+                       const AdminParams &adminParams) : FinalizationState(_params, adminParams),
+                                                         params(_params) {}
   FinalizationStateSpy() : FinalizationState(params, AdminParams()) {}
   FinalizationStateSpy(const FinalizationParams &_params) : FinalizationState(_params, AdminParams()),
                                                             params(_params) {}
@@ -62,5 +65,7 @@ class FinalizationStateSpy : public FinalizationState {
 };
 
 uint160 RandValidatorAddr();
+CPubKey MakePubKey();
+esperanza::AdminKeySet MakeKeySet();
 
 #endif  //UNIT_E_TESTS_FINALIZATIONSTATE_UTILS_H


### PR DESCRIPTION
Fixes #480

Here are a couple of tests for finalization transactions.

Signed-off-by: Dmitry Saveliev <dima@thirdhash.com>
