### PR TITLE
Mute false errors during full sync

### DIFF
--- a/src/esperanza/finalizationstate.h
+++ b/src/esperanza/finalizationstate.h
@@ -88,7 +88,7 @@ class FinalizationState : public FinalizationStateData {
   //! \brief Validates the vote of the deposit against the current state.
   //!
   //! This does assume that the normal transaction validation process already took place.
-  Result ValidateVote(const Vote &vote) const;
+  Result ValidateVote(const Vote &vote, bool log_errors = true) const;
 
   //! Performs a vote using the given vote input.
   void ProcessVote(const Vote &vote);
@@ -116,7 +116,7 @@ class FinalizationState : public FinalizationStateData {
 
   //! \brief Checks whether two distinct votes from the same voter are proven being a
   //! slashable misbehaviour.
-  Result IsSlashable(const Vote &vote1, const Vote &vote2) const;
+  Result IsSlashable(const Vote &vote1, const Vote &vote2, bool log_errors = true) const;
 
   //! Given two votes, performs a slash against the validator who casted them.
   void ProcessSlash(const Vote &vote1, const Vote &vote2);
@@ -206,7 +206,8 @@ class FinalizationState : public FinalizationStateData {
 
   //! Checks if the validator can create a valid vote with the given parameters.
   Result IsVotable(const Validator &validator, const uint256 &targetHash,
-                   uint32_t targetEpoch, uint32_t sourceEpoch) const;
+                   uint32_t targetEpoch, uint32_t sourceEpoch,
+                   bool log_errors) const;
 
   bool IsInDynasty(const Validator &validator, uint32_t dynasty) const;
   CAmount ProcessReward(const uint160 &validatorAddress, uint64_t reward);

--- a/src/finalization/vote_recorder.h
+++ b/src/finalization/vote_recorder.h
@@ -77,7 +77,8 @@ class VoteRecorder : private boost::noncopyable {
  public:
   void RecordVote(const esperanza::Vote &vote,
                   const std::vector<unsigned char> &voteSig,
-                  const FinalizationState &fin_state);
+                  const FinalizationState &fin_state,
+                  bool log_errors = true);
 
   boost::optional<VoteRecord> GetVote(const uint160 &validatorAddress,
                                       uint32_t epoch) const;
@@ -94,7 +95,8 @@ class VoteRecorder : private boost::noncopyable {
 //!           and slashable condition. It must be best known finalization state on a moment.
 bool RecordVote(const CTransaction &tx,
                 CValidationState &err_state,
-                const FinalizationState &fin_state);
+                const FinalizationState &fin_state,
+                bool log_errors = true);
 
 }  // namespace finalization
 

--- a/src/p2p/finalizer_commits_handler_impl.cpp
+++ b/src/p2p/finalizer_commits_handler_impl.cpp
@@ -358,7 +358,7 @@ bool FinalizerCommitsHandlerImpl::OnCommits(
 
       for (const auto &c : d.commits) {
         if (c->IsVote()) {
-          if (!finalization::RecordVote(*c, err_state, *fin_state)) {
+          if (!finalization::RecordVote(*c, err_state, *fin_state, /*log_errors=*/false)) {
             return false;
           }
         }

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -534,7 +534,7 @@ BOOST_AUTO_TEST_CASE(script_build)
     tests.push_back(TestBuilder(CScript() << ToByteVector(keys.pubkey0C) << OP_CHECKSIG,
                                 "P2SH(P2PK), bad redeemscript", SCRIPT_VERIFY_P2SH, true
                                ).PushSig(keys.key0).PushRedeem().DamagePush(10).ScriptError(SCRIPT_ERR_EVAL_FALSE));
-    
+
     tests.push_back(TestBuilder(CScript() << OP_DUP << OP_HASH160 << ToByteVector(keys.pubkey0.GetID()) << OP_EQUALVERIFY << OP_CHECKSIG,
                                 "P2SH(P2PKH)", SCRIPT_VERIFY_P2SH, true
                                ).PushSig(keys.key0).Push(keys.pubkey0).PushRedeem());
@@ -1968,7 +1968,7 @@ BOOST_AUTO_TEST_CASE(verify_slash_script)
 {
   CKey key;
   key.MakeNewKey(true);
-  ScriptError *s_error;
+  ScriptError *s_error = nullptr;
 
   CMutableTransaction txn;
   txn.SetType(TxType::SLASH);


### PR DESCRIPTION
When full sync, commits are usually far ahead of the current active chain tip, but at the
same time, vote recorder records votes against the current active chain tip which leads to
false positive error messages in the log.

Note: avoiding of these messages could be reached by passing CBlockIndex->pprev finalization
state to VoteRecorder instead of the active chain's tip one. But we're still debating on this
topic because beside logging this change would have a security impact. Muting false errors is
a compromise we can use unless we decide the good strategy for finalization state picking.

Fixes #988.
