### PR TITLE
Adapt code of conduct contact email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at conduct@unit-e.io. All
+reported by contacting the project team at conduct@dtr.org. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
We use the dtr.org domain for these kind of general email addresses. Will prepare PRs for the other repos where we need to adapt this email address as well.
