### PR TITLE
Change TxType type from uint16_t to uint8_t

### DIFF
--- a/src/primitives/txtype.h
+++ b/src/primitives/txtype.h
@@ -17,7 +17,7 @@
 // clang-format off
 BETTER_ENUM(
   TxType,
-  uint16_t,
+  uint8_t,
   REGULAR = 0,
   COINBASE = 1,
   DEPOSIT = 2,


### PR DESCRIPTION
**what we want to maintain**
This `TxType` type is used in `Coin` and `snapshot::UTXOSubset` and we serialize
it as `uint8_t` to reduce the disk usage as 256 types of transactions must be
more than enough for all future transactions that we might create.

**possible issue**
Since `TxType` is `uint16_t` there is a risk that we create a record
that will have a number larger than 255 and it will cause incorrect
value to be stored in the Coin or transferred via snapshot.

**proposed fix**
To make it consistent on how this field is used,
we should stick to `uint8_t` everywhere.

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>