### PR TITLE
Set stake_modifier + functional tests for it

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -107,7 +107,6 @@ UNITE_CORE_H = \
   consensus/consensus.h \
   consensus/tx_verify.h \
   consensus/ltor.h \
-  consensus/ltor.cpp \
   core_io.h \
   core_memusage.h \
   cuckoocache.h \
@@ -369,7 +368,6 @@ libunite_server_a_SOURCES = \
   staking/coin.cpp \
   staking/legacy_validation_interface.cpp \
   staking/network.cpp \
-  staking/proof_of_stake.cpp \
   staking/stake_validator.cpp \
   staking/staking_rpc.cpp \
   staking/validation_error.cpp \
@@ -551,6 +549,7 @@ libunite_common_a_SOURCES = \
   snapshot/messages.cpp \
   snapshot/iterator.cpp \
   snapshot/indexer.cpp \
+  staking/proof_of_stake.cpp \
   ufp64.cpp \
   warnings.cpp \
   $(UNITE_CORE_H)

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -131,6 +131,12 @@ public:
     //! \brief (Re)computes the merkle trees of this block.
     void ComputeMerkleTrees();
 
+    const CTxIn &GetStakingInput() const {
+        assert(!vtx.empty() && "GetStakingInput() invoked on an empty block");
+        assert(vtx[0]->vin.size() >= 2 && "GetStakingInput() invoked in a block that has no staking input");
+        return vtx[0]->vin[1];
+    }
+
     std::string ToString() const;
 };
 

--- a/src/proposer/proposer_rpc.cpp
+++ b/src/proposer/proposer_rpc.cpp
@@ -133,7 +133,7 @@ class ProposerRPCImpl : public ProposerRPC {
     return proposerstatus(request);
   }
 
