### PR TITLE
Remove unused variables/code

### DIFF
--- a/src/injector.h
+++ b/src/injector.h
@@ -116,7 +116,6 @@ class UnitEInjector : public Injector<UnitEInjector> {
   COMPONENT(MultiWallet, proposer::MultiWallet, proposer::MultiWallet::New)
 
   COMPONENT(BlockBuilder, proposer::BlockBuilder, proposer::BlockBuilder::New,
-            blockchain::Behavior,
             Settings)
 
   COMPONENT(ProposerRPC, proposer::ProposerRPC, proposer::ProposerRPC::New,

--- a/src/proposer/block_builder.cpp
+++ b/src/proposer/block_builder.cpp
@@ -17,7 +17,6 @@ namespace proposer {
 
 class BlockBuilderImpl : public BlockBuilder {
  private:
-  const Dependency<blockchain::Behavior> m_blockchain_behavior;
   const Dependency<Settings> m_settings;
 
   std::vector<CAmount> SplitAmount(const CAmount amount, const CAmount threshold) const {
@@ -64,10 +63,8 @@ class BlockBuilderImpl : public BlockBuilder {
 
  public:
   explicit BlockBuilderImpl(
-      Dependency<blockchain::Behavior> blockchain_behavior,
       Dependency<Settings> settings)
-      : m_blockchain_behavior(blockchain_behavior),
-        m_settings(settings) {}
+      : m_settings(settings) {}
 
   const CTransactionRef BuildCoinbaseTransaction(
       const uint256 &snapshot_hash,
@@ -189,10 +186,8 @@ class BlockBuilderImpl : public BlockBuilder {
   }
 };
 
-std::unique_ptr<BlockBuilder> BlockBuilder::New(
-    const Dependency<blockchain::Behavior> blockchain_behavior,
-    const Dependency<Settings> settings) {
-  return std::unique_ptr<BlockBuilder>(new BlockBuilderImpl(blockchain_behavior, settings));
+std::unique_ptr<BlockBuilder> BlockBuilder::New(const Dependency<Settings> settings) {
+  return std::unique_ptr<BlockBuilder>(new BlockBuilderImpl(settings));
 }
 
 }  // namespace proposer

--- a/src/proposer/block_builder.h
+++ b/src/proposer/block_builder.h
@@ -44,9 +44,7 @@ class BlockBuilder {
 
   virtual ~BlockBuilder() = default;
 
-  static std::unique_ptr<BlockBuilder> New(
-      Dependency<blockchain::Behavior>,
-      Dependency<Settings>);
+  static std::unique_ptr<BlockBuilder> New(Dependency<Settings>);
 };
 
 }  // namespace proposer

--- a/src/staking/legacy_validation_interface.cpp
+++ b/src/staking/legacy_validation_interface.cpp
@@ -204,63 +204,6 @@ class LegacyValidationImpl : public LegacyValidationInterface {
   }
 };
 
-class BlockValidatorAdapter : public LegacyValidationInterface {
- private:
-  const Dependency<ActiveChain> m_active_chain;
-  const Dependency<BlockValidator> m_block_validator;
-  const Dependency<StakeValidator> m_stake_validator;
-
- public:
-  BlockValidatorAdapter(
-      const Dependency<ActiveChain> active_chain,
-      const Dependency<BlockValidator> block_validator,
-      const Dependency<StakeValidator> stake_validator) : m_active_chain(active_chain),
-                                                          m_block_validator(block_validator),
-                                                          m_stake_validator(stake_validator) {}
-
-  bool CheckBlockHeader(
-      const CBlockHeader &block,
-      CValidationState &validation_state,
-      const Consensus::Params &consensus_params,
-      bool check_proof_of_work) override {
-    return false;
-  }
-
-  bool CheckBlock(
-      const CBlock &block,
-      CValidationState &validation_state,
-      const Consensus::Params &consensus_params,
-      bool check_proof_of_work,
-      bool check_merkle_root) override {
-    return false;
-  }
-
-  bool ContextualCheckBlock(
-      const CBlock &block,
-      CValidationState &validation_state,
-      const Consensus::Params &consensus_params,
-      const CBlockIndex *prev_block) override {
-    return false;
-  };
-
-  bool ContextualCheckBlockHeader(
-      const CBlockHeader &block,
-      CValidationState &validation_state,
-      const CChainParams &chainparams,
-      const CBlockIndex *prev_block,
-      std::int64_t adjusted_time) override {
-    return false;
-  };
-};
-
-std::unique_ptr<LegacyValidationInterface> LegacyValidationInterface::New(
-    const Dependency<ActiveChain> active_chain,
-    const Dependency<BlockValidator> block_validator,
-    const Dependency<StakeValidator> stake_validator) {
-  return std::unique_ptr<LegacyValidationInterface>(new BlockValidatorAdapter(
-      active_chain, block_validator, stake_validator));
-}
-
 std::unique_ptr<LegacyValidationInterface> LegacyValidationInterface::LegacyImpl(
     const Dependency<ActiveChain> active_chain,
     const Dependency<BlockValidator> block_validator,

--- a/src/test/esperanza/walletextension_tests.cpp
+++ b/src/test/esperanza/walletextension_tests.cpp
@@ -80,8 +80,7 @@ BOOST_FIXTURE_TEST_CASE(sign_coinbase_transaction, WalletTestingSetup) {
   const auto pubkey = key.GetPubKey();
   const auto pubkeydata = std::vector<unsigned char>(pubkey.begin(), pubkey.end());
 
-  auto behavior = blockchain::Behavior::NewFromParameters(blockchain::Parameters::TestNet());
-  auto block_builder = proposer::BlockBuilder::New(behavior.get(), &settings);
+  auto block_builder = proposer::BlockBuilder::New(&settings);
 
   {
     LOCK(pwalletMain->cs_wallet);

--- a/src/test/proposer/block_builder_tests.cpp
+++ b/src/test/proposer/block_builder_tests.cpp
@@ -84,9 +84,7 @@ struct Fixture {
   }
 
   std::unique_ptr<proposer::BlockBuilder> MakeBlockBuilder() {
-    return proposer::BlockBuilder::New(
-        behavior.get(),
-        settings.get());
+    return proposer::BlockBuilder::New(settings.get());
   }
 };
 

--- a/src/test/test_unite_mocks.h
+++ b/src/test/test_unite_mocks.h
@@ -424,7 +424,7 @@ class BlockValidatorMock : public staking::BlockValidator {
     ++invocations_ContextualCheckBlockHeader;
     return stub_ContextualCheckBlockHeader(block_header, block_index, time, info);
   }
-  BlockValidationResult CheckCoinbaseTransaction(const CTransaction &coinbase_tx) {
+  BlockValidationResult CheckCoinbaseTransaction(const CTransaction &coinbase_tx) const override {
     ++invocations_CheckCoinbaseTransaction;
     return stub_CheckCoinbaseTransaction(coinbase_tx);
   }

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -49,8 +49,5 @@ struct TestChain100Setup : public WalletTestingSetup {
 
   std::vector<CTransaction> coinbaseTxns; // For convenience, coinbase transactions
   CKey coinbaseKey; // private/public key needed to spend coinbase transactions
-
- private:
-  std::uint32_t count = 0;
 };
 #endif


### PR DESCRIPTION
Removes unused variables.

Fixes some compiler warnings about unused variables and about a function which lacked `const override` in mocks.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
