### PR TITLE
Use directory name as project name

### DIFF
--- a/contrib/cmake/gen-cmakelists.sh
+++ b/contrib/cmake/gen-cmakelists.sh
@@ -14,7 +14,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 
 (
 echo "cmake_minimum_required(VERSION 3.12)"
-echo "project(unit_e)"
+echo "project($(basename `pwd`))"
 echo ""
 echo "set(CMAKE_CXX_STANDARD 11)"
 echo ""


### PR DESCRIPTION
Uses the directory name of the project as project name, Very useful if you have it checked out multiple times and work in several instances of your IDE.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
