### PR TITLE
Rename datadir on Unix

### DIFF
--- a/contrib/init/unit-e.openrc
+++ b/contrib/init/unit-e.openrc
@@ -1,13 +1,6 @@
 #!/sbin/openrc-run
 
-# backward compatibility for existing gentoo layout 
-#
-if [ -d "/var/lib/unite/.unite" ]; then
-	UNIT_E_DEFAULT_DATADIR="/var/lib/unite/.unite"
-else
-	UNIT_E_DEFAULT_DATADIR="/var/lib/unit-e"
-fi
-
+UNIT_E_DEFAULT_DATADIR="/var/lib/unit-e"
 UNIT_E_CONFIGFILE=${UNIT_E_CONFIGFILE:-/etc/unite/unit-e.conf}
 UNIT_E_PIDDIR=${UNIT_E_PIDDIR:-/var/run/unit-e}
 UNIT_E_PIDFILE=${UNIT_E_PIDFILE:-${UNIT_E_PIDDIR}/unit-e.pid}

--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -1,7 +1,7 @@
 # unit-e RPC settings (linearize-hashes)
 rpcuser=someuser
 rpcpassword=somepassword
-#datadir=~/.unite
+#datadir=~/.unit-e
 host=127.0.0.1
 
 #mainnet default
@@ -21,12 +21,12 @@ max_height=313000
 # mainnet
 netmagic=f9beb4d9
 genesis=000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
-input=/home/example/.unite/blocks
+input=/home/example/.unit-e/blocks
 
 # testnet
 #netmagic=0b110907
 #genesis=000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
-#input=/home/example/.unite/testnet/blocks
+#input=/home/example/.unit-e/testnet/blocks
 
 # "output" option causes blockchain files to be written to the given location,
 # with "output_file" ignored. If not used, "output_file" is used instead.

--- a/src/blockchain/blockchain_parameters.h
+++ b/src/blockchain/blockchain_parameters.h
@@ -223,7 +223,7 @@ struct Parameters {
   //! \brief Number of blocks which have to have a softfork activated in a confirmation period.
   std::uint32_t rule_change_activation_threshold;
 
-  //! \brief Suffix of the data dir. In the path "~/user/.unite/regtest", it's a "regtest" suffix.
+  //! \brief Suffix of the data dir. In the path "~user/.unit-e/regtest", it's a "regtest" suffix.
   std::string data_dir_suffix;
 
   //! \brief Default settings to use for this chain.

--- a/src/settings.h
+++ b/src/settings.h
@@ -42,10 +42,10 @@ struct Settings {
 
   std::uint16_t p2p_port = 7182;
 
-  //! \brief Path to the base data dir (e.g. ~/user/.unite).
+  //! \brief Path to the base data dir (e.g. ~user/.unit-e).
   fs::path base_data_dir = GetDefaultDataDir();
 
-  //! \brief Path to the data dir (e.g. ~/user/.unite/regtest).
+  //! \brief Path to the data dir (e.g. ~user/.unit-e/regtest).
   fs::path data_dir = GetDefaultDataDir();
 
   //! \brief From which block in the epoch finalizer must start voting

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -643,7 +643,7 @@ fs::path GetDefaultDataDir()
     // Windows < Vista: C:\Documents and Settings\Username\Application Data\Unit-e
     // Windows >= Vista: C:\Users\Username\AppData\Roaming\Unit-e
     // Mac: ~/Library/Application Support/Unit-e
-    // Unix: ~/.unite
+    // Unix: ~/.unit-e
 #ifdef WIN32
     // Windows
     return GetSpecialFolderPath(CSIDL_APPDATA) / "Unit-e";
@@ -659,7 +659,7 @@ fs::path GetDefaultDataDir()
     return pathRet / "Library/Application Support/Unit-e";
 #else
     // Unix
-    return pathRet / ".unite";
+    return pathRet / ".unit-e";
 #endif
 #endif
 }


### PR DESCRIPTION
Rename default datadir on Unix from `~/.unite/` to `~/.unit-e`.

Fixes #877

Signed-off-by: Cornelius Schumacher <cornelius@thirdhash.com>
