### PR TITLE
Rename testnet directory from testnet3 to testnet

### DIFF
--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -26,7 +26,7 @@ input=/home/example/.unite/blocks
 # testnet
 #netmagic=0b110907
 #genesis=000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
-#input=/home/example/.unite/testnet3/blocks
+#input=/home/example/.unite/testnet/blocks
 
 # "output" option causes blockchain files to be written to the given location,
 # with "output_file" ignored. If not used, "output_file" is used instead.

--- a/src/blockchain/blockchain_parameters.cpp
+++ b/src/blockchain/blockchain_parameters.cpp
@@ -93,7 +93,7 @@ Parameters Parameters::TestNet() noexcept {
   p.genesis_block = GenesisBlock(GenesisBlockBuilder().Add(TestnetFunds()).Build(p));
 
   p.default_settings.p2p_port = 17182;
-  p.data_dir_suffix = "testnet3";
+  p.data_dir_suffix = "testnet";
 
   return p;
 }

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -33,7 +33,7 @@ public:
     CBaseTestNetParams()
     {
         nRPCPort = 17181;
-        strDataDir = "testnet3";
+        strDataDir = "testnet";
     }
 };
 

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -62,7 +62,7 @@ MESSAGEMAP = {
 
 MAGIC_BYTES = {
     "mainnet": b"\xf9\xbe\xb4\xd9",   # mainnet
-    "testnet3": b"\x0b\x11\x09\x07",  # testnet3
+    "testnet": b"\x0b\x11\x09\x07",   # testnet
     "regtest": b"\xfa\xbf\xb5\xda",   # regtest
 }
 


### PR DESCRIPTION
`testnet3` came with bitcoin, and there is no reason to keep that name.

Signed-off-by: Mateusz Morusiewicz <mateusz@thirdhash.com>