### PR TITLE
Stop node from using P2PKH outputs for staking

### DIFF
--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -299,9 +299,7 @@ bool IsStakeableByMe(const CKeyStore &keystore, const CScript &script_pub_key)
     IsMineInfo is_mine_info;
     const isminetype is_mine = IsMine(keystore, script_pub_key, &is_mine_info);
 
-    // UNIT-E TODO: Restrict to witness programs only once #212 is merged (fixes #48)
     switch (is_mine_info.type) {
-        case TX_PUBKEYHASH:
         case TX_WITNESS_V0_KEYHASH: {
             if (is_mine != ISMINE_SPENDABLE) {
                 // Non-remote-staking scripts can be used as stake only if they

--- a/src/test/esperanza/walletextension_tests.cpp
+++ b/src/test/esperanza/walletextension_tests.cpp
@@ -291,7 +291,7 @@ BOOST_FIXTURE_TEST_CASE(get_stakeable_coins, TestChain100Setup) {
   }
 
   // Make the first coinbase mature
-  CScript coinbase_script = GetScriptForDestination(coinbaseKey.GetPubKey().GetID());
+  CScript coinbase_script = GetScriptForDestination(WitnessV0KeyHash(coinbaseKey.GetPubKey().GetID()));
   CreateAndProcessBlock({}, coinbase_script);
 
   CTransaction &stakeable = coinbaseTxns.front();

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -495,7 +495,7 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         keystore.AddKey(keys[0]);
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
-        BOOST_CHECK(IsStakeableByMe(keystore, scriptPubKey));
+        BOOST_CHECK(!IsStakeableByMe(keystore, scriptPubKey));
     }
 
     // P2PKH uncompressed

--- a/test/functional/esperanza_vote_reorg.py
+++ b/test/functional/esperanza_vote_reorg.py
@@ -202,7 +202,7 @@ class EsperanzaVoteReorgTest(UnitETestFramework):
                                          'lastFinalizedEpoch': 4,
                                          'validators': 2})
 
-        fork1.generatetoaddress(3, fork1.getnewaddress())
+        fork1.generatetoaddress(3, fork1.getnewaddress("", "bech32"))
         assert_equal(fork1.getblockcount(), 46)
         self.wait_for_vote_and_disconnect(finalizer=finalizer2, node=fork1)
         fork1.generatetoaddress(1, fork1.getnewaddress('', 'bech32'))

--- a/test/functional/proposer_balance.py
+++ b/test/functional/proposer_balance.py
@@ -156,7 +156,7 @@ class ProposerBalanceTest(UnitETestFramework):
     @staticmethod
     def generate_block(nodes, node_idx):
         try:
-            nodes[node_idx].generatetoaddress(nblocks=1, address=nodes[node_idx].getnewaddress())
+            nodes[node_idx].generatetoaddress(nblocks=1, address=nodes[node_idx].getnewaddress("", "bech32"))
             sync_blocks(nodes)
         except JSONRPCException as exp:
             print("error generating block:", exp.error)

--- a/test/functional/proposer_stakeable_balance.py
+++ b/test/functional/proposer_stakeable_balance.py
@@ -88,13 +88,7 @@ class ProposerStakeableBalanceTest(UnitETestFramework):
             assert_equal(wallet['stakeable_balance'], Decimal('0.00000000'))
 
         # Check that if we send all the money to a P2PKH address we cannot stake anymore.
-        for node in self.nodes[2:]:
-            node.stop_node(wait=0)
-
-        self.nodes = self.nodes[0:2]
-
-        # Disconnecting all nodes to stop proposal.
-        disconnect_nodes(nodes[0], nodes[1].index)
+        disconnect_all_nodes(nodes)
 
         p2pkh_tx = nodes[0].sendtoaddress(nodes[0].getnewaddress("", "legacy"), nodes[0].getbalance(), "", "", True)
 

--- a/test/functional/proposer_stakeable_balance.py
+++ b/test/functional/proposer_stakeable_balance.py
@@ -5,6 +5,7 @@
 from test_framework.util import *
 from test_framework.test_framework import UnitETestFramework
 
+
 class ProposerStakeableBalanceTest(UnitETestFramework):
 
     def set_test_params(self):
@@ -14,7 +15,7 @@ class ProposerStakeableBalanceTest(UnitETestFramework):
             '-proposing=1',
             '-minimumchainwork=0',
             '-maxtipage=1000000000'
