### PR TITLE
Fix issue 924 (silenced test for wallet_listsinceblock.py)

### DIFF
--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -106,7 +106,7 @@ def sign_coinbase(node, coinbase):
     return coinbase
 
 
-def generate(node, n, preserve_utxos=[]):
+def generate(node, n, preserve_utxos=[], send_witness=False):
     """ Generate n blocks on the node, making sure not to touch the utxos specified.
 
     :param preserve_utxos: an iterable of either dicts {'txid': ..., 'vout': ...}
@@ -128,7 +128,10 @@ def generate(node, n, preserve_utxos=[]):
         block = create_block(tip, coinbase, block_time)
         snapshot_meta = update_snapshot_with_tx(node, snapshot_meta.data, 0, height + 1, coinbase)
         block.solve()
-        node.p2p.send_message(msg_block(block))
+        if send_witness:
+            node.p2p.send_message(msg_witness_block(block))
+        else:
+            node.p2p.send_message(msg_block(block))
         tip = block.sha256
         block_time += 1
         height += 1

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -251,7 +251,7 @@ class ListSinceBlockTest (UnitETestFramework):
         txid1 = self.nodes[1].sendrawtransaction(signedtx)
 
         # generate bb1-bb2 on right side
-        generate(self.nodes[2], 2, preserve_utxos=utxoDicts)
+        generate(self.nodes[2], 2, preserve_utxos=utxoDicts, send_witness=True)
 
         # send from nodes[2]; this will end up in bb3
         txid2 = self.nodes[2].sendrawtransaction(signedtx)
@@ -261,8 +261,6 @@ class ListSinceBlockTest (UnitETestFramework):
         # generate on both sides
         lastblockhash = self.nodes[1].generate(3)[2]
         self.nodes[2].generate(2)
-
-        return  # TODO UNIT-E : Enable the following tests again
 
         self.join_network()
 


### PR DESCRIPTION
Added `send_witness` option to the `blocktools.py`'s `generate` method.

Signed-off-by: Andres Correa Casablanca <andres@thirdhash.com>