### PR TITLE
Fix finalization state restoration logic

### DIFF
--- a/src/finalization/state_processor.cpp
+++ b/src/finalization/state_processor.cpp
@@ -145,7 +145,7 @@ bool ProcessorImpl::ProcessNewCommits(const CBlockIndex &block_index, const std:
 
   const auto state = m_repo->FindOrCreate(block_index, FinalizationState::FROM_COMMITS);
   if (state == nullptr) {
-    LogPrint(BCLog::FINALIZATION, "ERROR: Cannot find or create finalization state for %s\n",
+    LogPrint(BCLog::FINALIZATION, "Cannot find or create finalization state for %s\n",
              block_index.GetBlockHash().GetHex());
     return false;
   }

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -14,6 +14,7 @@ import logging
 import os
 import random
 import re
+import shutil
 from subprocess import CalledProcessError
 import time
 import types
@@ -427,7 +428,7 @@ def rpc_url(datadir, i, rpchost=None):
 ################
 
 def initialize_datadir(dirname, n):
-    datadir = os.path.join(dirname, "node" + str(n))
+    datadir = get_datadir_path(dirname, n)
     if not os.path.isdir(datadir):
         os.makedirs(datadir)
     with open(os.path.join(datadir, "unit-e.conf"), 'w', encoding='utf8') as f:
@@ -436,6 +437,10 @@ def initialize_datadir(dirname, n):
         f.write("rpcport=" + str(rpc_port(n)) + "\n")
         f.write("listenonion=0\n")
     return datadir
+
+def cleanup_datadir(dirname, n):
+    datadir = get_datadir_path(dirname, n)
+    shutil.rmtree(datadir)
 
 def get_datadir_path(dirname, n):
     return os.path.join(dirname, "node" + str(n))


### PR DESCRIPTION
The issue happened because node was trying to recover finalization states for block indexes which have never had commits or full blocks. 

1. Do not try to read the block which has no data.
2. Extend finalization_state_restoration test.

Fixes #955.

Signed-off-by: Stanislav Frolov <stanislav@thirdhash.com>
