### PR TITLE
Fix some log messages

### DIFF
--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -288,8 +288,8 @@ bool WalletExtension::SendDeposit(const CKeyID &keyID, CAmount amount,
           vecSend, wtxOut, reservekey, nFeeRet, nChangePosInOut, sError,
           coinControl, true, TxType::DEPOSIT)) {
 
-    LogPrint(BCLog::FINALIZATION, "%s: Cannot create deposit transaction.\n",
-             __func__);
+    LogPrint(BCLog::FINALIZATION, "%s: Cannot create deposit transaction. %s\n",
+             __func__, sError);
     return false;
   }
 

--- a/src/proposer/proposer.cpp
+++ b/src/proposer/proposer.cpp
@@ -112,7 +112,7 @@ class ProposerImpl : public Proposer {
               m_transaction_picker->PickTransactions(parameters);
 
           if (!result) {
-            LogPrint(BCLog::PROPOSING, "Failed to pick transactions: %s – proposing empty block.\n");
+            LogPrint(BCLog::PROPOSING, "Failed to pick transactions (wallet=%s, error=%s) – proposing empty block.\n", wallet_name, result.error);
           }
           const CAmount fees = std::accumulate(result.fees.begin(), result.fees.end(), CAmount(0));
           const uint256 snapshot_hash = m_active_chain->ComputeSnapshotHash();


### PR DESCRIPTION
Log in walletextension.cpp lacked info about the error, and the log in proposer.cpp was not formatted properly (also added info about the problem).

Signed-off-by: Mateusz Morusiewicz <mateusz@thirdhash.com>
