### PR TITLE
Synchronize the wallet to the active chain before getting stakeable coins

### DIFF
--- a/src/proposer/proposer.cpp
+++ b/src/proposer/proposer.cpp
@@ -102,6 +102,8 @@ class ProposerImpl : public Proposer {
         }
         std::shared_ptr<const CBlock> block;
         {
+          // To pick up to date coins for staking we need to make sure that the wallet is synced to the current chain.
+          wallet->BlockUntilSyncedToCurrentChain();
           LOCK2(m_active_chain->GetLock(), wallet_ext.GetLock());
           const CBlockIndex &tip = *m_active_chain->GetTip();
           const staking::CoinSet coins = wallet_ext.GetStakeableCoins();

--- a/src/proposer/proposer_rpc.cpp
+++ b/src/proposer/proposer_rpc.cpp
@@ -30,9 +30,10 @@ class ProposerRPCImpl : public ProposerRPC {
   const Dependency<Proposer> m_proposer;
 
   UniValue GetWalletInfo(const std::vector<CWalletRef> &wallets) const {
-    LOCK(m_chain->GetLock());
     UniValue result(UniValue::VARR);
     for (const auto &wallet : wallets) {
+      wallet->BlockUntilSyncedToCurrentChain();
+      LOCK(m_chain->GetLock());
       const auto &wallet_extension = wallet->GetWalletExtension();
       const auto &proposerState = wallet_extension.GetProposerState();
       UniValue info(UniValue::VOBJ);
@@ -145,6 +146,7 @@ class ProposerRPCImpl : public ProposerRPC {
           "get the stakeable coins\n",
           __func__));
     }
+    wallet->BlockUntilSyncedToCurrentChain();
     UniValue obj(UniValue::VOBJ);
     const staking::StakingWallet &staking_wallet = wallet->GetWalletExtension();
     const staking::CoinSet stakeable_coins = [&]() {

--- a/src/staking/legacy_validation_interface.h
+++ b/src/staking/legacy_validation_interface.h
@@ -39,7 +39,7 @@ class StakeValidator;
 //!
 //! For backwards compatibility CValidationState has been augmented
 //! with staking::BlockValidationInfo. The scope of it is narrower
-//! then for CValidationState as we also have BlockValidationResult.
+//! than for CValidationState as we also have BlockValidationResult.
 //! To translate into the existing validation interface different
 //! implementations are provided for the LegacyValidationInterface:
 //! - LegacyValidationInterface::New which accesses the PoS BlockValidator

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3442,6 +3442,11 @@ UniValue generateBlocks(CWallet * const pwallet, std::shared_ptr<CReserveScript>
     }
     unsigned int nExtraNonce = 0;
     UniValue blockHashes(UniValue::VARR);
+
+    // To pick up to date coins for staking we need to make sure that the wallet is synced to the current chain.
+    if (pwallet) {
+        pwallet->BlockUntilSyncedToCurrentChain();
+    }
     while (nHeight < nHeightEnd)
     {
         std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(Params()).CreateNewBlock(

--- a/test/functional/proposer_stakeable_balance.py
+++ b/test/functional/proposer_stakeable_balance.py
@@ -81,7 +81,7 @@ class ProposerStakeableBalanceTest(UnitETestFramework):
             wallet = status['wallets'][0]
             assert_equal(wallet['balance'], Decimal('10000.00000000'))
             assert_equal(wallet['stakeable_balance'], Decimal('10000.00000000'))
-        # and others shoulds till not have enough funds for proposing blocks
+        # and others should still not have enough funds for proposing blocks
         for i in range(num_keys, self.num_nodes):
             status = nodes[i].proposerstatus()
             wallet = status['wallets'][0]


### PR DESCRIPTION
Fixes #940. `proposer_stakable_balance.py` might fail if the call of `proposerstatus` happens at the moment when the node has proposed a new block but the wallet has not been updated yet. This PR adds `wallet->BlockUntilSyncedToCurrentChain()` which _does not give 100% protection_ but makes such situations very unlikely.