### PR TITLE
Remove duplicate vote validation during vote processing

### DIFF
--- a/src/esperanza/checks.cpp
+++ b/src/esperanza/checks.cpp
@@ -6,6 +6,7 @@
 #include <esperanza/adminparams.h>
 #include <esperanza/checks.h>
 #include <esperanza/finalizationstate.h>
+#include <finalization/vote_recorder.h>
 #include <script/interpreter.h>
 #include <script/sign.h>
 #include <script/standard.h>
@@ -350,6 +351,11 @@ bool ContextualCheckVoteTx(const CTransaction &tx, CValidationState &err_state,
   }
 
   const Result res = fin_state.ValidateVote(vote);
+  if (res != +esperanza::Result::ADMIN_BLACKLISTED &&
+      res != +esperanza::Result::VOTE_NOT_BY_VALIDATOR) {
+    finalization::VoteRecorder::GetVoteRecorder()->RecordVote(vote, vote_sig, fin_state);
+  }
+
   switch (+res) {
     case Result::SUCCESS:
       break;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -590,18 +590,10 @@ static BCLog::LogFlags GetTransactionLogCategory(const CTransaction &tx) {
 
 static bool ContextualCheckFinalizerCommit(const CTransaction &tx, CValidationState &err_state,
                                            const esperanza::FinalizationState &fin_state,
-                                           const esperanza::FinalizationState &tip_fin_state,
                                            const CCoinsView &view) {
     const auto log_cat = GetTransactionLogCategory(tx);
     LogPrint(log_cat, "Checking %s with id %s\n", tx.GetType()._to_string(), tx.GetHash().GetHex());
-    if (tx.IsVote()) {
-        if (!esperanza::CheckVoteTx(tx, err_state, /*vote_out=*/nullptr, /*vote_sig_out=*/nullptr)) {
-            return false;
-        }
-        if (!finalization::RecordVote(tx, err_state, tip_fin_state)) {
-            return false;
-        }
-    }
+
     if (!esperanza::ContextualCheckFinalizerCommit(tx, err_state, fin_state, view)) {
         LogPrint(log_cat, "ERROR: %s (%s) check failed: %s\n", tx.GetType()._to_string(), tx.GetHash().GetHex(),
                  err_state.GetRejectReason());
@@ -613,11 +605,10 @@ static bool ContextualCheckFinalizerCommit(const CTransaction &tx, CValidationSt
 static bool ContextualCheckBlockFinalizerCommits(const CBlock &block,
                                                  CValidationState &err_state,
                                                  const esperanza::FinalizationState &fin_state,
-                                                 const esperanza::FinalizationState &tip_fin_state,
                                                  const CCoinsView &view) {
     for (const auto &tx : block.vtx) {
         if (tx->IsFinalizerCommit()) {
-            if (!::ContextualCheckFinalizerCommit(*tx, err_state, fin_state, tip_fin_state, view)) {
+            if (!::ContextualCheckFinalizerCommit(*tx, err_state, fin_state, view)) {
                 return false;
             }
         }
@@ -685,7 +676,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
       GetComponent<finalization::StateRepository>()->GetTipState();
     assert(fin_state != nullptr);
     if (tx.IsFinalizerCommit() &&
-        !::ContextualCheckFinalizerCommit(tx, state, *fin_state, *fin_state, view)) {
+        !::ContextualCheckFinalizerCommit(tx, state, *fin_state, view)) {
         return false; // state already filled by ContextualCheckFinalizerTx
     }
 
@@ -2092,7 +2083,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         if (!isGenesisBlock &&
             has_finalization_tx &&
             !ContextualCheckBlockFinalizerCommits(
-                block,state, *fin_state, *tip_fin_state, view)) {
+                block, state, *fin_state, view)) {
             return false;
         }
     }


### PR DESCRIPTION
While reviewing logs on a testnet noticed that we have duplicate records, e.g:
```
2019-04-16 14:32:14 [finalization] ValidateVote: valid. validator=a7f4737d9a64c37a721fff3d360a537d0f51686d target=b67ca892128e553c627c86ee7ee5645e7eec09776beed18f5ab104bf83653dfc source_epoch=18 target_epoch=19
2019-04-16 14:32:14 [finalization] ValidateVote: valid. validator=a7f4737d9a64c37a721fff3d360a537d0f51686d target=b67ca892128e553c627c86ee7ee5645e7eec09776beed18f5ab104bf83653dfc source_epoch=18 target_epoch=19
```

All these duplicate records generate a redundant noise. And it happens because
`finalization::RecordVote` and `esperanza::ContextualCheckVoteTx`both  use
the same `FinalizationState::ValidateVote` function.

The solution is to invoke low-level function `VoteRecorder::RecordVote`
instead of `finalization::RecordVote` from `esperanza::ContextualCheckVoteTx`
which already does the necessary validation.

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>