### PR TITLE
Get rid of the race condition in example_test.py

### DIFF
--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -185,6 +185,8 @@ class ExampleTest(UnitETestFramework):
             txout = self.nodes[0].gettxout(stake['txid'], stake['vout'])
             coinbase = sign_coinbase(self.nodes[0], create_coinbase(height, stake, snapshot_meta.hash))
             block = create_block(self.tip, coinbase, self.block_time)
+            # Wait until the active chain picks up the previous block
+            wait_until(lambda: self.nodes[0].getblockcount() == height, timeout=5)
             snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta.data, 0, height + 1, coinbase)
             block.solve()
             block_message = msg_block(block)


### PR DESCRIPTION
Fixes #796 

[Snapshot builder](https://github.com/dtr-org/unit-e/blob/master/test/functional/test_framework/blocktools.py#L239) depends on **getblockcount** method, which is trying to get the [height of the active chain](https://github.com/dtr-org/unit-e/blob/master/src/rpc/blockchain.cpp#L182).
On other hands, we're sending brand-new block [in the test](https://github.com/dtr-org/unit-e/blob/master/test/functional/example_test.py#L192) and thus trying to update the active chain.

I added **wait_until** check to eliminate this timing problem.

Signed-off-by: Dmitry Saveliev <dima@thirdhash.com>