### PR TITLE
Add initial changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,22 @@ Initial release marking the start of the alpha testnet. This is a source code
 only release. Check it out from git and follow the instructions in the README.md
 to build and run it.
 
-The initial unit-e release is based on [Bitcoin Core
+The Release is based on [Bitcoin Core
 0.16.3](https://github.com/bitcoin/bitcoin/releases/tag/v0.16.3). It adds a
 number of significant changes:
 
-* Replace Proof of Work by Proof of Stake with on-chain block finalization and
-  remote staking
-* Native SegWit support
+* Replace Proof of Work by Esperanza Proof of Stake consensus protocol
+* Staking wallet with remote staking support, no minimum stake required
+* Finality, enabled by a new actor voting every epoch (50 blocks), with advanced
+  on-chain lifecycle (deposit, vote, slash, withdraw). Security is maintained
+  through financial incentives, including availability requirement and slashing
+  for misbehavior
+* Malleability protection through native SegWit support
 * Reduced bandwidth, storage, and time to sync of initial blockchain download by
   UTXO snapshots
 * Enhanced privacy through Dandelion Lite
 * Optimized block propagation through Graphene
 * Canonical transaction ordering
 * Hardware wallet support
-* Qt based GUI wallet has been removed. An alternative will be released later.
+* Qt based GUI wallet has been removed. An alternative will be released later in
+  a separate code repository.


### PR DESCRIPTION
This adds an initial changelog. Future releases will be added there as well with the changes compared to the then previous release. The changelog follows the conventions of [keep a changelog](https://keepachangelog.com/en/1.0.0/).

This also is the content which will be added to the release on GitHub.

I'm opening this as a draft pull request for now. Please chime in in case there are things which should be added or changed.
