### PR TITLE
Save log output from failing tests in run-unit-tests.sh

### DIFF
--- a/contrib/devtools/run-unit-tests.sh
+++ b/contrib/devtools/run-unit-tests.sh
@@ -9,8 +9,11 @@
 # usage:
 # - run contrib/devtools/run-unit-tests.sh from the repository root
 
+which parallel > /dev/null || (echo "GNU parallel is not installed"; false) || exit 1
+
 src/test/test_unite --list_content 2>&1 | \
   grep -v -F '    ' | \
-  awk '{ print "src/test/test_unite --run_test=" $0 " > \"" $0 ".log\" 2>&1 && (echo \"- [x] " $0 "\"; rm \"" $0 ".log\"; true) || (echo \"- [ ] " $0 " (see " $0 ".log)\"; false)"}' | \
+  tr -d '*' | \
+  awk '{ f = $0 ".log"; print "src/test/test_unite --run_test=" $0 " > \"" f "\" 2>&1 && (echo \"- [x] " $0 "\"; rm \"" f "\"; true) || (echo \"- [ ] " $0 " (see " f ")\"; false)"}' | \
   parallel -j 0 bash -c 2> /dev/null | \
   sort


### PR DESCRIPTION
The script `contrib/devtools/run-unit-tests.sh` runs tests in parallel and independent by executing each in its own process. This is highly useful for debugging and allows checking whether the tests work in a parallel setting (which will land in the build system proper as we merge 

Another shortcoming of the script was that it would not propagate the failing exit code. It now does so if any test fails, the whole script fails. This could be used to for instance have it part of a travis build (if desired).

Output for current master:

```
$ contrib/devtools/run-unit-tests.sh 
- [ ] accounting_tests* (see accounting_tests*.log)
- [ ] base58_tests* (see base58_tests*.log)
- [ ] bip32_tests* (see bip32_tests*.log)
- [ ] blockassembleradapter_tests* (see blockassembleradapter_tests*.log)
- [ ] block_builder_tests* (see block_builder_tests*.log)
- [ ] blockdiskstorage_tests* (see blockdiskstorage_tests*.log)
- [ ] block_validator_tests* (see block_validator_tests*.log)
- [ ] bloom_tests* (see bloom_tests*.log)
- [ ] checkqueue_tests* (see checkqueue_tests*.log)
- [ ] DoS_tests* (see DoS_tests*.log)
- [ ] finalization_checks_tests* (see finalization_checks_tests*.log)
- [ ] finalizationstate_deposit_tests* (see finalizationstate_deposit_tests*.log)
- [ ] finalizationstate_logout_tests* (see finalizationstate_logout_tests*.log)
- [ ] finalizationstate_slash_tests* (see finalizationstate_slash_tests*.log)
- [ ] finalizationstate_tests* (see finalizationstate_tests*.log)
- [ ] finalizationstate_vote_tests* (see finalizationstate_vote_tests*.log)
- [ ] finalizationstate_withdraw_tests* (see finalizationstate_withdraw_tests*.log)
- [ ] injector_tests* (see injector_tests*.log)
- [ ] main_tests* (see main_tests*.log)
- [ ] mempool_tests* (see mempool_tests*.log)
- [ ] merkle_tests* (see merkle_tests*.log)
- [ ] mnemonic_tests* (see mnemonic_tests*.log)
- [ ] net_tests* (see net_tests*.log)
- [ ] rpc_tests* (see rpc_tests*.log)
- [ ] rpcvalidator_tests* (see rpcvalidator_tests*.log)
- [ ] snapshot_chainstate_iterator_tests* (see snapshot_chainstate_iterator_tests*.log)
- [ ] snapshot_indexer_tests* (see snapshot_indexer_tests*.log)
- [ ] snapshot_iterator_tests* (see snapshot_iterator_tests*.log)
- [ ] snapshot_p2p_processing_tests* (see snapshot_p2p_processing_tests*.log)
- [ ] snapshot_state_tests* (see snapshot_state_tests*.log)
- [ ] state_repository_tests* (see state_repository_tests*.log)
- [ ] tx_validationcache_tests* (see tx_validationcache_tests*.log)
- [ ] validation_block_tests* (see validation_block_tests*.log)
- [ ] versionbits_tests* (see versionbits_tests*.log)
- [ ] vote_recorder_tests* (see vote_recorder_tests*.log)
- [ ] walletextension_tests* (see walletextension_tests*.log)
- [ ] wallet_tests* (see wallet_tests*.log)
- [x] abstract_block_validator_tests*
- [x] addrman_tests*
- [x] admincommand_tests*
- [x] adminstate_tests*
- [x] allocator_tests*
- [x] amount_tests*
- [x] arith_uint256_tests*
- [x] base16_tests*
- [x] base32_tests*
- [x] base64_tests*
- [x] bech32_tests*
- [x] better_enum_set_tests*
- [x] blockchain_behavior_test*
- [x] blockchain_custom_parameters_tests*
- [x] blockchain_difficulty_tests*
- [x] blockchain_parameters_tests*
- [x] blockencodings_tests*
- [x] bswap_tests*
- [x] coins_tests*
- [x] coins_view_db_tests*
- [x] coin_tests*
- [x] compress_tests*
- [x] crypto_tests*
- [x] cuckoocache_tests*
- [x] dbwrapper_tests*
- [x] dependency_injector_tests*
- [x] embargoman_tests*
- [x] finalization_params_tests*
- [x] finalizer_commits_tests*
- [x] getarg_tests*
- [x] hash_tests*
- [x] iblt_tests*
- [x] interpreter_tests*
- [x] ismine_tests*
- [x] key_tests*
- [x] limitedmap_tests*
- [x] merkleblock_tests*
- [x] multisig_tests*
- [x] netbase_tests*
- [x] pmt_tests*
- [x] policyestimator_tests*
- [x] pow_tests*
- [x] PrevectorTests*
- [x] proof_of_stake_tests*
- [x] proposer_logic_tests*
- [x] proposer_tests*
- [x] raii_event_tests*
- [x] random_tests*
- [x] reverselock_tests*
- [x] sanity_tests*
- [x] scheduler_tests*
- [x] scriptnum_tests*
- [x] script_P2SH_tests*
- [x] script_standard_tests*
- [x] script_tests*
- [x] semaphore_tests*
- [x] serialize_tests*
- [x] settings_tests*
- [x] sighash_tests*
- [x] sign_tests*
- [x] sigopcount_tests*
- [x] skiplist_tests*
- [x] snapshot_creator_tests*
- [x] snapshot_messages_tests*
- [x] snapshot_snapshot_index_tests*
- [x] snapshot_validation_tests*
- [x] stake_validator_tests*
- [x] state_db_tests*
- [x] state_processor_tests*
- [x] streams_tests*
- [x] timedata_tests*
- [x] torcontrol_tests*
- [x] transaction_tests*
- [x] trit_tests*
- [x] txvalidation_tests*
- [x] tx_verify_tests*
- [x] ufp64_tests*
- [x] uint256_tests*
- [x] util_tests*
- [x] validation_tests*
- [x] waiter_tests*
- [x] wallet_crypto*
```

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
