### PR TITLE
Rename FinalizationTx to FinalizerCommit

### DIFF
--- a/src/esperanza/checks.cpp
+++ b/src/esperanza/checks.cpp
@@ -14,10 +14,10 @@
 
 namespace esperanza {
 
-bool ContextualCheckFinalizerTx(const CTransaction &tx,
-                                CValidationState &err_state,
-                                const Consensus::Params &params,
-                                const FinalizationState &fin_state) {
+bool ContextualCheckFinalizerCommit(const CTransaction &tx,
+                                    CValidationState &err_state,
+                                    const Consensus::Params &params,
+                                    const FinalizationState &fin_state) {
   switch (tx.GetType()) {
     case +TxType::REGULAR:
     case +TxType::COINBASE:
@@ -38,7 +38,7 @@ bool ContextualCheckFinalizerTx(const CTransaction &tx,
   return false;
 }
 
-bool CheckFinalizerTx(const CTransaction &tx, CValidationState &err_state) {
+bool CheckFinalizerCommit(const CTransaction &tx, CValidationState &err_state) {
   switch (tx.GetType()) {
     case +TxType::REGULAR:
     case +TxType::COINBASE:

--- a/src/esperanza/checks.h
+++ b/src/esperanza/checks.h
@@ -30,13 +30,13 @@ bool IsVoteExpired(const CTransaction &tx);
 //! checks it tests transaction is consistent with its input and finalization state.
 
 //! \brief Generalized finalization transaction check. Asserts on non-finalization transactions.
-bool CheckFinalizerTx(const CTransaction &tx, CValidationState &err_state);
+bool CheckFinalizerCommit(const CTransaction &tx, CValidationState &err_state);
 
 //! \brief Generalized finalization transaction contextual check. Asserts on non-finalization transactions.
-bool ContextualCheckFinalizerTx(const CTransaction &tx,
-                                CValidationState &err_state,
-                                const Consensus::Params &params,
-                                const FinalizationState &fin_state);
+bool ContextualCheckFinalizerCommit(const CTransaction &tx,
+                                    CValidationState &err_state,
+                                    const Consensus::Params &params,
+                                    const FinalizationState &fin_state);
 
 bool CheckDepositTx(const CTransaction &tx, CValidationState &err_state,
                     uint160 *validator_address_out);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3526,7 +3526,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, size_t node_index, size_t tot
                     bool send = fSendTrickle;
                     if (!send) {
                         CTransactionRef tx = mempool.get(*it);
-                        send = tx && tx->IsFinalizerTx();
+                        send = tx && tx->IsFinalizerCommit();
                     }
                     if (send) {
                         vInvTx.push_back(it);

--- a/src/p2p/finalizer_commits_handler_impl.cpp
+++ b/src/p2p/finalizer_commits_handler_impl.cpp
@@ -201,7 +201,7 @@ boost::optional<HeaderAndFinalizerCommits> FinalizerCommitsHandlerImpl::FindHead
   }
 
   for (const auto &tx : block.vtx) {
-    if (tx->IsFinalizerTx()) {
+    if (tx->IsFinalizerCommit()) {
       hc.commits.push_back(tx);
     }
   }
@@ -310,11 +310,11 @@ bool FinalizerCommitsHandlerImpl::OnCommits(
   for (const HeaderAndFinalizerCommits &d : msg.data) {
     // UNIT-E TODO: Check commits merkle root after it is added
     for (const auto &c : d.commits) {
-      if (!c->IsFinalizerTx()) {
+      if (!c->IsFinalizerCommit()) {
         return err(100, "bad-non-commit", d.header.GetHash());
       }
       // Make simplest checks which doesn't depend on the context.
-      if (!(CheckTransaction(*c, err_state) && esperanza::CheckFinalizerTx(*c, err_state))) {
+      if (!(CheckTransaction(*c, err_state) && esperanza::CheckFinalizerCommit(*c, err_state))) {
         return false;
       }
     }

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -305,7 +305,7 @@ public:
         return GetType() == +TxType::ADMIN;
     }
 
-    bool IsFinalizerTx() const {
+    bool IsFinalizerCommit() const {
         switch (+GetType()) {
             case TxType::DEPOSIT:
             case TxType::VOTE:

--- a/src/test/esperanza/checks_tests.cpp
+++ b/src/test/esperanza/checks_tests.cpp
@@ -894,7 +894,7 @@ BOOST_AUTO_TEST_CASE(CheckVoteTransaction_malformed_vote) {
   CTransaction invalidVote(mutedTx);
   Consensus::Params params = Params().GetConsensus();
   CValidationState err_state;
-  BOOST_CHECK(CheckFinalizerTx(invalidVote, err_state) == false);
+  BOOST_CHECK(CheckFinalizerCommit(invalidVote, err_state) == false);
   const auto &fin_state = *esperanza::FinalizationState::GetState(chainActive.Tip());
   BOOST_CHECK(ContextualCheckVoteTx(invalidVote, err_state, params, fin_state) == false);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -592,12 +592,12 @@ static BCLog::LogFlags GetTransactionLogCategory(const CTransaction &tx) {
     assert(!"silence gcc warnings");
 }
 
-static bool ContextualCheckFinalizerTx(const CTransaction &tx, CValidationState &err_state,
+static bool ContextualCheckFinalizerCommit(const CTransaction &tx, CValidationState &err_state,
                                           const Consensus::Params &params,
                                           const esperanza::FinalizationState &fin_state) {
     const auto log_cat = GetTransactionLogCategory(tx);
     LogPrint(log_cat, "Checking %s with id %s\n", tx.GetType()._to_string(), tx.GetHash().GetHex());
-    if (!esperanza::ContextualCheckFinalizerTx(tx, err_state, params, fin_state)) {
+    if (!esperanza::ContextualCheckFinalizerCommit(tx, err_state, params, fin_state)) {
         LogPrint(log_cat, "ERROR: %s (%s) check failed: %s\n", tx.GetType()._to_string(), tx.GetHash().GetHex(),
                  err_state.GetRejectReason());
         return false;
@@ -605,13 +605,13 @@ static bool ContextualCheckFinalizerTx(const CTransaction &tx, CValidationState 
     return true;
 }
 
-static bool ContextualCheckBlockFinalizerTxes(const CBlock &block,
+static bool ContextualCheckBlockFinalizerCommits(const CBlock &block,
                                               CValidationState &err_state,
                                               const Consensus::Params &params,
                                               const esperanza::FinalizationState &fin_state) {
     for (const auto &tx : block.vtx) {
-        if (tx->IsFinalizerTx()) {
-            if (!::ContextualCheckFinalizerTx(*tx, err_state, params, fin_state)) {
+        if (tx->IsFinalizerCommit()) {
+            if (!::ContextualCheckFinalizerCommit(*tx, err_state, params, fin_state)) {
                 return false;
             }
         }
@@ -671,8 +671,8 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
 
     const auto *fin_state = esperanza::FinalizationState::GetState();
     assert(fin_state != nullptr);
-    if (tx.IsFinalizerTx() &&
-        !::ContextualCheckFinalizerTx(tx,
+    if (tx.IsFinalizerCommit() &&
+        !::ContextualCheckFinalizerCommit(tx,
                                       state,
                                       chainparams.GetConsensus(),
                                       *fin_state)) {
@@ -2008,7 +2008,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     // UNIT-E: Workaround #421 (we don't restore finalization state when reindex)
     bool has_finalization_tx = false;
     for (const auto &tx : block.vtx) {
-        if (tx->IsFinalizerTx()) {
+        if (tx->IsFinalizerCommit()) {
             has_finalization_tx = true;
             break;
         }
@@ -2029,7 +2029,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     // - lock pqueue->ControlMutex in BlockAssember::CreateNewBlock() -> TestBlockValidity() -> ConnectBlock() -> CCheckQueueControl()
     if (!isGenesisBlock &&
         has_finalization_tx &&
-        !ContextualCheckBlockFinalizerTxes(block,
+        !ContextualCheckBlockFinalizerCommits(block,
                                            state,
                                            chainparams.GetConsensus(),
                                            *fin_state)) {
@@ -3332,7 +3332,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Co
         if (!IsFinalTx(*tx, nHeight, nLockTimeCutoff)) {
             return state.DoS(10, false, REJECT_INVALID, "bad-txns-nonfinal", false, "non-final transaction");
         }
-        if (tx->IsFinalizerTx() && !esperanza::CheckFinalizerTx(*tx, state)) {
+        if (tx->IsFinalizerCommit() && !esperanza::CheckFinalizerCommit(*tx, state)) {
             return false;
         }
     }


### PR DESCRIPTION
This PR renames `ContextualCheckFinalizationTx` to `ContextualCheckFinalizerCommit` and `CheckFinalizationCommit` to `CheckFinalizerCommit`, to better adhere to the naming conventions [ADR-0025](https://github.com/dtr-org/unit-e-ADR-0025docs/blob/25e38c9a6a63d4b25a424e09b9ee22e9905999bd/adrs/ADR-0025.md).