### PR TITLE
Fix floating esperanza_withdraw

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -343,8 +343,6 @@ def main():
     if not args.keepcache:
         shutil.rmtree("%s/test/cache" % config["environment"]["BUILDDIR"], ignore_errors=True)
 
-    test_list = ['esperanza_withdraw.py'] * 200
-
     run_tests(test_list, config["environment"]["SRCDIR"], config["environment"]["BUILDDIR"], config["environment"]["EXEEXT"], tmpdir, args.jobs, args.coverage, passon_args, args.combinedlogslen)
 
 def run_tests(test_list, src_dir, build_dir, exeext, tmpdir, jobs=1, enable_coverage=False, args=[], combined_logs_len=0):


### PR DESCRIPTION
The issue happens when finalizer propagate transaction and fails due to short timeout
given from the test suite. Every other similar check in the test passes every time because
they work with finalizer commits, but this one is a regular transaction which propagation
might be delayed up to [148 seconds in the worst case scenario](https://github.com/dtr-org/unit-e-project/blob/3868152cf5d7455dd2f00025b5fa36f5ab7f4cc2/code-guides/tx_propagation_delays.md).
On the other hand, some developers advocate using custom timeouts to reduce execution
time of failed tests, that unfortunately leads to QA degradation and surprising results when
being ran on unusual configurations.

Closes #943.