### PR TITLE
Adapt hard-coded version number

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -900,7 +900,7 @@ bool CBlockPolicyEstimator::Write(CAutoFile& fileout) const
 {
     try {
         LOCK(cs_feeEstimator);
-        fileout << 149900; // version required to read: 0.14.99 or later
+        fileout << 10000; // version required to read: 0.1.0 or later
         fileout << CLIENT_VERSION; // version that wrote the file
         fileout << nBestSeenHeight;
         if (BlockSpan() > HistoricalBlockSpan()/2) {
@@ -935,9 +935,9 @@ bool CBlockPolicyEstimator::Read(CAutoFile& filein)
         unsigned int nFileBestSeenHeight;
         filein >> nFileBestSeenHeight;
 
-        if (nVersionRequired < 149900) {
+        if (nVersionRequired < 10000) {
             LogPrintf("%s: incompatible old fee estimation data (non-fatal). Version: %d\n", __func__, nVersionRequired);
-        } else { // New format introduced in 149900
+        } else { // New format introduced in 10000
             unsigned int nFileHistoricalFirst, nFileHistoricalBest;
             filein >> nFileHistoricalFirst >> nFileHistoricalBest;
             if (nFileHistoricalFirst > nFileHistoricalBest || nFileHistoricalBest > nFileBestSeenHeight) {


### PR DESCRIPTION
Change the minimum required client version for the fee estimator file
to 0.1.0. This fixes the bug which prevents loading of the file.

Doing this as a minimal change for now. Could be implemented in a
cleaner way in the future.

Fixes #968
