### PR TITLE
Some cleanups and fixes in commits exchange protocol

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3340,7 +3340,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, size_t node_index, size_t tot
                 state.fSyncStarted = true;
                 state.nHeadersSyncTimeout = GetTimeMicros() + HEADERS_DOWNLOAD_TIMEOUT_BASE + HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER * (GetAdjustedTime() - pindexBestHeader->GetBlockTime())/(consensusParams.nPowTargetSpacing);
                 nSyncStarted++;
-                const CBlockIndex *pindexStart = pindexBestHeader;
+                const CBlockIndex *pindexStart = chainActive.Tip();
                 /* If possible, start at the block preceding the currently
                    best known header.  This ensures that we always get a
                    non-empty list of headers back as long as the peer

--- a/src/p2p/finalizer_commits_handler_impl.cpp
+++ b/src/p2p/finalizer_commits_handler_impl.cpp
@@ -248,11 +248,9 @@ void FinalizerCommitsHandlerImpl::OnGetCommits(
     const size_t response_size = GetSerializeSize(response_copy, SER_NETWORK, PROTOCOL_VERSION);
     if (response_size >= MAX_PROTOCOL_MESSAGE_LENGTH) {
       response.status = FinalizerCommitsResponse::Status::LengthExceeded;
-      LogPrint(BCLog::NET, "Send %d headers+commits, status = %d\n",
+      LogPrint(BCLog::NET, "Send %d headers+commits, status=%d\n",
                response.data.size(), static_cast<uint8_t>(response.status));
       PushMessage(node, NetMsgType::COMMITS, std::move(response));
-      // Stakoverflow driven development is here!
-      // https://stackoverflow.com/questions/7027523
       response = FinalizerCommitsResponse();
     } else {
       response = std::move(response_copy);
@@ -264,9 +262,8 @@ void FinalizerCommitsHandlerImpl::OnGetCommits(
     return;
   }
 
-  LogPrint(BCLog::NET, "Send %d headers+commits, status = %d\n",
+  LogPrint(BCLog::NET, "Send %d headers+commits, status=%d\n",
            response.data.size(), static_cast<uint8_t>(response.status));
-
   PushMessage(node, NetMsgType::COMMITS, std::move(response));
 }
 
@@ -377,7 +374,7 @@ bool FinalizerCommitsHandlerImpl::OnCommits(
       }
 
       if (!m_proc->ProcessNewCommits(*new_index, d.commits)) {
-        return err(10, "bad-commits", d.header.GetHash());
+        return false;
       }
 
       to_append.emplace_back(new_index);


### PR DESCRIPTION
1. Follow code style and rename cs to m_cs in state repository (cc @AM5800)
2. Don't ban peer when we cannot process commits (follow-up #912)
3. When asking for commits, rely on the current tip instead of the best
   known block header because there may be a gap of finalization states
   between tip and best header. It fixes floating issue that has been discovered
   in #906, thanks to not properly `block_sync`-ed nodes.
