### PR TITLE
Remove OnBlock

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -147,7 +147,7 @@ public:
         };
 
         if(gArgs.GetBoolArg("-permissioning", false)) {
-          adminParams.m_block_to_admin_keys.emplace(0, CreateRegTestAdminKeys());
+          adminParams.admin_keys = CreateRegTestAdminKeys();
         }
 
         snapshotParams.create_snapshot_per_epoch = static_cast<uint16_t>(gArgs.GetArg("-createsnapshot", 1));

--- a/src/esperanza/adminparams.h
+++ b/src/esperanza/adminparams.h
@@ -20,8 +20,8 @@ using AdminKeySet = std::array<CPubKey, ADMIN_MULTISIG_KEYS>;
 
 //! \brief Esperanza Permissioning-specific blockchain parameters
 struct AdminParams {
-  std::map<blockchain::Height, AdminKeySet> m_block_to_admin_keys;
-  std::map<blockchain::Height, std::vector<uint160>> m_block_to_white_list;
+  boost::optional<AdminKeySet> admin_keys;
+  std::vector<uint160> white_list;
 };
 
 }  // namespace esperanza

--- a/src/esperanza/adminstate.h
+++ b/src/esperanza/adminstate.h
@@ -25,13 +25,11 @@ namespace esperanza {
 class AdminState {
   AdminKeySet m_admin_pub_keys;
   std::set<uint160> m_white_list;
-  const AdminParams &m_admin_params;
   bool m_permissioning_is_active;
 
  public:
-  explicit AdminState(const AdminParams &adminParams);
+  explicit AdminState(const AdminParams &params);
 
-  void OnBlock(blockchain::Height blockHeight);
   bool IsAdminAuthorized(const AdminKeySet &keys) const;
   bool IsValidatorAuthorized(const uint160 &validatorAddress) const;
   void ResetAdmin(const AdminKeySet &newKeys);
@@ -39,7 +37,6 @@ class AdminState {
   void RemoveValidator(const uint160 &validatorAddress);
   void EndPermissioning();
   bool IsPermissioningActive() const;
-  const AdminParams &GetParams() const;
   bool operator==(const AdminState &other) const;
 };
 

--- a/src/esperanza/finalizationstate.cpp
+++ b/src/esperanza/finalizationstate.cpp
@@ -666,10 +666,6 @@ bool FinalizationState::IsPermissioningActive() const {
   return m_admin_state.IsPermissioningActive();
 }
 
-void FinalizationState::OnBlock(blockchain::Height blockHeight) {
-  m_admin_state.OnBlock(blockHeight);
-}
-
 Result FinalizationState::ValidateAdminKeys(const AdminKeySet &adminKeys) const {
   LOCK(cs_esperanza);
 
@@ -990,9 +986,6 @@ void FinalizationState::ProcessNewCommits(const CBlockIndex &block_index,
   LOCK(cs_esperanza);
   assert(m_status == NEW);
   uint256 block_hash = block_index.GetBlockHash();
-
-  // Used to apply hardcoded parameters for a given block
-  OnBlock(block_index.nHeight);
 
   // We can skip everything for the genesis block since it isn't suppose to
   // contain esperanza's transactions.

--- a/src/esperanza/finalizationstate.h
+++ b/src/esperanza/finalizationstate.h
@@ -224,9 +224,6 @@ class FinalizationState : public FinalizationStateData {
  protected:
   const FinalizationParams &m_settings;
   InitStatus m_status = NEW;
-
- private:
-  void OnBlock(blockchain::Height blockHeight);
 };
 
 inline uint32_t GetEpoch(const CBlockIndex &blockIndex) { return FinalizationState::GetState()->GetEpoch(blockIndex); }

--- a/src/test/esperanza/adminstate_tests.cpp
+++ b/src/test/esperanza/adminstate_tests.cpp
@@ -25,20 +25,19 @@ BOOST_AUTO_TEST_CASE(empty_params_mean_no_admin) {
   esperanza::AdminParams emptyParams;
   esperanza::AdminState state(emptyParams);
 
-  const auto validatorAddress = RandValidatorAddr();
+  const uint160 validatorAddress = RandValidatorAddr();
 
   BOOST_CHECK(state.IsValidatorAuthorized(validatorAddress));
 }
 
-BOOST_AUTO_TEST_CASE(reset_admin_soft) {
-  const auto set0 = MakeKeySet();
-  const auto set1 = MakeKeySet();
+BOOST_AUTO_TEST_CASE(reset_admin) {
+  const esperanza::AdminKeySet set0 = MakeKeySet();
+  const esperanza::AdminKeySet set1 = MakeKeySet();
 
   esperanza::AdminParams params;
-  params.m_block_to_admin_keys.emplace(0, set0);
+  params.admin_keys = set0;
 
   esperanza::AdminState state(params);
-  state.OnBlock(0);
 
   BOOST_CHECK(state.IsAdminAuthorized(set0));
   BOOST_CHECK(!state.IsAdminAuthorized(set1));
@@ -49,42 +48,12 @@ BOOST_AUTO_TEST_CASE(reset_admin_soft) {
   BOOST_CHECK(state.IsAdminAuthorized(set1));
 }
 
-BOOST_AUTO_TEST_CASE(reset_admin_hard) {
-  const auto set0 = MakeKeySet();
-  const auto set1 = MakeKeySet();
-
+BOOST_AUTO_TEST_CASE(change_white_list) {
   esperanza::AdminParams params;
-  params.m_block_to_admin_keys.emplace(0, set0);
-  params.m_block_to_admin_keys.emplace(42, set1);
-
-  esperanza::AdminState state(params);
-  state.OnBlock(0);
-
-  BOOST_CHECK(state.IsAdminAuthorized(set0));
-  BOOST_CHECK(!state.IsAdminAuthorized(set1));
-
-  state.OnBlock(10);
-
-  BOOST_CHECK(state.IsAdminAuthorized(set0));
-  BOOST_CHECK(!state.IsAdminAuthorized(set1));
-
-  state.OnBlock(42);
-
-  BOOST_CHECK(!state.IsAdminAuthorized(set0));
-  BOOST_CHECK(state.IsAdminAuthorized(set1));
-
-  state.OnBlock(100);
-
-  BOOST_CHECK(!state.IsAdminAuthorized(set0));
-  BOOST_CHECK(state.IsAdminAuthorized(set1));
-}
-
-BOOST_AUTO_TEST_CASE(change_white_list_soft) {
-  esperanza::AdminParams params;
-  params.m_block_to_admin_keys.emplace(0, MakeKeySet());
+  params.admin_keys = MakeKeySet();
   esperanza::AdminState state(params);
 
-  const auto validator = RandValidatorAddr();
+  const uint160 validator = RandValidatorAddr();
 
   BOOST_CHECK(!state.IsValidatorAuthorized(validator));
 
@@ -97,56 +66,12 @@ BOOST_AUTO_TEST_CASE(change_white_list_soft) {
   BOOST_CHECK(!state.IsValidatorAuthorized(validator));
 }
 
-BOOST_AUTO_TEST_CASE(change_white_list_hard) {
-  esperanza::AdminParams params = {};
-  params.m_block_to_admin_keys.emplace(0, MakeKeySet());
-
-  const auto validator1 = RandValidatorAddr();
-  const auto validator2 = RandValidatorAddr();
-
-  params.m_block_to_white_list[0] = {};
-  params.m_block_to_white_list[1] = {validator1};
-  params.m_block_to_white_list[2] = {validator1, validator2};
-  params.m_block_to_white_list[3] = {validator2};
-  params.m_block_to_white_list[4] = {};
-
-  esperanza::AdminState state(params);
-
-  BOOST_CHECK(!state.IsValidatorAuthorized(validator1));
-  BOOST_CHECK(!state.IsValidatorAuthorized(validator2));
-
-  state.OnBlock(1);
-
-  BOOST_CHECK(state.IsValidatorAuthorized(validator1));
-  BOOST_CHECK(!state.IsValidatorAuthorized(validator2));
-
-  state.OnBlock(2);
-
-  BOOST_CHECK(state.IsValidatorAuthorized(validator1));
-  BOOST_CHECK(state.IsValidatorAuthorized(validator2));
-
-  state.OnBlock(3);
-
-  BOOST_CHECK(!state.IsValidatorAuthorized(validator1));
-  BOOST_CHECK(state.IsValidatorAuthorized(validator2));
-
-  // To check that hard reset is actually reset
-  state.AddValidator(validator1);
-
-  BOOST_CHECK(state.IsValidatorAuthorized(validator1));
-  BOOST_CHECK(state.IsValidatorAuthorized(validator2));
-
-  state.OnBlock(4);
-  BOOST_CHECK(!state.IsValidatorAuthorized(validator1));
-  BOOST_CHECK(!state.IsValidatorAuthorized(validator2));
-}
-
 BOOST_AUTO_TEST_CASE(end_permissioning) {
   esperanza::AdminParams params;
-  params.m_block_to_admin_keys.emplace(0, MakeKeySet());
+  params.admin_keys = MakeKeySet();
   esperanza::AdminState state(params);
 
-  const auto validator = RandValidatorAddr();
+  const uint160 validator = RandValidatorAddr();
 
   BOOST_CHECK(!state.IsValidatorAuthorized(validator));
 


### PR DESCRIPTION
The whole concept of OnBlock was introduced to envision possible loss of admin keys and to design how we would make a hard fork with admin keys.

While the problem this thing is solving is quite blurry, problems it causes are real. @frolosofsky suffered from it some time ago. And now @Ruteri is having problems in a test net.

So I decided to remove it completely. 
I am, however, leaving:
- `AdminParams` as a holder of initial admin keys and initial validator addresses
- Notion of `No admin keys provided => no permissioning`

Signed-off-by: Aleksandr Mikhailov <aleksandr@thirdhash.com>