### PR TITLE
Add missing include

### DIFF
--- a/src/staking/block_index_map.h
+++ b/src/staking/block_index_map.h
@@ -6,6 +6,7 @@
 #define UNITE_STAKING_BLOCK_INDEX_MAP
 
 #include <sync.h>
+#include <functional>
 #include <memory>
 
 class CBlockIndex;


### PR DESCRIPTION
Adds missing include to the staking/block_index_map.h that fixes compilation failures on some platforms.