### PR TITLE
Fix floating finalization_state_restoration.py

### DIFF
--- a/test/functional/finalization_state_restoration.py
+++ b/test/functional/finalization_state_restoration.py
@@ -88,7 +88,7 @@ class FinalizatoinStateRestoration(UnitETestFramework):
                                      'lastFinalizedEpoch': 5,
                                      'validators': 1})
 
-        # connect validator and chek how it votes
+        # connect validator and check how it votes
         self.wait_for_vote_and_disconnect(v, p)
         generate_block(p, count=1)
 


### PR DESCRIPTION
Fixes floating tests by adjusting blocks count generation: after deposit is set up, generate blocks up to the epoch where finalizer starts voting, and stop right on the checkpoint. That ensures we don't miss any vote when generate further epochs.

Fixes #927.