### PR TITLE
Fix segmentation fault after unloading wallet

### DIFF
--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -875,7 +875,21 @@ void WalletExtension::SlashingConditionDetected(
   pendingSlashings.emplace_back(vote1, vote2);
 }
 
+std::shared_ptr<CWallet> GetWalletHandle(CWallet *pwallet) {
+  for (std::shared_ptr<CWallet> w : GetWallets()) {
+    if (w.get() == pwallet) {
+      return w;
+    }
+  }
+  return nullptr;
+}
+
 void WalletExtension::ManagePendingSlashings() {
+  // Ensure the wallet won't be freed while we need it
+  std::shared_ptr<CWallet> wallet = GetWalletHandle(&m_enclosing_wallet);
+  if (!wallet) {
+    throw task_unscheduled();
+  }
 
   if (pendingSlashings.empty()) {
     return;

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -82,6 +82,8 @@ void CScheduler::serviceQueue()
                 reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
                 f();
             }
+        } catch (const task_unscheduled& ) {
+            // Do nothing
         } catch (...) {
             --nThreadsServicingQueue;
             throw;

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -123,4 +123,6 @@ public:
     size_t CallbacksPending();
 };
 
+class task_unscheduled : std::exception {};
+
 #endif


### PR DESCRIPTION
Bitcoin 0.17 now allows us to unload (and re-load) wallets. This clashed
with the `CWalletExtension::ManagePendingSlashings`, which was scheduled
to run periodically every 10 seconds, and which tried to access the
wallet, even though it could be unloaded by that moment.

This commit saves a reference to the wallet during the execution of the
task, to avoid a segfault. Further, it introduces a new type of benign
exception, `task_unscheduled`, which interrupts the execution of the
current task and does not reschedule it.