### PR TITLE
Fix compilation warning in UnitEInjector

### DIFF
--- a/src/finalization/state_db.h
+++ b/src/finalization/state_db.h
@@ -21,7 +21,7 @@ class BlockIndexMap;
 }  // namespace staking
 
 class CBlockIndex;
-class UnitEInjectorConfiguration;
+struct UnitEInjectorConfiguration;
 
 namespace finalization {
 


### PR DESCRIPTION
Fixes warning introduced by #870.
```
In file included from ./injector.h:17:
./injector_config.h:8:1: warning: 'UnitEInjectorConfiguration' defined as a struct here but previously declared as a class [-Wmismatched-tags]
struct UnitEInjectorConfiguration {
^
./finalization/state_db.h:24:1: note: did you mean struct here?
class UnitEInjectorConfiguration;
^~~~~
struct
```