### PR TITLE
Fix near-zero decode rate in graphene

### DIFF
--- a/src/bloom.h
+++ b/src/bloom.h
@@ -80,7 +80,7 @@ public:
         READWRITE(nHashFuncs);
         READWRITE(nTweak);
         READWRITE(nFlags);
-        
+
         if (ser_action.ForRead()) {
             UpdateEmptyFull();
         }

--- a/test/functional/feature_graphene_passive.py
+++ b/test/functional/feature_graphene_passive.py
@@ -67,9 +67,9 @@ class Graphene(UnitETestFramework):
         relay.allow((b'block', block_hash))
         sync_blocks([self.nodes[0], self.nodes[1]])
 
+        self.test_orphans(relay)
         self.test_synced_mempool(relay)
         self.test_non_synced_mempool(relay)
-        self.test_orphans(relay)
 
     def test_synced_mempool(self, relay):
         self.log.info("Testing synced mempool scenario")
@@ -146,11 +146,14 @@ class Graphene(UnitETestFramework):
 
         # This value was picked by trial and error. If some parameters of
         # this test change - you might need to readjust it
+        txs = []
         for _ in range(60):
             tx = self.nodes[0].sendtoaddress(address, 1)
             relay.allow((b'tx', tx))
+            txs.append(tx)
 
-        sync_mempools([self.nodes[0], self.nodes[1]])
+        for tx in txs:
+            self.wait_for_transaction(tx)
 
     def assert_graphene_txs(self, graphene_tx: GrapheneTx, expected_hashes: []):
         assert_equal(len(expected_hashes), len(graphene_tx.txs))


### PR DESCRIPTION
Currently we have near-zero decode rate in graphene. Here is what happening:
When deserializing graphene block:
1) Bloom filter is default constructed. And it sets `isFull = true`. This is correct. Empty bloom filter - is full
2) Bloom filter is deserialized, it is not empty anymore, but `isFull` flag is still true
3) Bloom filter with this flag returns true for all `contains` requests => graphene is ruined

This was not caught by tests because In functional tests we had nodes with very similar mempools. Somewhat different mempools were tested only in unit tests. And this serialization issue occurs only in functional tests

This PR fixes one more thing:
In the original PR I accidentally commented out some parts of functional tests. I am restoring them


Signed-off-by: Aleksandr Mikhailov <aleksandr@thirdhash.com>