### PR TITLE
Fix log message when ExtractValidatorAddress fails

### DIFF
--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -867,7 +867,8 @@ bool WalletExtension::AddToWalletIfInvolvingMe(const CTransactionRef &ptx,
 
         if (!esperanza::ExtractValidatorAddress(tx, validatorAddress)) {
           LogPrint(BCLog::FINALIZATION,
-                   "ERROR: %s - Cannot extract validator index.\n");
+                   "ERROR: %s: Cannot extract validator index.\n",
+                   __func__);
           return false;
         }
 


### PR DESCRIPTION
Fixes the following error:
```
2019-04-17 09:17:28 [finalization] Error "tinyformat: Too many conversion specifiers in format string" while formatting log message: ERROR: %s - Cannot extract validator index.
```

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>