### PR TITLE
Change message in case of DoS for sending an header on an invalid fork

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3316,8 +3316,8 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
             assert(most_common_index != nullptr);
             if (fin_state->GetEpoch(most_common_index->nHeight) < fin_state->GetLastFinalizedEpoch()) {
                 return state.DoS(10,
-                                 error("%s: %s came from previous dynasty", __func__, hash.ToString()),
-                                 REJECT_INVALID, "bad-fork-dynasty");
+                                 error("%s: %s came from a different fork, forking before the last finalized epoch.", __func__, hash.ToString()),
+                                 REJECT_INVALID, "bad-fork-before-last-finalized-epoch");
             }
         }
     }

--- a/test/functional/feature_fork_choice_parallel_justifications.py
+++ b/test/functional/feature_fork_choice_parallel_justifications.py
@@ -352,7 +352,7 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
         attacker.send_message(msg_witness_block(block))
 
         # node should't re-org to malicious fork
-        wait_for_reject(attacker, b'bad-fork-dynasty', block.sha256)
+        wait_for_reject(attacker, b'bad-fork-before-last-finalized-epoch', block.sha256)
         assert_equal(node.getblockcount(), 57)
         assert_equal(node.getblockhash(57), tip)
         assert_finalizationstate(node, {'currentDynasty': 5,


### PR DESCRIPTION
After reading the current message in the logs I found it not describing well enough the reason for the DoS. I suggest here a new description that is imho clearer.