### PR TITLE
Adjust logging in finalization state processor

### DIFF
--- a/src/finalization/state_processor.cpp
+++ b/src/finalization/state_processor.cpp
@@ -31,7 +31,7 @@ bool ProcessorImpl::ProcessNewTipWorker(const CBlockIndex &block_index, const CB
   AssertLockHeld(m_repo->GetLock());
   const auto state = m_repo->FindOrCreate(block_index, FinalizationState::FROM_COMMITS);
   if (state == nullptr) {
-    LogPrint(BCLog::FINALIZATION, "ERROR: Cannot find or create finalization state for %s\n",
+    LogPrint(BCLog::FINALIZATION, "Cannot find or create finalization state for %s\n",
              block_index.GetBlockHash().GetHex());
     return false;
   }


### PR DESCRIPTION
During testnet we figured out that scenario when peer sends
outdated commits/blocks is a normal case scenario, and in fact
too often one. When node syncs with two peers, it receives commits
and blocks from first one. It leads to trimming finalization state
repository. Then the node starts receving commits from second
peer with some delay and prints dozen of errors which actually is
not an error but just a fact that full sync completed with another
peer.

I'm keeping the log message because it might be helpful in debugging,
but removing misleading "ERROR".