-        ] for i in range(0, self.num_nodes))
+        ] for _ in range(0, self.num_nodes))
         self.setup_clean_chain = True
 
     def run_test(self):
@@ -85,6 +86,27 @@ class ProposerStakeableBalanceTest(UnitETestFramework):
             wallet = status['wallets'][0]
             assert_equal(wallet['balance'], Decimal('0.00000000'))
             assert_equal(wallet['stakeable_balance'], Decimal('0.00000000'))
+
+        # Check that if we send all the money to a P2PKH address we cannot stake anymore.
+        for node in self.nodes[2:]:
+            node.stop_node(wait=0)
+
+        self.nodes = self.nodes[0:2]
+
+        # Disconnecting all nodes to stop proposal.
+        disconnect_nodes(nodes[0], nodes[1].index)
+
+        p2pkh_tx = nodes[0].sendtoaddress(nodes[0].getnewaddress("", "legacy"), nodes[0].getbalance(), "", "", True)
+
+        wait_until(lambda: p2pkh_tx in nodes[0].getrawmempool())
+        connect_nodes(nodes[0], nodes[1].index)
+        sync_mempools(nodes[0:1])
+
+        wait_until(lambda: nodes[0].gettransaction(p2pkh_tx)['confirmations'] > 0, timeout=60)
+
+        assert_equal(len(nodes[0].liststakeablecoins()['stakeable_coins']), 0)
+        assert_equal(nodes[0].liststakeablecoins()['stakeable_balance'], Decimal('0.00000000'))
+        assert_equal(nodes[0].proposerstatus()['wallets'][0]['stakeable_balance'], Decimal('0.00000000'))
 
         print("Test succeeded.")
 

--- a/test/functional/rpc_filtertransactions.py
+++ b/test/functional/rpc_filtertransactions.py
@@ -100,7 +100,7 @@ class FilterTransactionsTest(UnitETestFramework):
 
         # coinbase
         sync_mempools(self.nodes)
-        self.nodes[0].generatetoaddress(1, self.nodes[0].getnewaddress())  # Clear node1's mempool
+        self.nodes[0].generatetoaddress(1, self.nodes[0].getnewaddress("", "bech32"))  # Clear node1's mempool
         sync_blocks(self.nodes)
 
         address = self.nodes[1].getnewaddress()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -567,7 +567,7 @@ class UnitETestFramework():
                 for peer in range(4):
                     for j in range(25):
                         set_node_times(self.nodes, block_time)
-                        self.nodes[peer].generate(1)
+                        self.nodes[peer].generatetoaddress(1, self.nodes[peer].getnewaddress('', 'bech32'))
                         block_time += 10 * 60
                     # Must sync before next peer starts generating blocks
                     sync_blocks(self.nodes)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -514,7 +514,7 @@ def disconnect_nodes_bi(nodes, a, b):
 def disconnect_all_nodes(nodes):
     for i in range(0, len(nodes)):
         if i+1 < len(nodes):
-            connect_nodes_bi(nodes, i, i + 1)
+            disconnect_nodes_bi(nodes, i, i + 1)
 
 def sync_blocks(rpc_connections, *, wait=1, timeout=60, height=None):
     """

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -507,6 +507,15 @@ def connect_nodes_bi(nodes, a, b):
     connect_nodes(nodes[a], b)
     connect_nodes(nodes[b], a)
 
+def disconnect_nodes_bi(nodes, a, b):
+    disconnect_nodes(nodes[a], b)
+    disconnect_nodes(nodes[b], a)
+
+def disconnect_all_nodes(nodes):
+    for i in range(0, len(nodes)):
+        if i+1 < len(nodes):
+            connect_nodes_bi(nodes, i, i + 1)
+
 def sync_blocks(rpc_connections, *, wait=1, timeout=60, height=None):
     """
     Wait until everybody has the same tip.

--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -133,7 +133,7 @@ class ImportRescanTest(UnitETestFramework):
     def run_test(self):
 
         self.setup_stake_coins(self.nodes[0])
-        self.nodes[0].generatetoaddress(200, self.nodes[0].getnewaddress())
+        self.nodes[0].generatetoaddress(200, self.nodes[0].getnewaddress("", "bech32"))
         sync_blocks(self.nodes)
 
         # Create one transaction on node 0 with a unique amount and label for


### PR DESCRIPTION
At the moment `GetStakeableCoins()` still returns P2PKH coins, that we cannot use to sign a segwit coinbase. This leads to nodes creating blocks but then discarding them because they can't sign them.

Fixes #997 