### PR TITLE
Add -Wno-sign-compare compiler flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -259,6 +259,7 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wunused-local-typedef],[CXXFLAGS="$CXXFLAGS -Wno-unused-local-typedef"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wdeprecated-register],[CXXFLAGS="$CXXFLAGS -Wno-deprecated-register"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough],[CXXFLAGS="$CXXFLAGS -Wno-implicit-fallthrough"],,[[$CXXFLAG_WERROR]])
+  AX_CHECK_COMPILE_FLAG([-Wsign-compare],[CXXFLAGS="$CXXFLAGS -Wno-sign-compare"],,[[$CXXFLAG_WERROR]])
 fi
 
 # Check for optional instruction set support. Enabling these does _not_ imply that all code will


### PR DESCRIPTION
After upgrading Apples' developer tools, clang starts producing warnings in thousands of places, like:

```C++
std::vector<int> v;
...
BOOST_CHECK_EQUAL(v.size(), 0); // warning: comparison of integers of different signs: 'const int' and 'const unsigned int'
```

This code could be adjusted in the way:

```C++
std::vector<int> v;
...
BOOST_CHECK_EQUAL(v.size(), 0u);
```

But I'd postpone this change until we merge with bitcoin. 

The flag `-Wno-sign-compare` reverts clang warning to the same level it was previously. I guess, they basically added `-Wsign-compare` in the `-Wextra` group.

```
$ /Library/Developer/CommandLineTools/usr/bin/clang++ --version
Apple LLVM version 10.0.1 (clang-1001.0.46.3)
Target: x86_64-apple-darwin18.5.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

**To enable this flag you have to run ./autogen.sh**