### PR TITLE
Remove not needed check in InFlightSnapshotDiscovery

### DIFF
--- a/src/snapshot/p2p_processing.cpp
+++ b/src/snapshot/p2p_processing.cpp
@@ -578,15 +578,6 @@ bool P2PState::InFlightSnapshotDiscovery(const CNode &node) {
     }
   }
 
-  // check node reply timeout
-  {
-    const auto diff = now - node.m_requested_snapshot_at;
-    const auto diff_sec = std::chrono::duration_cast<std::chrono::seconds>(diff);
-    if (diff_sec.count() > m_params.snapshot_chunk_timeout_sec) {
-      return false;
-    }
-  }
-
   return true;
 }
 


### PR DESCRIPTION
Reported by @cmihai and was caught by compiling with `CXXFLAGS=-Og`

The following check is not needed as we check the discovery timeout above.
And also the `now - node.m_requested_snapshot_at` causes int overflow
so that block always returns `true` and doesn't affect `InFlightSnapshotDiscovery`

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>