### PR TITLE
Fix inconsistent ValidatorState after re-org'ing deposit

### DIFF
--- a/src/esperanza/finalizationstate.cpp
+++ b/src/esperanza/finalizationstate.cpp
@@ -629,20 +629,16 @@ Result FinalizationState::CalculateWithdrawAmount(const uint160 &validatorAddres
                 validatorAddress.GetHex());
   }
 
-  const auto &validator = it->second;
-
-  uint32_t endDynasty = validator.m_end_dynasty;
-
-  if (m_current_dynasty <= endDynasty) {
+  const Validator &validator = it->second;
+  Result result = Result::SUCCESS;
+  const uint32_t withdrawalEpoch = CalculateWithdrawEpoch(validator, &result);
+  if (result != +Result::SUCCESS) {
     return fail(Result::WITHDRAW_BEFORE_END_DYNASTY,
                 /*log_errors=*/true,
                 "%s: Too early to withdraw, minimum expected dynasty for "
                 "withdraw is %d.\n",
-                __func__, endDynasty);
+                __func__, validator.m_end_dynasty);
   }
-
-  uint32_t endEpoch = m_dynasty_start_epoch.find(endDynasty + 1)->second;
-  uint32_t withdrawalEpoch = endEpoch + m_settings.withdrawal_epoch_delay;
 
   if (m_current_epoch < withdrawalEpoch) {
     return fail(Result::WITHDRAW_TOO_EARLY,
@@ -651,6 +647,8 @@ Result FinalizationState::CalculateWithdrawAmount(const uint160 &validatorAddres
                 "withdraw is %d.\n",
                 __func__, withdrawalEpoch);
   }
+
+  const uint32_t endEpoch = withdrawalEpoch - m_settings.withdrawal_epoch_delay;
 
   if (!validator.m_is_slashed) {
     withdrawAmountOut = ufp64::mul_to_uint(GetDepositScaleFactor(endEpoch),
@@ -679,7 +677,7 @@ Result FinalizationState::CalculateWithdrawAmount(const uint160 &validatorAddres
 
     LogPrint(BCLog::FINALIZATION,
              "%s: Withdraw from validator %s of %d units.\n", __func__,
-             validatorAddress.GetHex(), endDynasty, withdrawAmountOut);
+             validatorAddress.GetHex(), validator.m_end_dynasty, withdrawAmountOut);
   }
 
   return success();
@@ -1121,6 +1119,35 @@ bool FinalizationState::IsFinalizerVoting(const uint160 &finalizer_address) cons
 
 bool FinalizationState::IsFinalizerVoting(const Validator &finalizer) const {
   return IsInDynasty(finalizer, m_current_dynasty) || IsInDynasty(finalizer, m_current_dynasty - 1);
+}
+
+uint32_t FinalizationState::CalculateWithdrawEpoch(const Validator &finalizer,
+                                                   Result *result_out) const {
+
+  // m_end_dynasty is not set
+  if (finalizer.m_end_dynasty == DEFAULT_END_DYNASTY) {
+    if (result_out) {
+      *result_out = Result::WITHDRAW_BEFORE_END_DYNASTY;
+    }
+    return std::numeric_limits<uint32_t>::max();
+  }
+
+  if (m_current_dynasty <= finalizer.m_end_dynasty) {
+    if (result_out) {
+      *result_out = Result::WITHDRAW_BEFORE_END_DYNASTY;
+    }
+    return std::numeric_limits<uint32_t>::max();
+  }
+
+  const auto it = m_dynasty_start_epoch.find(finalizer.m_end_dynasty + 1);
+  assert(it != m_dynasty_start_epoch.end() && "incorrect m_dynasty_start_epoch mapping");
+  const uint32_t &end_epoch = it->second;
+  const uint32_t withdraw_epoch = end_epoch + m_settings.withdrawal_epoch_delay;
+
+  if (result_out) {
+    *result_out = Result::SUCCESS;
+  }
+  return withdraw_epoch;
 }
 
 }  // namespace esperanza

--- a/src/esperanza/finalizationstate.h
+++ b/src/esperanza/finalizationstate.h
@@ -189,6 +189,9 @@ class FinalizationState : public FinalizationStateData {
   //! \brief Returns true if finalizer can vote in current dynasty
   bool IsFinalizerVoting(const Validator &finalizer) const;
 
+  //! \brief Calculate the epoch at which finalizer can start withdrawing
+  uint32_t CalculateWithdrawEpoch(const Validator &finalizer, Result *result_out) const;
+
  private:
   //!In case there is nobody available to justify we justify automatically.
   void InstaJustify();

--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -276,6 +276,24 @@ bool WalletExtension::SendDeposit(const CKeyID &keyID, CAmount amount,
                                   CWalletTx &wtxOut) {
 
   assert(validatorState);
+
+  LOCK2(cs_main, m_enclosing_wallet.cs_wallet);
+
+  LOCK(m_dependencies.GetFinalizationStateRepository().GetLock());
+  const FinalizationState *fin_state = m_dependencies.GetFinalizationStateRepository().GetTipState();
+  assert(fin_state);
+
+  const ValidatorState::Phase cur_phase = GetFinalizerPhase(*fin_state);
+  const ValidatorState::Phase exp_phase = ValidatorState::Phase::NOT_VALIDATING;
+  if (cur_phase != exp_phase) {
+    LogPrint(BCLog::FINALIZATION,
+             "ERROR: %s: can't send deposit because finalizer in phase=%s when expected=%s\n",
+             __func__,
+             cur_phase._to_string(),
+             exp_phase._to_string());
+    return false;
+  }
+
   ValidatorState &validator = validatorState.get();
   ValidatorStateWatchWriter validator_writer(*this);
 
@@ -306,7 +324,6 @@ bool WalletExtension::SendDeposit(const CKeyID &keyID, CAmount amount,
   }
 
   {
-    LOCK2(cs_main, m_enclosing_wallet.cs_wallet);
     CValidationState state;
     if (!m_enclosing_wallet.CommitTransaction(wtxOut, reservekey,
                                               g_connman.get(), state)) {
@@ -322,20 +339,9 @@ bool WalletExtension::SendDeposit(const CKeyID &keyID, CAmount amount,
       return false;
     }
 
+    validator.m_last_deposit_tx = wtxOut.GetHash();
     LogPrint(BCLog::FINALIZATION, "%s: Created new deposit transaction %s.\n",
              __func__, wtxOut.GetHash().GetHex());
-
-    if (validator.m_phase == +ValidatorState::Phase::NOT_VALIDATING) {
-      LogPrint(BCLog::FINALIZATION,
-               "%s: Validator waiting for deposit confirmation.\n", __func__);
-
-      validator.m_phase = ValidatorState::Phase::WAITING_DEPOSIT_CONFIRMATION;
-    } else {
-      LogPrintf(
-          "ERROR: %s - Wrong state for validator state with deposit %s, %s "
-          "expected.\n",
-          __func__, wtxOut.GetHash().GetHex(), "WAITING_DEPOSIT_CONFIRMATION");
-    }
   }
 
   return true;
@@ -358,6 +364,10 @@ bool WalletExtension::SendLogout(CWalletTx &wtxNewOut) {
         __func__);
   }
 
+  if (!state->IsFinalizerVoting(*validator)) {
+    return error("%s: Cannot create logouts for non-validators.", __func__);
+  }
+
   wtxNewOut.fTimeReceivedIsTxTime = true;
   wtxNewOut.BindWallet(&m_enclosing_wallet);
   wtxNewOut.fFromMe = true;
@@ -366,10 +376,6 @@ bool WalletExtension::SendLogout(CWalletTx &wtxNewOut) {
 
   CMutableTransaction txNew;
   txNew.SetType(TxType::LOGOUT);
-
-  if (validatorState->m_phase != +ValidatorState::Phase::IS_VALIDATING) {
-    return error("%s: Cannot create logouts for non-validators.", __func__);
-  }
 
   CTransactionRef prevTx;
   {
@@ -425,6 +431,10 @@ bool WalletExtension::SendLogout(CWalletTx &wtxNewOut) {
     return false;
   }
 
+  // must be forgotten as if we sent logout, deposit can't be reverted
+  // and GetFinalizerPhase() must rely on global FinalizationState
+  validatorState->m_last_deposit_tx.SetNull();
+
   return true;
 }
 
@@ -445,6 +455,17 @@ bool WalletExtension::SendWithdraw(const CTxDestination &address, CWalletTx &wtx
         __func__);
   }
 
+  const ValidatorState::Phase cur_phase = GetFinalizerPhase(*state);
+  const ValidatorState::Phase exp_phase = ValidatorState::Phase::WAITING_TO_WITHDRAW;
+  if (cur_phase != exp_phase) {
+    LogPrint(BCLog::FINALIZATION,
+             "ERROR: %s: can't send withdraw because finalizer in phase=%s when expected=%s\n",
+             __func__,
+             cur_phase._to_string(),
+             exp_phase._to_string());
+    return false;
+  }
+
   CCoinControl coinControl;
   coinControl.m_fee_mode = FeeEstimateMode::CONSERVATIVE;
 
@@ -460,11 +481,6 @@ bool WalletExtension::SendWithdraw(const CTxDestination &address, CWalletTx &wtx
 
   CMutableTransaction txNew;
   txNew.SetType(TxType::WITHDRAW);
-
-  if (validatorState->m_phase == +ValidatorState::Phase::IS_VALIDATING) {
-    return error("%s: Cannot withdraw with an active validator, logout first.",
-                 __func__);
-  }
 
   const std::vector<unsigned char> pkv = ToByteVector(pubKey.GetID());
   const CScript &scriptPubKey = CScript::CreateP2PKHScript(pkv);
@@ -556,16 +572,6 @@ void WalletExtension::VoteIfNeeded(const FinalizationState &state, const blockch
     return;
   }
 
-  const uint32_t dynasty = state.GetCurrentDynasty();
-
-  if (dynasty > validator->m_end_dynasty) {
-    return;
-  }
-
-  if (dynasty < validator->m_start_dynasty) {
-    return;
-  }
-
   const uint32_t target_epoch = state.GetRecommendedTargetEpoch();
   if (state.GetCurrentEpoch() != target_epoch + 1) {
     // not the right time to vote
@@ -579,7 +585,7 @@ void WalletExtension::VoteIfNeeded(const FinalizationState &state, const blockch
 
   LogPrint(BCLog::FINALIZATION,
            "%s: Validator voting for epoch %d and dynasty %d.\n", __func__,
-           target_epoch, dynasty);
+           target_epoch, state.GetCurrentDynasty());
 
   Vote vote = state.GetRecommendedVote(validatorState->m_validator_address);
   assert(vote.m_target_epoch == target_epoch);
@@ -624,10 +630,6 @@ bool WalletExtension::SendVote(const CTransactionRef &prevTxRef,
 
   CMutableTransaction txNew;
   txNew.SetType(TxType::VOTE);
-
-  if (validator.m_phase != +ValidatorState::Phase::IS_VALIDATING) {
-    return error("%s: Cannot create votes for non-validators.", __func__);
-  }
 
   const CScript &scriptPubKey = prevTxRef->vout[0].scriptPubKey;
   const CAmount amount = prevTxRef->vout[0].nValue;
@@ -760,63 +762,27 @@ bool WalletExtension::SendSlash(const finalization::VoteRecord &vote1,
 void WalletExtension::BlockConnected(
     const std::shared_ptr<const CBlock> &pblock, const CBlockIndex &index) {
 
+  if (!nIsValidatorEnabled) {
+    // finalizer is explicitly disabled
+    return;
+  }
+
+  if (IsInitialBlockDownload()) {
+    // there is no reason to vote as such votes will be outdated
+    // and won't be included in the chain
+    return;
+  }
+
   LOCK2(cs_main, m_enclosing_wallet.cs_wallet);
-  if (nIsValidatorEnabled) {
-    assert(validatorState);
+  assert(validatorState);
 
-    LOCK(m_dependencies.GetFinalizationStateRepository().GetLock());
-    const CBlockIndex *tip_block_index = m_dependencies.GetActiveChain().GetTip();
-    const FinalizationState *fin_state = m_dependencies.GetFinalizationStateRepository().Find(*tip_block_index);
-    assert(fin_state);
+  LOCK(m_dependencies.GetFinalizationStateRepository().GetLock());
+  const CBlockIndex *tip_block_index = m_dependencies.GetActiveChain().GetTip();
+  const FinalizationState *fin_state = m_dependencies.GetFinalizationStateRepository().Find(*tip_block_index);
+  assert(fin_state);
 
-    const esperanza::Validator *validator = fin_state->GetValidator(validatorState->m_validator_address);
-    if (!validator) {
-      // this wallet doesn't have associated finalizer
-      // because no deposit from this wallet was made
-      return;
-    }
-
-    ValidatorStateWatchWriter validator_writer(*this);
-
-    if (fin_state->GetCurrentDynasty() < validator->m_start_dynasty) {
-      return;  // to early to vote
-    }
-
-    // TODO: UNIT-E: review if we need to keep track of the state
-    // as it seems checking against current dynasty is enough
-    if (fin_state->GetCurrentDynasty() <= validator->m_end_dynasty) {
-      if (validatorState->m_phase == +ValidatorState::Phase::WAITING_DEPOSIT_FINALIZATION) {
-        validatorState->m_phase = ValidatorState::Phase::IS_VALIDATING;
-        WriteValidatorStateToFile();
-        LogPrint(BCLog::FINALIZATION,
-                 "finalizer=%d phase changed to %s because start_dynasty=%d began\n",
-                 validator->m_validator_address.ToString(),
-                 validatorState->m_phase._to_string(),
-                 validator->m_start_dynasty);
-      }
-      assert(validatorState->m_phase == +ValidatorState::Phase::IS_VALIDATING);
-    } else {
-      if (validatorState->m_phase == +ValidatorState::Phase::IS_VALIDATING) {
-        validatorState->m_phase = ValidatorState::Phase::NOT_VALIDATING;
-        WriteValidatorStateToFile();
-        LogPrint(BCLog::FINALIZATION,
-                 "finalizer=%d phase changed to %s because end_dynasty=%d passed\n",
-                 validator->m_validator_address.ToString(),
-                 validatorState->m_phase._to_string(),
-                 validator->m_end_dynasty);
-      }
-      assert(validatorState->m_phase == +ValidatorState::Phase::NOT_VALIDATING);
-    }
-
-    if (IsInitialBlockDownload()) {
-      // there is no reason to vote as such votes will be outdated
-      // and won't be included in the chain
-      return;
-    }
-
-    if (fin_state->IsFinalizerVoting(*validator)) {
-      VoteIfNeeded(*fin_state, tip_block_index->nHeight);  // responsible to write validator state
-    }
+  if (GetFinalizerPhase(*fin_state) == +ValidatorState::Phase::IS_VALIDATING) {
+    VoteIfNeeded(*fin_state, tip_block_index->nHeight);
   }
 }
 
@@ -839,55 +805,28 @@ bool WalletExtension::AddToWalletIfInvolvingMe(const CTransactionRef &ptx,
 
   switch (tx.GetType()) {
     case TxType::DEPOSIT: {
-      assert(!validatorState->HasDeposit());
-      esperanza::ValidatorState &state = validatorState.get();
+      LOCK(m_dependencies.GetFinalizationStateRepository().GetLock());
+      const FinalizationState *fin_state = m_dependencies.GetFinalizationStateRepository().GetTipState();
+      assert(fin_state != nullptr);
 
-      // In case that we are reading from blocks in initial sync we need to
-      // consider the case where we do not initiate our deposit, but we read it
-      // from the blockchain.
-      const auto bootstrap_phase =
-          +esperanza::ValidatorState::Phase::NOT_VALIDATING;
-
-      if (pIndex && state.m_phase == bootstrap_phase) {
-        state.m_phase = +esperanza::ValidatorState::Phase::WAITING_DEPOSIT_CONFIRMATION;
-      }
-
-      const auto expected_phase =
-          +esperanza::ValidatorState::Phase::WAITING_DEPOSIT_CONFIRMATION;
-
-      if (state.m_phase == expected_phase) {
-
-        state.m_phase = esperanza::ValidatorState::Phase::WAITING_DEPOSIT_FINALIZATION;
+      const ValidatorState::Phase cur_phase = GetFinalizerPhase(*fin_state);
+      if (cur_phase != +ValidatorState::Phase::NOT_VALIDATING &&                // deposit received via (re-)indexing
+          cur_phase != +ValidatorState::Phase::WAITING_DEPOSIT_CONFIRMATION) {  // deposit was sent explicitly
         LogPrint(BCLog::FINALIZATION,
-                 "%s: Validator waiting for deposit finalization. "
-                 "Deposit hash %s.\n",
-                 __func__, tx.GetHash().GetHex());
-
-        uint160 validatorAddress = uint160();
-
-        if (!esperanza::ExtractValidatorAddress(tx, validatorAddress)) {
-          LogPrint(BCLog::FINALIZATION,
-                   "ERROR: %s: Cannot extract validator index.\n",
-                   __func__);
-          return false;
-        }
-
-        {
-          LOCK(m_dependencies.GetFinalizationStateRepository().GetLock());
-          const FinalizationState *fin_state = m_dependencies.GetFinalizationStateRepository().GetTipState();
-          assert(fin_state != nullptr);
-
-          state.m_validator_address = validatorAddress;
-        }
-
-      } else {
-        LogPrint(BCLog::FINALIZATION,
-                 "ERROR: %s - Wrong state for validator state with "
-                 "deposit %s, %s expected but %s found.\n",
-                 __func__, tx.GetHash().GetHex(), expected_phase._to_string(),
-                 state.m_phase._to_string());
+                 "ERROR: %s: finalizer=%s has already created a deposit.\n",
+                 __func__,
+                 validatorState->m_validator_address.ToString());
         return false;
       }
+
+      uint160 finalizer_address;
+      if (!esperanza::ExtractValidatorAddress(tx, finalizer_address)) {
+        LogPrint(BCLog::FINALIZATION,
+                 "ERROR: %s: Cannot extract validator index.\n",
+                 __func__);
+        return false;
+      }
+      validatorState->m_validator_address = finalizer_address;
       break;
     }
     case TxType::LOGOUT: {
@@ -914,6 +853,10 @@ bool WalletExtension::AddToWalletIfInvolvingMe(const CTransactionRef &ptx,
                  validator->m_end_dynasty);
         return false;
       }
+
+      // at this point we don't care about the last deposit as it can't be reverted.
+      // we must reset this field to misinterpret NOT_VALIDATING as WAITING_DEPOSIT_CONFIRMATION
+      validatorState->m_last_deposit_tx.SetNull();
       break;
     }
     case TxType::VOTE: {
@@ -943,21 +886,76 @@ bool WalletExtension::AddToWalletIfInvolvingMe(const CTransactionRef &ptx,
       break;
     }
     case TxType::WITHDRAW: {
-      const auto expected_phase = +esperanza::ValidatorState::Phase::NOT_VALIDATING;
-      assert(validatorState->m_phase == expected_phase);
+      LOCK(m_dependencies.GetFinalizationStateRepository().GetLock());
+      const FinalizationState *fin_state = m_dependencies.GetFinalizationStateRepository().GetTipState();
+      assert(fin_state != nullptr);
+
+      const ValidatorState::Phase cur_phase = GetFinalizerPhase(*fin_state);
+      if (cur_phase != +ValidatorState::Phase::WAITING_TO_WITHDRAW &&  // __func__ is called before block is processed
+          cur_phase != +ValidatorState::Phase::NOT_VALIDATING) {       // __func__ is called after block is processed
+        LogPrint(BCLog::FINALIZATION,
+                 "ERROR: %s: finalizer=%s can't withdraw as it's still validating.\n",
+                 __func__,
+                 validatorState->m_validator_address.ToString());
+        return false;
+      }
 
       validatorState = ValidatorState();
       break;
     }
-    default: {
-      return true;
-    }
+    case TxType::SLASH:
+    case TxType::ADMIN:
+    case TxType::REGULAR:
+    case TxType::COINBASE:
+      break;
   }
+
   return true;
 }
 
 const proposer::State &WalletExtension::GetProposerState() const {
   return m_proposer_state;
+}
+
+const ValidatorState::Phase WalletExtension::GetFinalizerPhase(const FinalizationState &state) const {
+  if (!nIsValidatorEnabled) {
+    return ValidatorState::Phase::NOT_VALIDATING;
+  }
+
+  if (!validatorState) {
+    return ValidatorState::Phase::NOT_VALIDATING;
+  }
+
+  // check if finalizer created deposit
+  // but it's not included in the chain yet
+  const esperanza::Validator *validator = state.GetValidator(validatorState->m_validator_address);
+  if (!validator) {
+    if (validatorState->m_last_deposit_tx.IsNull()) {
+      return ValidatorState::Phase::NOT_VALIDATING;
+    }
+
+    const CWalletTx *tx = m_enclosing_wallet.GetWalletTx(validatorState->m_last_deposit_tx);
+    if (!tx) {
+      return ValidatorState::Phase::NOT_VALIDATING;
+    }
+
+    return ValidatorState::Phase::WAITING_DEPOSIT_CONFIRMATION;
+  }
+
+  if (state.GetCurrentDynasty() < validator->m_start_dynasty) {
+    return ValidatorState::Phase::WAITING_DEPOSIT_FINALIZATION;
+  }
+
+  if (state.IsFinalizerVoting(*validator)) {
+    return ValidatorState::Phase::IS_VALIDATING;
+  }
+
+  if (state.GetCurrentEpoch() < state.CalculateWithdrawEpoch(*validator,
+                                                             /*result_out*/ nullptr)) {
+    return ValidatorState::Phase::WAITING_FOR_WITHDRAW_DELAY;
+  }
+
+  return ValidatorState::Phase::WAITING_TO_WITHDRAW;
 }
 
 EncryptionState WalletExtension::GetEncryptionState() const {

--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -803,12 +803,12 @@ bool WalletExtension::AddToWalletIfInvolvingMe(const CTransactionRef &ptx,
   LOCK(m_enclosing_wallet.cs_wallet);
   ValidatorStateWatchWriter validator_writer(*this);
 
+  LOCK(m_dependencies.GetFinalizationStateRepository().GetLock());
+  const FinalizationState *fin_state = m_dependencies.GetFinalizationStateRepository().GetTipState();
+  assert(fin_state != nullptr);
+
   switch (tx.GetType()) {
     case TxType::DEPOSIT: {
-      LOCK(m_dependencies.GetFinalizationStateRepository().GetLock());
-      const FinalizationState *fin_state = m_dependencies.GetFinalizationStateRepository().GetTipState();
-      assert(fin_state != nullptr);
-
       const ValidatorState::Phase cur_phase = GetFinalizerPhase(*fin_state);
       if (cur_phase != +ValidatorState::Phase::NOT_VALIDATING &&                // deposit received via (re-)indexing
           cur_phase != +ValidatorState::Phase::WAITING_DEPOSIT_CONFIRMATION) {  // deposit was sent explicitly
@@ -830,10 +830,6 @@ bool WalletExtension::AddToWalletIfInvolvingMe(const CTransactionRef &ptx,
       break;
     }
     case TxType::LOGOUT: {
-      LOCK(m_dependencies.GetFinalizationStateRepository().GetLock());
-      const FinalizationState *fin_state = m_dependencies.GetFinalizationStateRepository().GetTipState();
-      assert(fin_state != nullptr);
-
       const esperanza::Validator *validator = fin_state->GetValidator(validatorState->m_validator_address);
       if (!validator) {
         LogPrint(BCLog::FINALIZATION,
@@ -860,10 +856,6 @@ bool WalletExtension::AddToWalletIfInvolvingMe(const CTransactionRef &ptx,
       break;
     }
     case TxType::VOTE: {
-      LOCK(m_dependencies.GetFinalizationStateRepository().GetLock());
-      const FinalizationState *fin_state = m_dependencies.GetFinalizationStateRepository().GetTipState();
-      assert(fin_state != nullptr);
-
       const esperanza::Validator *validator = fin_state->GetValidator(validatorState->m_validator_address);
       if (!validator) {
         LogPrint(BCLog::FINALIZATION,
@@ -886,10 +878,6 @@ bool WalletExtension::AddToWalletIfInvolvingMe(const CTransactionRef &ptx,
       break;
     }
     case TxType::WITHDRAW: {
-      LOCK(m_dependencies.GetFinalizationStateRepository().GetLock());
-      const FinalizationState *fin_state = m_dependencies.GetFinalizationStateRepository().GetTipState();
-      assert(fin_state != nullptr);
-
       const ValidatorState::Phase cur_phase = GetFinalizerPhase(*fin_state);
       if (cur_phase != +ValidatorState::Phase::WAITING_TO_WITHDRAW &&  // __func__ is called before block is processed
           cur_phase != +ValidatorState::Phase::NOT_VALIDATING) {       // __func__ is called after block is processed

--- a/src/esperanza/walletextension.h
+++ b/src/esperanza/walletextension.h
@@ -192,6 +192,8 @@ class WalletExtension : public staking::StakingWallet {
   boost::optional<ValidatorState> validatorState = boost::none;
   bool nIsValidatorEnabled = false;
 
+  const ValidatorState::Phase GetFinalizerPhase(const FinalizationState &state) const;
+
   EncryptionState GetEncryptionState() const;
 
   bool Unlock(const SecureString &wallet_passphrase, bool for_staking_only);

--- a/src/wallet/rpcvalidator.cpp
+++ b/src/wallet/rpcvalidator.cpp
@@ -43,10 +43,6 @@ UniValue deposit(const JSONRPCRequest &request)
     throw JSONRPCError(RPC_INVALID_REQUEST, "The node must be enabled to be a finalizer.");
   }
 
-  if (extWallet.validatorState->HasDeposit()) {
-    throw JSONRPCError(RPC_INVALID_REQUEST, "The node is already a finalizer.");
-  }
-
   CTxDestination address = DecodeDestination(request.params[0].get_str());
   if (!IsValidDestination(address)) {
     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address.");
@@ -59,16 +55,24 @@ UniValue deposit(const JSONRPCRequest &request)
 
   CAmount amount = AmountFromValue(request.params[1]);
 
-  esperanza::ValidatorState &validator = extWallet.validatorState.get();
-  if (validator.m_phase == +esperanza::ValidatorState::Phase::IS_VALIDATING){
-    throw JSONRPCError(RPC_INVALID_PARAMETER, "The node is already validating.");
-  }
-
   {
     LOCK(GetComponent<finalization::StateRepository>()->GetLock());
     const finalization::FinalizationState *fin_state =
       GetComponent<finalization::StateRepository>()->GetTipState();
     assert(fin_state != nullptr);
+
+    switch (extWallet.GetFinalizerPhase(*fin_state)) {
+      case esperanza::ValidatorState::Phase::NOT_VALIDATING:
+        break;
+      case esperanza::ValidatorState::Phase::WAITING_DEPOSIT_CONFIRMATION:
+      case esperanza::ValidatorState::Phase::WAITING_DEPOSIT_FINALIZATION:
+        throw JSONRPCError(RPC_VERIFY_ERROR, "Cannot re-deposit. Only one deposit is allowed.");
+      case esperanza::ValidatorState::Phase::IS_VALIDATING:
+        throw JSONRPCError(RPC_VERIFY_ERROR, "Cannot re-deposit while validating. Withdraw first.");
+      case esperanza::ValidatorState::Phase::WAITING_FOR_WITHDRAW_DELAY:
+      case esperanza::ValidatorState::Phase::WAITING_TO_WITHDRAW:
+        throw JSONRPCError(RPC_VERIFY_ERROR, "Cannot re-deposit while waiting for withdraw.");
+    }
 
     if (!fin_state->ValidateDepositAmount(amount)) {
       throw JSONRPCError(RPC_INVALID_PARAMETER, "Amount is below minimum allowed.");
@@ -117,10 +121,6 @@ UniValue withdraw(const JSONRPCRequest &request)
 
   assert(extWallet.validatorState);
 
-  if (extWallet.validatorState->m_phase != +esperanza::ValidatorState::Phase::NOT_VALIDATING){
-    throw JSONRPCError(RPC_INVALID_PARAMETER, "The node is validating, logout first.");
-  }
-
   uint256 last_tx_hash;
   {
     auto state_repo = GetComponent<finalization::StateRepository>();
@@ -132,6 +132,25 @@ UniValue withdraw(const JSONRPCRequest &request)
     const esperanza::Validator *validator = state->GetValidator(extWallet.validatorState->m_validator_address);
     if(!validator) {
       throw JSONRPCError(RPC_INVALID_PARAMETER, "Not a validator.");
+    }
+
+    switch (extWallet.GetFinalizerPhase(*state)) {
+      case esperanza::ValidatorState::Phase::NOT_VALIDATING:
+        throw JSONRPCError(RPC_VERIFY_ERROR, "Deposit wasn't created. Can't withdraw.");
+      case esperanza::ValidatorState::Phase::WAITING_DEPOSIT_CONFIRMATION:
+        throw JSONRPCError(RPC_VERIFY_ERROR, "Deposit is not confirmed. Can't withdraw.");
+      case esperanza::ValidatorState::Phase::WAITING_DEPOSIT_FINALIZATION:
+        throw JSONRPCError(RPC_VERIFY_ERROR, "Deposit is not finalized. Can't withdraw.");
+      case esperanza::ValidatorState::Phase::IS_VALIDATING:
+        if (validator->m_end_dynasty == esperanza::DEFAULT_END_DYNASTY) {
+          throw JSONRPCError(RPC_VERIFY_ERROR, "The node is validating, logout first.");
+        } else {
+          throw JSONRPCError(RPC_VERIFY_ERROR, "Logout delay hasn't passed yet. Can't withdraw.");
+        }
+      case esperanza::ValidatorState::Phase::WAITING_FOR_WITHDRAW_DELAY:
+        throw JSONRPCError(RPC_VERIFY_ERROR, "Withdraw delay hasn't passed yet. Can't withdraw.");
+      case esperanza::ValidatorState::Phase::WAITING_TO_WITHDRAW:
+        break;
     }
 
     last_tx_hash = validator->m_last_transaction_hash;
@@ -188,14 +207,12 @@ UniValue logout(const JSONRPCRequest& request) {
 
     const esperanza::Validator *validator = state->GetValidator(extWallet.validatorState->m_validator_address);
     if (!validator) {
-      throw JSONRPCError(RPC_INVALID_PARAMETER, "Not a validator.");
+      throw JSONRPCError(RPC_VERIFY_ERROR, "Not a validator.");
     }
-  }
 
-  if (extWallet.validatorState->m_phase !=
-      +esperanza::ValidatorState::Phase::IS_VALIDATING) {
-    throw JSONRPCError(RPC_INVALID_PARAMETER,
-                       "The node is not validating.");
+    if (!state->IsFinalizerVoting(*validator)) {
+      throw JSONRPCError(RPC_INVALID_PARAMETER, "The node is not validating.");
+    }
   }
 
   CWalletTx tx;
@@ -237,11 +254,17 @@ UniValue getvalidatorinfo(const JSONRPCRequest &request){
     throw JSONRPCError(RPC_INVALID_REQUEST, "The node must be a validator.");
   }
 
-  esperanza::ValidatorState &validator = extWallet.validatorState.get();
+  LOCK2(cs_main, pwallet->cs_wallet);
+
+  LOCK(GetComponent<finalization::StateRepository>()->GetLock());
+  const finalization::FinalizationState *fin_state =
+      GetComponent<finalization::StateRepository>()->GetTipState();
+  assert(fin_state != nullptr);
+
   UniValue obj(UniValue::VOBJ);
 
   obj.pushKV("enabled", gArgs.GetBoolArg("-validating", true));
-  obj.pushKV("validator_status", validator.m_phase._to_string());
+  obj.pushKV("validator_status", extWallet.GetFinalizerPhase(*fin_state)._to_string());
 
   return obj;
 }

--- a/src/wallet/rpcvalidator.cpp
+++ b/src/wallet/rpcvalidator.cpp
@@ -207,11 +207,11 @@ UniValue logout(const JSONRPCRequest& request) {
 
     const esperanza::Validator *validator = state->GetValidator(extWallet.validatorState->m_validator_address);
     if (!validator) {
-      throw JSONRPCError(RPC_VERIFY_ERROR, "Not a validator.");
+      throw JSONRPCError(RPC_INVALID_REQUEST, "Not a validator.");
     }
 
     if (!state->IsFinalizerVoting(*validator)) {
-      throw JSONRPCError(RPC_INVALID_PARAMETER, "The node is not validating.");
+      throw JSONRPCError(RPC_VERIFY_ERROR, "The node is not validating.");
     }
   }
 

--- a/test/functional/esperanza_deposit.py
+++ b/test/functional/esperanza_deposit.py
@@ -186,7 +186,7 @@ def test_deposit_too_small(finalizer):
 # Deposit again
 def test_duplicate_deposit(finalizer):
     payto = finalizer.getnewaddress("", "legacy")
-    assert_raises_rpc_error(-32600, "The node is already a finalizer.", finalizer.deposit, payto, 1500)
+    assert_raises_rpc_error(-25, "Cannot re-deposit while validating. Withdraw first.", finalizer.deposit, payto, 1500)
 
 
 if __name__ == '__main__':

--- a/test/functional/esperanza_logout.py
+++ b/test/functional/esperanza_logout.py
@@ -146,7 +146,7 @@ class EsperanzaLogoutTest(UnitETestFramework):
         connect_nodes(finalizer1, proposer.index)
         sync_blocks([finalizer1, proposer], timeout=10)
         assert_equal(finalizer1.getvalidatorinfo()['validator_status'], 'WAITING_FOR_WITHDRAW_DELAY')
-        assert_raises_rpc_error(-8, 'The node is not validating.', finalizer1.logout)
+        assert_raises_rpc_error(-25, 'The node is not validating.', finalizer1.logout)
 
         # Check that we manage to finalize even with one finalizer
         self.wait_for_vote_and_disconnect(finalizer=finalizer2, node=proposer)

--- a/test/functional/finalization_deposit_reorg.py
+++ b/test/functional/finalization_deposit_reorg.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Unit-e developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import UnitETestFramework
+from test_framework.util import (
+    connect_nodes,
+    sync_blocks,
+    assert_equal,
+    disconnect_nodes,
+    wait_until,
+)
+import os
+
+ESPERANZA_CONFIG = '-esperanzaconfig={"epochLength": 10}'
+
+
+class EsperanzaDepositReorgTest(UnitETestFramework):
+    def set_test_params(self):
+        self.num_nodes = 4
+
+        self.extra_args = [
+            [ESPERANZA_CONFIG],
+            [ESPERANZA_CONFIG],
+            [ESPERANZA_CONFIG],
+            [ESPERANZA_CONFIG, '-validating=1'],
+        ]
+        self.setup_clean_chain = True
+
+    def setup_network(self):
+        # topology:
+        # node[0] -> node[1]
+        #         -> node[2]
+        #         -> node[3]
+        self.setup_nodes()
+        connect_nodes(self.nodes[0], self.nodes[1].index)
+        connect_nodes(self.nodes[0], self.nodes[2].index)
+        connect_nodes(self.nodes[0], self.nodes[3].index)
+
+    def run_test(self):
+        node0 = self.nodes[0]
+        node1 = self.nodes[1]
+        node2 = self.nodes[2]
+        finalizer = self.nodes[3]
+
+        self.setup_stake_coins(node0, node1)
+
+        # leave IBD
+        # e0 - e1[1] node1, node2, node3, finalizer
+        node0.generatetoaddress(1, node0.getnewaddress('', 'bech32'))
+        assert_equal(node0.getblockcount(), 1)
+        sync_blocks([node0, node1, finalizer], timeout=10)
+        assert_equal(finalizer.getvalidatorinfo()['validator_status'], 'NOT_VALIDATING')
+        self.log.info('started epoch=1')
+
+        # disconnect node1 to be able to revert finalizer's and node2's UTXOs later
+        # e0 - e1[1] node0, node2, finalizer
+        #         |
+        #         - node1
+        disconnect_nodes(node0, node1.index)
+
+        # transfer amount to node2 which will be used to create an UTXO for finalizer
+        #            t1
+        # e0 - e1[1, 2] node0, node2, finalizer
+        #         |
+        #         - node1
+        a1 = node2.getnewaddress('', 'bech32')
+        t1 = node0.sendtoaddress(a1, 5000)
+        assert t1 in node0.getrawmempool()
+        node0.generatetoaddress(1, node0.getnewaddress('', 'bech32'))
+        assert_equal(node0.getblockcount(), 2)
+        sync_blocks([node0, node2, finalizer], timeout=10)
+        assert_equal(node2.getbalance(), 5000)
+        self.log.info('created UTXO for node2')
+
+        # receive amount for deposit
+        #            t1 t2
+        # e0 - e1[1, 2, 3] node0, node2, finalizer
+        #         |
+        #         - node1
+        a2 = finalizer.getnewaddress('', 'bech32')
+        t2 = node2.sendtoaddress(a2, 2000)
+        assert t2 in node2.getrawmempool()
+        wait_until(lambda: t2 in node0.getrawmempool(), timeout=150)
+        node0.generatetoaddress(1, node0.getnewaddress('', 'bech32'))
+        sync_blocks([node0, node2, finalizer], timeout=10)
+        assert_equal(node0.getblockcount(), 3)
+        assert_equal(finalizer.getbalance(), 2000)
+        assert_equal(finalizer.getvalidatorinfo()['validator_status'], 'NOT_VALIDATING')
+        self.log.info('created UTXO for finalizer1')
+
+        # disconnect node2 to be able to revert deposit
+        #            t1 t2
+        # e0 - e1[1, 2, 3] node0, finalizer
+        #         |     |
+        #         |     - node2
+        #         - node1
+        disconnect_nodes(node0, node2.index)
+
+        # create deposit
+        #            t1 t2 d1
+        # e0 - e1[1, 2, 3, 4] node0, finalizer
+        #         |     |
+        #         |     - node2
+        #         - node1
+        a3 = finalizer.getnewaddress('', 'legacy')
+        d1 = finalizer.deposit(a3, 1500)
+        wait_until(lambda: d1 in node0.getrawmempool(), timeout=20)
+        assert_equal(finalizer.getvalidatorinfo()['validator_status'], 'WAITING_DEPOSIT_CONFIRMATION')
+        self.log.info('validator_status is correct after creating deposit')
+
+        node0.generatetoaddress(1, node0.getnewaddress('', 'bech32'))
+        assert_equal(node0.getblockcount(), 4)
+        sync_blocks([node0, finalizer], timeout=10)
+        assert_equal(finalizer.getvalidatorinfo()['validator_status'], 'WAITING_DEPOSIT_FINALIZATION')
+        self.log.info('validator_status is correct after mining deposit')
+
+        # revert deposit
+        #            t1 t2 d1
+        # e0 - e1[1, 2, 3, 4] node0
+        #         |     |
+        #         |     -- 4, 5] node2, finalizer
+        #         - node1
+        node2.generatetoaddress(2, node2.getnewaddress('', 'bech32'))
+        assert_equal(node2.getblockcount(), 5)
+        disconnect_nodes(node0, finalizer.index)
+        connect_nodes(node2, finalizer.index)
+        sync_blocks([node2, finalizer], timeout=10)
+        assert_equal(finalizer.getblockcount(), 5)
+
+        # we re-org'ed deposit but since the finalizer keeps
+        # its txs in mempool, status must be WAITING_DEPOSIT_CONFIRMATION
+        assert_equal(finalizer.getvalidatorinfo()['validator_status'], 'WAITING_DEPOSIT_CONFIRMATION')
+        assert_equal(finalizer.gettransaction(d1)['txid'], d1)
+
+        assert d1 in finalizer.resendwallettransactions()
+        wait_until(lambda: d1 in finalizer.getrawmempool(), timeout=10)
+        wait_until(lambda: d1 in node2.getrawmempool(), timeout=10)
+        disconnect_nodes(node2, finalizer.index)
+        self.log.info('validator_status is correct after reverting deposit')
+
+        # revert UTXOs that lead to deposit
+        #            t1 t2 d1
+        # e0 - e1[1, 2, 3, 4] node0
+        #         |     |
+        #         |     -- 4, 5] node2
+        #         -- 2, 3, 4, 5, 6] node1, finalizer
+        node1.generatetoaddress(5, node1.getnewaddress('', 'bech32'))
+        assert_equal(node1.getblockcount(), 6)
+        connect_nodes(node1, finalizer.index)
+        sync_blocks([node1, finalizer], timeout=10)
+        assert_equal(finalizer.getblockcount(), 6)
+
+        # we re-org'ed all txs but since they are in mempool
+        # validator_status shouldn't change
+        wait_until(lambda: d1 in finalizer.getrawmempool(), timeout=10)
+        wait_until(lambda: t2 in finalizer.getrawmempool(), timeout=10)
+        wait_until(lambda: t1 in finalizer.getrawmempool(), timeout=10)
+        assert_equal(finalizer.getvalidatorinfo()['validator_status'], 'WAITING_DEPOSIT_CONFIRMATION')
+        self.log.info('validator_status is correct after reverting all txs that led to deposit')
+
+        # remove mempool.dat to simulate tx eviction
+        # this keeps the same phase as wallet knows about its transactions
+        # and expects to resend them once evicted txs are in the block
+        self.stop_node(finalizer.index)
+        os.remove(os.path.join(finalizer.datadir, "regtest", "mempool.dat"))
+        self.start_node(finalizer.index, [ESPERANZA_CONFIG, '-validating=1'])
+        wait_until(lambda: finalizer.getblockcount(), timeout=10)
+        assert_equal(len(finalizer.getrawmempool()), 0)
+        assert_equal(finalizer.getvalidatorinfo()['validator_status'], 'WAITING_DEPOSIT_CONFIRMATION')
+        self.log.info('validator_status is correct after removing mempool.dat')
+
+        # add missing UTXOs and deposit to the node1 fork
+        #            t1 t2 d1
+        # e0 - e1[1, 2, 3, 4] node0
+        #         |     |
+        #         |     -- 4, 5] node2
+        #         |                 t1 t2 d1
+        #         -- 2, 3, 4, 5, 6, 7       ] node1, finalizer
+        assert_equal(node1.sendrawtransaction(node0.getrawtransaction(t1)), t1)
+        assert_equal(node1.sendrawtransaction(node0.getrawtransaction(t2)), t2)
+        assert_equal(node1.sendrawtransaction(node0.getrawtransaction(d1)), d1)
+        node1.generatetoaddress(1, node1.getnewaddress('', 'bech32'))
+        connect_nodes(node1, finalizer.index)
+        sync_blocks([node1, finalizer], timeout=10)
+        assert_equal(finalizer.getvalidatorinfo()['validator_status'], 'WAITING_DEPOSIT_FINALIZATION')
+        disconnect_nodes(node1, finalizer.index)
+        self.log.info('validator_status is correct after re-mining txs on a different fork')
+
+        # finalize deposit and re-org to that fork
+        #            t1 t2 d1
+        # e0 - e1[1, 2, 3, 4, ...           ] - ... - e5[51] node0, finalizer
+        #         |     |
+        #         |     -- 4, 5] node2
+        #         |                 t1 t2 d1
+        #         -- 2, 3, 4, 5, 6, 7       ] node1
+        node0.generatetoaddress(6, node0.getnewaddress('', 'bech32'))
+        assert_equal(node0.getblockcount(), 10)
+        assert_equal(node0.getfinalizationstate()['currentDynasty'], 0)
+        for _ in range(4):
+            node0.generatetoaddress(10, node0.getnewaddress('', 'bech32'))
+        assert_equal(node0.getblockcount(), 50)
+        assert_equal(node0.getfinalizationstate()['currentDynasty'], 2)
+
+        connect_nodes(node0, finalizer.index)
+        sync_blocks([node0, finalizer], timeout=60)
+        assert_equal(finalizer.getvalidatorinfo()['validator_status'], 'WAITING_DEPOSIT_FINALIZATION')
+
+        node0.generatetoaddress(1, node0.getnewaddress('', 'bech32'))
+        assert_equal(node0.getfinalizationstate()['currentDynasty'], 3)
+        sync_blocks([node0, finalizer], timeout=10)
+        assert_equal(finalizer.getvalidatorinfo()['validator_status'], 'IS_VALIDATING')
+        self.log.info('validator_status is correct after re-organizing to the fork of finalized deposit')
+
+
+if __name__ == '__main__':
+    EsperanzaDepositReorgTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -94,7 +94,7 @@ BASE_SCRIPTS= [
     'esperanza_slash.py',
     'feature_segwit.py',
     'esperanza_withdraw.py',
-    'finalization_deposit_reorg.py'
+    'finalization_deposit_reorg.py',
     'feature_fork_choice_forked_finalize_epoch.py',
     'p2p_snapshot.py',
     'proposer_settings.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -94,6 +94,7 @@ BASE_SCRIPTS= [
     'esperanza_slash.py',
     'feature_segwit.py',
     'esperanza_withdraw.py',
+    'finalization_deposit_reorg.py'
     'feature_fork_choice_forked_finalize_epoch.py',
     'p2p_snapshot.py',
     'proposer_settings.py',


### PR DESCRIPTION
WIP: Opened to get early feedback

This commit fixes the issue with deposits during re-orgs.
Reference to the issue: https://github.com/dtr-org/unit-e/issues/972

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>