### PR TITLE
Prevent node from unnecessary lookup block on disk

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2617,13 +2617,13 @@ bool CChainState::ProcessFinalizationState(const Consensus::Params &params, CBlo
     auto state_processor = GetComponent<finalization::StateProcessor>();
 
     {
-      LOCK(state_repo->GetLock());
-      if (const auto *state = state_repo->Find(*block_index)) {
-        if (state->GetInitStatus() != esperanza::FinalizationState::NEW) {
-          UpdateLastJustifiedEpoch(block_index);
-          return true;
+        LOCK(state_repo->GetLock());
+        if (const auto *state = state_repo->Find(*block_index)) {
+            if (state->GetInitStatus() != esperanza::FinalizationState::NEW) {
+                UpdateLastJustifiedEpoch(block_index);
+                return true;
+            }
         }
-      }
     }
 
     CBlock block_data;


### PR DESCRIPTION
When finalization state is available, it is not necessary to read block from disk because
on the next step (finalization::StateProcessor::ProcessTipCandidate) we rely on the saved
state anyway. This commit must speedup full sync process and reduce CPU consumption.

