### PR TITLE
Fix compiler warning about multiline comments

### DIFF
--- a/src/test/finalizer_commits_handler_tests.cpp
+++ b/src/test/finalizer_commits_handler_tests.cpp
@@ -314,8 +314,8 @@ BOOST_AUTO_TEST_CASE(get_commits_locator) {
   // Build a fork after finalization
   //           F
   // 0 .. 4 .. 9 .. 11 12 ..    -- main chain
-  //                  \
-  //                   12 .. 17 -- fork
+  //                 |
+  //                 > 12 .. 17 -- fork
   std::map<blockchain::Height, uint256> fork_hashes;
   std::map<blockchain::Height, CBlockIndex> fork;
 
@@ -345,8 +345,8 @@ BOOST_AUTO_TEST_CASE(get_commits_locator) {
   // Build a fork after finalization
   //                          F
   // 0 .. 4 .. 9 .. 11 12 .. 14 ..    -- main chain
-  //                  \
-  //                   12 .. 14 .. 17 -- fork
+  //                 |
+  //                 > 12 .. 14 .. 17 -- fork
   state.SetLastFinalizedEpoch(2);
   BOOST_REQUIRE(state.GetLastFinalizedEpoch() == 2);
 


### PR DESCRIPTION
https://github.com/dtr-org/unit-e/pull/793 introduced comments which produce warnings in gcc as they use the blackslash character at the end of a line. The backslash character continues a line which means that:

```C++
int x = 3;
// comment \
x = 4;
std::cout << x << std::endl;
```

would adjoin the line `x = 4` to the comment before. The snippet above will print `3`, clearly not what was intended. The syntax highlight here in github shows this nicely too.

@kostyantyn and I were discussing to use a unicode character instead, but unfortunately having unicode characters in the codebase screws up some lint scripts :-(

So I am going for the alternative proposed by @kostyantyn , which is to use

```
|
>
```

instead for the ascii graphic.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
