### PR TITLE
Fix floating esperanza_logout.py

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -343,8 +343,6 @@ def main():
     if not args.keepcache:
         shutil.rmtree("%s/test/cache" % config["environment"]["BUILDDIR"], ignore_errors=True)
 
-    test_list = ['esperanza_logout.py'] * 200
-
     run_tests(test_list, config["environment"]["SRCDIR"], config["environment"]["BUILDDIR"], config["environment"]["EXEEXT"], tmpdir, args.jobs, args.coverage, passon_args, args.combinedlogslen)
 
 def run_tests(test_list, src_dir, build_dir, exeext, tmpdir, jobs=1, enable_coverage=False, args=[], combined_logs_len=0):


### PR DESCRIPTION
Make finalizer leave IBD correctly. The reason test flaked was that finalizer
didn't finish IBD phase that leads to not processing deposit transaction correctly.

Fixes #932.
Closes #936.