### PR TITLE
Add more rpc ToUniValue utility functions

### DIFF
--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -4,6 +4,7 @@
 
 #include <base58.h>
 #include <blockchain/blockchain_behavior.h>
+#include <core_io.h>
 #include <injector.h>
 #include <keystore.h>
 #include <pubkey.h>
@@ -99,11 +100,38 @@ UniValue ToUniValue(const double value) {
     return value;
 }
 
-UniValue ToUniValue(const uint256& hash) {
+UniValue ToUniValue(const COutPoint &outpoint) {
+    UniValue obj(UniValue::VOBJ);
+    obj.pushKV("txid", ToUniValue(outpoint.hash));
+    obj.pushKV("n", ToUniValue(outpoint.n));
+    return obj;
+}
+
+UniValue ToUniValue(const CScript &script) {
+    UniValue obj;
+    ScriptPubKeyToUniv(script, obj, /* fIncludeHex= */ true);
+    return obj;
+}
+
+UniValue ToUniValue(const CTxOut &txout) {
+    UniValue obj(UniValue::VOBJ);
+    obj.pushKV("amount", txout.nValue);
+    obj.pushKV("scriptPubKey", ToUniValue(txout.scriptPubKey));
+    return obj;
+}
+
+UniValue ToUniValue(const CTxIn &txin) {
+    UniValue obj(UniValue::VOBJ);
+    obj.pushKV("prevout", ToUniValue(txin.prevout));
+    obj.pushKV("scriptSig", ToUniValue(txin.scriptSig));
+    return obj;
+}
+
+UniValue ToUniValue(const uint256 &hash) {
     return UniValue(hash.GetHex());
 }
 
-UniValue ToUniValue(const blockchain::GenesisBlock& value) {
+UniValue ToUniValue(const blockchain::GenesisBlock &value) {
     UniValue result(UniValue::VOBJ);
     result.pushKV("version", ToUniValue(value.block.nVersion));
     result.pushKV("time", ToUniValue(value.block.nTime));

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -17,19 +17,19 @@ class CKeyStore;
 class CPubKey;
 class CScript;
 
-CPubKey HexToPubKey(const std::string& hex_in);
-CPubKey AddrToPubKey(CKeyStore* const keystore, const std::string& addr_in);
-CScript CreateMultisigRedeemscript(int required, const std::vector<CPubKey>& pubkeys);
+CPubKey HexToPubKey(const std::string &hex_in);
+CPubKey AddrToPubKey(CKeyStore *const keystore, const std::string &addr_in);
+CScript CreateMultisigRedeemscript(int required, const std::vector<CPubKey> &pubkeys);
 
 template <typename T>
-UniValue ToUniValue(const T& value) {
+UniValue ToUniValue(const T &value) {
   return UniValue(value);
 }
 
 template <typename T>
-UniValue ToUniValue(const std::vector<T> vector) {
+UniValue ToUniValue(const std::vector<T> &vector) {
   UniValue array(UniValue::VARR);
-  for (const T& v : vector) {
+  for (const T &v : vector) {
     array.push_back(ToUniValue(v));
   }
   return array;
@@ -38,8 +38,12 @@ UniValue ToUniValue(const std::vector<T> vector) {
 UniValue ToUniValue(std::uint32_t value);
 UniValue ToUniValue(float value);
 UniValue ToUniValue(double value);
-UniValue ToUniValue(const uint256& hash);
-UniValue ToUniValue(const blockchain::GenesisBlock& value);
+UniValue ToUniValue(const COutPoint &outpoint);
+UniValue ToUniValue(const CScript &script);
+UniValue ToUniValue(const CTxOut &txout);
+UniValue ToUniValue(const CTxIn &txin);
+UniValue ToUniValue(const uint256 &hash);
+UniValue ToUniValue(const blockchain::GenesisBlock &value);
 UniValue ToUniValue(const std::vector<unsigned char> base58_prefixes[blockchain::Base58Type::_size_constant]);
 
-#endif // UNITE_RPC_UTIL_H
+#endif  // UNITE_RPC_UTIL_H


### PR DESCRIPTION
Adds overloads for turning differents transaction related objects to `UniValue`s. I am extracting this from an upcoming pull request.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