-  UniValue getstakeablecoins(const JSONRPCRequest &request) const override {
+  UniValue liststakeablecoins(const JSONRPCRequest &request) const override {
     CWallet *const wallet = GetWalletForJSONRPCRequest(request);
     if (!EnsureWalletIsAvailable(wallet, request.fHelp)) {
       return NullUniValue;

--- a/src/proposer/proposer_rpc.h
+++ b/src/proposer/proposer_rpc.h
@@ -38,7 +38,7 @@ class ProposerRPC {
 
   virtual UniValue proposerwake(const JSONRPCRequest &request) const = 0;
 
-  virtual UniValue getstakeablecoins(const JSONRPCRequest &request) const = 0;
+  virtual UniValue liststakeablecoins(const JSONRPCRequest &request) const = 0;
 
   virtual ~ProposerRPC() = default;
 

--- a/src/proposer/proposer_state.h
+++ b/src/proposer/proposer_state.h
@@ -16,13 +16,13 @@ struct State {
 
   Status m_status = Status::NOT_PROPOSING;
 
-  //! \brief how often the proposer looked for an eligible coin
+  //! \brief how many times the proposer looked for an eligible coin
   std::uint64_t m_number_of_searches = 0;
 
-  //! \brief how often the proposer found an eligible coin
+  //! \brief how many times the proposer found an eligible coin
   std::uint64_t m_number_of_search_attempts = 0;
 
-  //! \brief how often the proposer actually proposed
+  //! \brief how many blocks the proposer actually proposed
   std::uint64_t m_number_of_proposed_blocks = 0;
 
   //! \brief how many transactions the proposer included in proposed blocks in total

--- a/src/rpc/proposing.cpp
+++ b/src/rpc/proposing.cpp
@@ -19,7 +19,7 @@
   t.appendCommand(NAME.name, &NAME);
 
 void RegisterProposerRPCCommands(CRPCTable &t) {
-  PROPOSER_RPC_COMMAND(getstakeablecoins);
+  PROPOSER_RPC_COMMAND(liststakeablecoins);
   PROPOSER_RPC_COMMAND(proposerstatus);
   PROPOSER_RPC_COMMAND(proposerwake);
 }

--- a/src/rpc/staking.cpp
+++ b/src/rpc/staking.cpp
@@ -19,6 +19,7 @@
   t.appendCommand(NAME.name, &NAME);
 
 void RegisterStakingRPCCommands(CRPCTable &t) {
+  STAKING_RPC_COMMAND(calcstakemodifier, "txid", "prev");
   STAKING_RPC_COMMAND(tracechain, "start", "length");
   STAKING_RPC_COMMAND(tracestake, "start", "length", "reverse");
 }

--- a/src/snapshot/rpc_processing.cpp
+++ b/src/snapshot/rpc_processing.cpp
@@ -167,7 +167,7 @@ UniValue deletesnapshot(const JSONRPCRequest &request) {
 }
 
 UniValue calcsnapshothash(const JSONRPCRequest &request) {
-  if (request.fHelp || request.params.size() < 2) {
+  if (request.fHelp || request.params.size() < 4 || request.params.size() > 5) {
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
 
     stream << std::vector<UTXO>(1);
@@ -207,7 +207,7 @@ UniValue calcsnapshothash(const JSONRPCRequest &request) {
   }
 
   CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
-  for (int i = 0; i < 2; ++i) {
+  for (std::size_t i = 0; i < 2; ++i) {
     std::vector<uint8_t> data = ParseHex(request.params[i].get_str());
     stream.write(reinterpret_cast<char *>(data.data()), data.size());
   }
@@ -217,8 +217,8 @@ UniValue calcsnapshothash(const JSONRPCRequest &request) {
   stream >> inputs;
   stream >> outputs;
 
-  uint256 stake_modifier = uint256(ParseHex(request.params[2].get_str()));
-  uint256 chain_work = uint256(ParseHex(request.params[3].get_str()));
+  const uint256 stake_modifier = uint256S(request.params[2].get_str());
+  const uint256 chain_work = uint256(ParseHex(request.params[3].get_str()));
 
   SnapshotHash hash;
   if (request.params.size() == 5) {

--- a/src/staking/block_validator.h
+++ b/src/staking/block_validator.h
@@ -105,6 +105,15 @@ class BlockValidator {
       BlockValidationInfo *info          //!< [in,out] Access to the validation info for this block (optional, nullptr may be passed).
       ) const = 0;
 
+  //! \brief checks the coinbase transaction to be well-formed
+  //!
+  //! A coinbase transaction is expected to have at least two inputs:
+  //! - the meta input carrying height and snapshot hash at vin[0]
+  //! - the staking input at vin[1]
+  virtual BlockValidationResult CheckCoinbaseTransaction(
+      const CTransaction &coinbase_tx  //!< [in] The coinbase transaction to check
+      ) const = 0;
+
   virtual ~BlockValidator() = default;
 
   static std::unique_ptr<BlockValidator> New(Dependency<blockchain::Behavior>);
@@ -129,8 +138,8 @@ class AbstractBlockValidator : public BlockValidator {
 
   virtual void CheckBlockInternal(
       const CBlock &block,
-      blockchain::Height &height_out,
-      uint256 &snapshot_hash_out,
+      blockchain::Height *height_out,
+      uint256 *snapshot_hash_out,
       BlockValidationResult &result) const = 0;
 
   virtual void ContextualCheckBlockInternal(

--- a/src/staking/legacy_validation_interface.cpp
+++ b/src/staking/legacy_validation_interface.cpp
@@ -60,15 +60,15 @@ class LegacyValidationImpl : public LegacyValidationInterface {
     if (check_merkle_root) {
       bool mutated;
       uint256 hashMerkleRoot2 = BlockMerkleRoot(block, &mutated);
-      if (block.hashMerkleRoot != hashMerkleRoot2)
+      if (block.hashMerkleRoot != hashMerkleRoot2) {
         return state.DoS(100, false, REJECT_INVALID, "bad-txnmrklroot", true, "hashMerkleRoot mismatch");
-
+      }
       // Check for merkle tree malleability (CVE-2012-2459): repeating sequences
       // of transactions in a block without affecting the merkle root of a block,
       // while still invalidating it.
-      if (mutated)
+      if (mutated) {
         return state.DoS(100, false, REJECT_INVALID, "bad-txns-duplicate", true, "duplicate transaction");
-
+      }
       uint256 merkle_root = BlockFinalizerCommitsMerkleRoot(block);
       if (block.hash_finalizer_commits_merkle_root != merkle_root) {
         return state.DoS(100, false, REJECT_INVALID, "bad-finalizercommits-merkleroot", true, "hash_finalizer_commits_merkle_root mismatch");

--- a/src/staking/proof_of_stake.cpp
+++ b/src/staking/proof_of_stake.cpp
@@ -6,6 +6,7 @@
 
 #include <script/script.h>
 #include <script/standard.h>
+#include <streams.h>
 
 namespace staking {
 
@@ -98,6 +99,34 @@ std::vector<CPubKey> ExtractBlockSigningKeys(const CBlock &block) {
     return std::vector<CPubKey>{};
   }
   return ExtractBlockSigningKeys(coinbase_inputs[1]);
+}
+
+uint256 ComputeKernelHash(const uint256 &previous_block_stake_modifier,
+                          const blockchain::Time stake_block_time,
+                          const uint256 &stake_txid,
+                          const std::uint32_t stake_out_index,
+                          const blockchain::Time target_block_time) {
+
+  CDataStream s(SER_GETHASH, 0);
+
+  s << previous_block_stake_modifier;
+  s << stake_block_time;
+  s << stake_txid;
+  s << stake_out_index;
+  s << target_block_time;
+
+  return Hash(s.begin(), s.end());
+}
+
+uint256 ComputeStakeModifier(const uint256 &stake_transaction_hash,
+                             const uint256 &previous_blocks_stake_modifier) {
+
+  CDataStream s(SER_GETHASH, 0);
+
+  s << stake_transaction_hash;
+  s << previous_blocks_stake_modifier;
+
+  return Hash(s.begin(), s.end());
 }
 
 }  // namespace staking

--- a/src/staking/stake_validator.h
+++ b/src/staking/stake_validator.h
@@ -21,9 +21,7 @@
 
 namespace staking {
 
-//! \brief
-//!
-//!
+//! \brief Validates Proof-of-Stake specific aspects of a block.
 class StakeValidator {
  public:
   virtual CCriticalSection &GetLock() = 0;
@@ -108,7 +106,7 @@ class StakeValidator {
   //!
   //! Requires the lock (obtained via GetLock) to be held.
   virtual bool IsStakeMature(
-      const blockchain::Height height  //!< [in] The height of the stake coin.
+      blockchain::Height height  //!< [in] The height of the stake coin.
       ) const = 0;
 
   virtual ~StakeValidator() = default;

--- a/src/staking/staking_rpc.h
+++ b/src/staking/staking_rpc.h
@@ -15,6 +15,7 @@ class BlockDB;
 namespace staking {
 
 class ActiveChain;
+class StakeValidator;
 
 //! \brief The staking RPC commands, dependency injected.
 //!
@@ -30,6 +31,8 @@ class StakingRPC {
   virtual UniValue tracechain(const JSONRPCRequest &request) = 0;
 
   virtual UniValue tracestake(const JSONRPCRequest &request) = 0;
+
+  virtual UniValue calcstakemodifier(const JSONRPCRequest &request) = 0;
 
   virtual ~StakingRPC() = default;
 

--- a/src/test/staking/abstract_block_validator_tests.cpp
+++ b/src/test/staking/abstract_block_validator_tests.cpp
@@ -52,8 +52,8 @@ class SomeBlockValidator : public staking::AbstractBlockValidator {
 
   void CheckBlockInternal(
       const CBlock &block,
-      blockchain::Height &height_out,
-      uint256 &snapshot_hash_out,
+      blockchain::Height *height_out,
+      uint256 *snapshot_hash_out,
       staking::BlockValidationResult &result) const override {
     ++count_CheckBlockInternal;
     if (func_CheckBlockInternal) {
@@ -70,6 +70,10 @@ class SomeBlockValidator : public staking::AbstractBlockValidator {
     if (func_ContextualCheckBlockInternal) {
       (*func_ContextualCheckBlockInternal)(result);
     }
+  }
+
+  staking::BlockValidationResult CheckCoinbaseTransaction(const CTransaction &coinbase_tx) const override {
+    return staking::BlockValidationResult();
   }
 };
 

--- a/src/test/test_unite_mocks.h
+++ b/src/test/test_unite_mocks.h
@@ -379,11 +379,13 @@ class BlockValidatorMock : public staking::BlockValidator {
   mutable std::atomic<std::uint32_t> invocations_CheckBlockHeader{0};
   mutable std::atomic<std::uint32_t> invocations_ContextualCheckBlock{0};
   mutable std::atomic<std::uint32_t> invocations_ContextualCheckBlockHeader{0};
+  mutable std::atomic<std::uint32_t> invocations_CheckCoinbaseTransaction{0};
 
   mutable BlockValidationResult result_CheckBlock;
   mutable BlockValidationResult result_ContextualCheckBlock;
   mutable BlockValidationResult result_CheckBlockHeader;
   mutable BlockValidationResult result_ContextualCheckBlockHeader;
+  mutable BlockValidationResult result_CheckCoinbaseTransaction;
 
   mutable std::function<BlockValidationResult(const CBlock &, BlockValidationInfo *)> stub_CheckBlock =
       [&](const CBlock &block, BlockValidationInfo *info) {
@@ -401,6 +403,10 @@ class BlockValidatorMock : public staking::BlockValidator {
       [&](const CBlockHeader &block_header, const CBlockIndex &block_index, blockchain::Time time, BlockValidationInfo *info) {
         return result_ContextualCheckBlockHeader;
       };
+  mutable std::function<BlockValidationResult(const CTransaction &)> stub_CheckCoinbaseTransaction =
+      [&](const CTransaction &coinbase_tx) {
+        return result_CheckCoinbaseTransaction;
+      };
 
   BlockValidationResult CheckBlock(const CBlock &block, BlockValidationInfo *info) const override {
     ++invocations_CheckBlock;
@@ -417,6 +423,10 @@ class BlockValidatorMock : public staking::BlockValidator {
   BlockValidationResult ContextualCheckBlockHeader(const CBlockHeader &block_header, const CBlockIndex &block_index, blockchain::Time time, BlockValidationInfo *info) const override {
     ++invocations_ContextualCheckBlockHeader;
     return stub_ContextualCheckBlockHeader(block_header, block_index, time, info);
+  }
+  BlockValidationResult CheckCoinbaseTransaction(const CTransaction &coinbase_tx) {
+    ++invocations_CheckCoinbaseTransaction;
+    return stub_CheckCoinbaseTransaction(coinbase_tx);
   }
 };
 

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -182,12 +182,11 @@ class ExampleTest(UnitETestFramework):
             # Use the mininode and blocktools functionality to manually build a block
             # Calling the generate() rpc is easier, but this allows us to exactly
             # control the blocks and transactions.
-            txout = self.nodes[0].gettxout(stake['txid'], stake['vout'])
             coinbase = sign_coinbase(self.nodes[0], create_coinbase(height, stake, snapshot_meta.hash))
             block = create_block(self.tip, coinbase, self.block_time)
             # Wait until the active chain picks up the previous block
             wait_until(lambda: self.nodes[0].getblockcount() == height, timeout=5)
-            snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta.data, 0, height + 1, coinbase)
+            snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta, height + 1, coinbase)
             block.solve()
             block_message = msg_block(block)
             # Send message is used to send a P2P message to the node over our P2PInterface

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -167,7 +167,7 @@ class AssumeValidTest(UnitETestFramework):
         self.tip = block.sha256
 
         utxo1 = UTXO(height, TxType.COINBASE, COutPoint(coinbase.sha256, 0), coinbase.vout[0])
-        snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta.data, 0, height, coinbase)
+        snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta, height, coinbase)
         height += 1
 
         self.log.info("Bury the block 100 deep so the coinbase output is spendable")
@@ -180,7 +180,7 @@ class AssumeValidTest(UnitETestFramework):
             self.tip = block.sha256
             self.block_time += 1
             utxo = UTXO(height, TxType.COINBASE, COutPoint(coinbase.sha256, 0), coinbase.vout[0])
-            snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta.data, 0, height, coinbase)
+            snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta, height, coinbase)
             height += 1
 
         self.log.info("Create a transaction spending the coinbase output with an invalid (null) signature")
@@ -201,10 +201,10 @@ class AssumeValidTest(UnitETestFramework):
         self.tip = block102.sha256
         self.block_time += 1
 
-        snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta.data, 0, height, coinbase)
+        snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta, height, coinbase)
 
         utxo2 = UTXO(height, tx.get_type(), COutPoint(tx.sha256, 0), tx.vout[0])
-        snapshot_meta = calc_snapshot_hash(self.nodes[0], snapshot_meta.data, 0, height, [utxo1], [utxo2])
+        snapshot_meta = calc_snapshot_hash(self.nodes[0], snapshot_meta, height, [utxo1], [utxo2])
 
         height += 1
 
@@ -219,7 +219,7 @@ class AssumeValidTest(UnitETestFramework):
             self.tip = block.sha256
             self.block_time += 1
             utxo = UTXO(height, TxType.COINBASE, COutPoint(coinbase.sha256, 0), coinbase.vout[0])
-            snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta.data, 0, height, coinbase)
+            snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta, height, coinbase)
             height += 1
 
         # We're adding new connections so terminate the network thread

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -333,7 +333,7 @@ class BIP68Test(UnitETestFramework):
             block.solve()
             tip = block.sha256
 
-            tip_snapshot_meta = update_snapshot_with_tx(self.nodes[0], tip_snapshot_meta.data, 0, height, coinbase)
+            tip_snapshot_meta = update_snapshot_with_tx(self.nodes[0], tip_snapshot_meta, height, coinbase)
 
             height += 1
             self.nodes[0].p2p.send_and_ping(msg_witness_block(block))

--- a/test/functional/feature_bip9_softforks.py
+++ b/test/functional/feature_bip9_softforks.py
@@ -67,7 +67,7 @@ class BIP9SoftForksTest(ComparisonTestFramework):
             test_blocks.append([block, True])
             self.last_block_time += 1
 
-            self.snapshot_meta = update_snapshot_with_tx(self.nodes[0], self.snapshot_meta.data, 0, self.height, coinbase)
+            self.snapshot_meta = update_snapshot_with_tx(self.nodes[0], self.snapshot_meta, self.height, coinbase)
             self.tip = block.sha256
             self.height += 1
         return test_blocks

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -168,7 +168,7 @@ class FullBlockTest(ComparisonTestFramework):
 
         assert_equal(block_height, self.block_heights[block.hashPrevBlock]+1)
         prev_meta = self.block_snapshot_meta[block.hashPrevBlock]
-        new_meta = calc_snapshot_hash(self.nodes[0], prev_meta.data, 0, block_height, inputs, outputs)
+        new_meta = calc_snapshot_hash(self.nodes[0], prev_meta, block_height, inputs, outputs, block.vtx[0] if block.vtx else None)
         self.block_snapshot_meta[block.sha256] = new_meta
 
     def next_block(self, number, coin, spend=None, additional_coinbase_value=0, script=CScript([OP_TRUE]), solve=True, coinbase_pieces=1, sign_stake=True, sign_spend=True):

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -149,7 +149,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
         block.compute_merkle_trees()
         block.solve()
 
-        self.tip_snapshot_meta = update_snapshot_with_tx(self.nodes[0], self.tip_snapshot_meta.data, 0, self.tipheight + 1, coinbase)
+        self.tip_snapshot_meta = update_snapshot_with_tx(self.nodes[0], self.tip_snapshot_meta, self.tipheight + 1, coinbase)
         return block
 
     def create_bip68txs(self, bip68inputs, txversion, locktime_delta = 0):

--- a/test/functional/feature_ltor.py
+++ b/test/functional/feature_ltor.py
@@ -20,7 +20,8 @@ from test_framework.blocktools import (
     create_block,
     sign_coinbase,
     create_coinbase,
-    create_transaction
+    create_transaction,
+    get_tip_snapshot_meta,
 )
 from test_framework.comptool import (
     RejectResult,
@@ -231,7 +232,7 @@ class LTORTest(UnitETestFramework):
         node0 = self.nodes[0]
 
         hashprev = uint256_from_str(unhexlify(node0.getbestblockhash())[::-1])
-        snapshot_hash = SnapshotMeta(node0.gettipsnapshot()).hash
+        snapshot_hash = get_tip_snapshot_meta(node0).hash
 
         if len(self.spendable_outputs) > 0:
             block_time = self.spendable_outputs[-1].nTime + 1

--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -53,7 +53,7 @@ class P2PFingerprintTest(UnitETestFramework):
             blocks.append(block)
             prev_hash = block.hash
 
-            snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta.data, 0, prev_height + 1, coinbase)
+            snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta, prev_height + 1, coinbase)
             prev_height += 1
             prev_median_time = block_time
         return blocks

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -79,7 +79,7 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
             input_utxo = UTXO(height-1, TxType.COINBASE, coinbase.vin[1].prevout, prev_coinbase.vout[1])
             output_reward = UTXO(height, TxType.COINBASE, COutPoint(coinbase.sha256, 0), coinbase.vout[0])
             output_stake = UTXO(height, TxType.COINBASE, COutPoint(coinbase.sha256, 1), coinbase.vout[1])
-            snapshot_meta = calc_snapshot_hash(self.nodes[0], snapshot_meta.data, 0, height, [input_utxo], [output_reward, output_stake])
+            snapshot_meta = calc_snapshot_hash(self.nodes[0], snapshot_meta, height, [input_utxo], [output_reward, output_stake], coinbase)
 
             height += 1
         yield test

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -74,7 +74,7 @@ class InvalidTxRequestTest(ComparisonTestFramework):
             input_utxo = UTXO(height-1, TxType.COINBASE, coinbase.vin[1].prevout, prev_coinbase.vout[1])
             output_reward = UTXO(height, TxType.COINBASE, COutPoint(coinbase.sha256, 0), coinbase.vout[0])
             output_stake = UTXO(height, TxType.COINBASE, COutPoint(coinbase.sha256, 1), coinbase.vout[1])
-            snapshot_meta = calc_snapshot_hash(self.nodes[0], snapshot_meta.data, 0, height, [input_utxo], [output_reward, output_stake])
+            snapshot_meta = calc_snapshot_hash(self.nodes[0], snapshot_meta, height, [input_utxo], [output_reward, output_stake], coinbase)
             height += 1
         yield test
 

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -380,7 +380,7 @@ class SendHeadersTest(UnitETestFramework):
                     blocks[-1].solve()
                     tip = blocks[-1].sha256
 
-                    snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta.data, 0, height, coinbase)
+                    snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta, height, coinbase)
 
                     block_time += 1
                     height += 1
@@ -499,7 +499,7 @@ class SendHeadersTest(UnitETestFramework):
             blocks.append(create_block(tip, coinbase, block_time))
             blocks[-1].solve()
             tip = blocks[-1].sha256
-            snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta.data, 0, height, coinbase)
+            snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta, height, coinbase)
             block_time += 1
             height += 1
             inv_node.send_message(msg_block(blocks[-1]))
@@ -521,7 +521,7 @@ class SendHeadersTest(UnitETestFramework):
             blocks.append(create_block(tip, coinbase, block_time))
             blocks[-1].solve()
             tip = blocks[-1].sha256
-            snapshots.append(update_snapshot_with_tx(self.nodes[0], snapshots[-1].data, 0, height, coinbase))
+            snapshots.append(update_snapshot_with_tx(self.nodes[0], snapshots[-1], height, coinbase))
             block_time += 1
             height += 1
 
@@ -546,7 +546,7 @@ class SendHeadersTest(UnitETestFramework):
             blocks.append(create_block(tip, coinbase, block_time))
             blocks[-1].solve()
             tip = blocks[-1].sha256
-            snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta.data, 0, height, coinbase)
+            snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta, height, coinbase)
             block_time += 1
             height += 1
 
@@ -597,7 +597,7 @@ class SendHeadersTest(UnitETestFramework):
                 blocks.append(create_block(tip, coinbase, block_time))
                 blocks[-1].solve()
                 tip = blocks[-1].sha256
-                snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta.data, 0, height, coinbase)
+                snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta, height, coinbase)
                 block_time += 1
                 height += 1
             # Send the header of the second block -> this won't connect.
@@ -622,7 +622,7 @@ class SendHeadersTest(UnitETestFramework):
             blocks.append(create_block(tip, coinbase, block_time))
             blocks[-1].solve()
             tip = blocks[-1].sha256
-            snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta.data, 0, height, coinbase)
+            snapshot_meta = update_snapshot_with_tx(self.nodes[0], snapshot_meta, height, coinbase)
             block_time += 1
             height += 1
 

--- a/test/functional/p2p_snapshot.py
+++ b/test/functional/p2p_snapshot.py
@@ -335,7 +335,7 @@ class P2PSnapshotTest(UnitETestFramework):
                 utxos.append(utxo)
         inputs = bytes_to_hex_str(ser_vector([]))
         outputs = bytes_to_hex_str(ser_vector(utxos))
-        stake_modifier = bytes_to_hex_str(ser_uint256(syncing_p2p.snapshot_header.stake_modifier))
+        stake_modifier = "%064x" % syncing_p2p.snapshot_header.stake_modifier
         chain_work = bytes_to_hex_str(ser_uint256(syncing_p2p.snapshot_header.chain_work))
         res = self.nodes[0].calcsnapshothash(inputs, outputs, stake_modifier, chain_work)
         snapshot_hash = uint256_from_hex(res['hash'])

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -76,6 +76,7 @@ class UTXOManager:
         self.spent_outputs = []
         self.current_inputs = []
         self.current_outputs = []
+        self.prev_coinbase = None
 
     def process(self, tx, height):
         is_coinbase = tx.get_type() == TxType.COINBASE
@@ -100,11 +101,13 @@ class UTXOManager:
         self.available_outputs.remove(utxo)
         self.spent_outputs.append(utxo)
         coin = {'txid': hex(utxo.outpoint.hash), 'vout': utxo.outpoint.n, 'amount': utxo.txOut.nValue/UNIT}
-        return sign_coinbase(self.node, create_coinbase(height, coin, snapshot_hash, **kwargs))
+        coinbase = sign_coinbase(self.node, create_coinbase(height, coin, snapshot_hash, **kwargs))
+        self.prev_coinbase = coinbase
+        return coinbase
 
     def get_hash(self, height):
         if self.current_inputs or self.current_outputs:
-            self.snapshot_meta = calc_snapshot_hash(self.node, self.snapshot_meta.data, 0, height, self.current_inputs, self.current_outputs)
+            self.snapshot_meta = calc_snapshot_hash(self.node, self.snapshot_meta, height, self.current_inputs, self.current_outputs, self.prev_coinbase)
             for output in self.current_inputs:
                 if output in self.available_outputs:
                     self.available_outputs.remove(output)

--- a/test/functional/rpc_liststakeablecoins.py
+++ b/test/functional/rpc_liststakeablecoins.py
@@ -22,7 +22,7 @@ class RpcGetStakeableBalanceTest(UnitETestFramework):
     def run_test(self):
         node = self.nodes[0]
         self.setup_stake_coins(node)
-        result = node.getstakeablecoins()
+        result = node.liststakeablecoins()
         assert_matches(result, {
             'stakeable_balance': Decimal,
             'stakeable_coins': [

--- a/test/functional/rpc_tracechain.py
+++ b/test/functional/rpc_tracechain.py
@@ -39,6 +39,7 @@ class RpcTraceChainTest(UnitETestFramework):
                 {
                     'block_hash': Matcher.hexstr(64),
                     'block_height': 1,
+                    'stake_modifier': Matcher.hexstr(64),
                     'status': str,
                     'transactions': Matcher.many(Matcher.hexstr(64), min=1),
                     'coinbase': {
@@ -70,6 +71,7 @@ class RpcTraceChainTest(UnitETestFramework):
                 {
                     'block_hash': Matcher.hexstr(64),
                     'block_height': 0,
+                    'stake_modifier': Matcher.hexstr(64),
                     'status': str,
                     'initial_funds': {
                         'txid': Matcher.hexstr(64),

--- a/test/functional/rpc_tracestake.py
+++ b/test/functional/rpc_tracestake.py
@@ -29,6 +29,7 @@ class RpcTraceStakeTest(UnitETestFramework):
             {
                 'block_hash': Matcher.hexstr(64),
                 'block_height': 0,
+                'stake_modifier': Matcher.hexstr(64),
                 'status': str,
             },
             {
@@ -36,6 +37,7 @@ class RpcTraceStakeTest(UnitETestFramework):
                 'block_height': 1,
                 'funding_block_hash': Matcher.hexstr(64),
                 'funding_block_height': 0,
+                'stake_modifier': Matcher.hexstr(64),
                 'stake_txout': {
                     'amount': Decimal,
                     'scriptPubKey': {

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -126,7 +126,7 @@ def generate(node, n, preserve_utxos=[], send_witness=False):
         stake = txouts.pop()
         coinbase = sign_coinbase(node, create_coinbase(height, stake, snapshot_meta.hash))
         block = create_block(tip, coinbase, block_time)
-        snapshot_meta = update_snapshot_with_tx(node, snapshot_meta.data, 0, height + 1, coinbase)
+        snapshot_meta = update_snapshot_with_tx(node, snapshot_meta, height + 1, coinbase)
         block.solve()
         if send_witness:
             node.p2p.send_message(msg_witness_block(block))
@@ -213,28 +213,42 @@ def send_to_witness(use_p2wsh, node, utxo, pubkey, encode_p2sh, amount, sign=Tru
 
 
 class SnapshotMeta:
-    def __init__(self, res):
+    def __init__(self, res, stake_modifier):
         self.hash = uint256_from_str(hex_str_to_bytes(res['hash']))
         self.data = res['data']
+        self.stake_modifier = stake_modifier
 
 
 def get_tip_snapshot_meta(node):
-    return SnapshotMeta(node.gettipsnapshot())
+    height = node.getblockcount()
+    stake_modifier = node.tracechain(start=height, length=1)['chain'][0]['stake_modifier']
+    return SnapshotMeta(node.gettipsnapshot(), stake_modifier)
 
 
-def calc_snapshot_hash(node, snapshot_data, stake_modifier, height, inputs, outputs):
+def calc_snapshot_hash(node, snapshot_meta, height, inputs, outputs, stake_prevout_txid=None):
     chain_work = 2 + 2*height
+    if isinstance(stake_prevout_txid, CTransaction):
+        if len(stake_prevout_txid.vin) < 2:
+            stake_prevout_txid = None
+    if stake_prevout_txid is None:
+        stake_modifier = snapshot_meta.stake_modifier
+    else:
+        if isinstance(stake_prevout_txid, CTransaction):
+            stake_prevout_txid = stake_prevout_txid.vin[1].prevout.hash
+        if isinstance(stake_prevout_txid, int):
+            stake_prevout_txid = "%064x" % stake_prevout_txid
+        stake_modifier = node.calcstakemodifier(txid=stake_prevout_txid, prev=snapshot_meta.stake_modifier)
     res = node.calcsnapshothash(
         bytes_to_hex_str(ser_vector(inputs)),
         bytes_to_hex_str(ser_vector(outputs)),
-        bytes_to_hex_str(ser_uint256(stake_modifier)),
+        stake_modifier,
         bytes_to_hex_str(ser_uint256(chain_work)),
-        snapshot_data
+        snapshot_meta.data
     )
-    return SnapshotMeta(res)
+    return SnapshotMeta(res, stake_modifier)
 
 
-def update_snapshot_with_tx(node, snapshot_data, stake_modifier, height, tx):
+def update_snapshot_with_tx(node, snapshot_meta, height, tx):
     """
     Returns updated snapshot for a single tx (if need arises, change it to a list of txses)
     """
@@ -258,4 +272,4 @@ def update_snapshot_with_tx(node, snapshot_data, stake_modifier, height, tx):
         utxo = UTXO(height, tx.get_type(), COutPoint(tx.sha256, i), tx_out)
         outputs.append(utxo)
 
-    return calc_snapshot_hash(node, snapshot_data, stake_modifier, height, inputs, outputs)
+    return calc_snapshot_hash(node, snapshot_meta, height, inputs, outputs, tx.vin[1].prevout.hash)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -141,8 +141,11 @@ def assert_matches(actual, expected, strict=True, path=()):
         When given a list invokes assert_matches for every item.
         When given a string the value must equal that string.
         When given an int the value must equal that int.
-        When given a type the value must be of that type.
+        When given a float the value must equal that float.
+        When given a bool the value must equal that bool.
+        When given a Decimal the value must equal that Decimal.
         When given a function the value must satisfy that predicate.
+        When given a type (all other cases) the value must be of that type.
     :param strict:
         In strict mode a dictionary must have exactly the same keys
         (otherwise at least the same keys) and lists must have the same length.
@@ -171,9 +174,7 @@ def assert_matches(actual, expected, strict=True, path=()):
             for actual_item, expected_item in zip(actual, expected):
                 assert_matches(actual_item, expected_item, strict=strict, path=path+(ix,))
                 ix += 1
-        elif type(expected) == str:
-            assert_equal(actual, expected)
-        elif type(expected) == int:
+        elif isinstance(expected, (str, int, float, bool, Decimal)):
             assert_equal(actual, expected)
         elif isinstance(expected, types.FunctionType):
             if not expected(actual, path):

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -118,7 +118,7 @@ BASE_SCRIPTS= [
     'wallet_keypool_topup.py',
     'p2p_commits.py',
     'rpc_blockchain.py',
-    'rpc_getstakeablecoins.py',
+    'rpc_liststakeablecoins.py',
     'esperanza_logout.py',
     'feature_versionbits_warning.py',
     'rpc_filtertransactions.py',


### PR DESCRIPTION
The stake_modifier for a block is saved in `CBlockIndex` and it was not set before. This pull request changes that.

Updated the functional tests such that the snapshot hash calculation correctly takes `stake_modifier` into account. Notable change: Instead of passing `snapshot_meta.hash` it passes `snapshot_meta` which harbours both `hash` and `stake_modifier`.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
