### PR TITLE
Use RPC to vote on parallel chain

### DIFF
--- a/test/functional/feature_fork_choice_forked_finalize_epoch.py
+++ b/test/functional/feature_fork_choice_forked_finalize_epoch.py
@@ -30,17 +30,33 @@ from test_framework.regtest_mnemonics import regtest_mnemonics
 from test_framework.util import (
     connect_nodes,
     assert_finalizationstate,
+    bytes_to_hex_str,
     disconnect_nodes,
     sync_blocks,
     assert_equal,
     wait_until,
 )
+from test_framework.messages import FromHex, ToHex, CTransaction
+from test_framework.keytools import BinaryData
 import time
+
+
+def make_vote_tx(finalizer, finalizer_address, target_hash, source_epoch, target_epoch, input_tx_id):
+    vote = {
+        'validator_address': finalizer_address,
+        'target_hash': target_hash,
+        'target_epoch': target_epoch,
+        'source_epoch': source_epoch
+    }
+    vtx = finalizer.createvotetransaction(vote, input_tx_id)
+    vtx = finalizer.signrawtransaction(vtx)
+    vtx = FromHex(CTransaction(), vtx['hex'])
+    return vtx
 
 
 class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
     def set_test_params(self):
-        self.num_nodes = 8
+        self.num_nodes = 6
         self.setup_clean_chain = True
 
         esperanza_config = '-esperanzaconfig={"epochLength":5}'
@@ -48,11 +64,9 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
             ['-proposing=0', esperanza_config],
             ['-proposing=0', esperanza_config],
             ['-proposing=0', esperanza_config, '-validating=1'],
-            ['-proposing=0', esperanza_config, '-validating=1'],
 
             ['-proposing=0', esperanza_config],
             ['-proposing=0', esperanza_config],
-            ['-proposing=0', esperanza_config, '-validating=1'],
             ['-proposing=0', esperanza_config, '-validating=1'],
         ]
 
@@ -62,38 +76,30 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
     def test_fork_on_finalized_checkpoint(self):
         node = self.nodes[0]
         fork = self.nodes[1]
-
-        finalizer1 = self.nodes[2]
-        finalizer2 = self.nodes[3]
+        finalizer = self.nodes[2]
 
         self.start_node(node.index)
         self.start_node(fork.index)
-        self.start_node(finalizer1.index)
-        self.start_node(finalizer2.index)
+        self.start_node(finalizer.index)
 
-        finalizer1.importmasterkey(regtest_mnemonics[0]['mnemonics'])
-        finalizer2.importmasterkey(regtest_mnemonics[0]['mnemonics'])
+        finalizer.importmasterkey(regtest_mnemonics[0]['mnemonics'])
         node.importmasterkey(regtest_mnemonics[1]['mnemonics'])
         fork.importmasterkey(regtest_mnemonics[2]['mnemonics'])
 
         connect_nodes(node, fork.index)
-        connect_nodes(node, finalizer1.index)
-        connect_nodes(node, finalizer2.index)
+        connect_nodes(node, finalizer.index)
 
         # leave IBD
         node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
-        sync_blocks([node, fork, finalizer1])
+        sync_blocks([node, fork, finalizer])
 
         # create deposit
-        disconnect_nodes(node, finalizer2.index)
-        payto = finalizer1.getnewaddress('', 'legacy')
-        txid1 = finalizer1.deposit(payto, 1500)
-        finalizer2.setaccount(payto, '')
-        txid2 = finalizer2.deposit(payto, 1500)
-        assert_equal(txid1, txid2)
+        payto = finalizer.getnewaddress('', 'legacy')
+        finalizer_address = bytes_to_hex_str(BinaryData.from_base58check(payto).to_bytes()[::-1])
+        deposit_tx_id = finalizer.deposit(payto, 1500)
         wait_until(lambda: len(node.getrawmempool()) > 0, timeout=10)
         node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
-        disconnect_nodes(node, finalizer1.index)
+        disconnect_nodes(node, finalizer.index)
 
         # leave instant justification
         node.generatetoaddress(3 + 5 + 5 + 5 + 5, node.getnewaddress('', 'bech32'))
@@ -111,8 +117,12 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         #    |                J
         #    ..] - [ e6 ] - [ e7 ] - [ e8 ] fork
         disconnect_nodes(node, fork.index)
-        fork.generatetoaddress(5 + 5 + 1, fork.getnewaddress('', 'bech32'))
-        self.wait_for_vote_and_disconnect(finalizer=finalizer2, node=fork)
+        fork.generatetoaddress(5 + 5, fork.getnewaddress('', 'bech32'))
+        target = fork.getbestblockhash()
+        fork.generatetoaddress(1, fork.getnewaddress('', 'bech32'))
+        vtx = make_vote_tx(finalizer, finalizer_address, target,
+                           source_epoch=4, target_epoch=7, input_tx_id=deposit_tx_id)
+        fork.sendrawtransaction(ToHex(vtx))
         fork.generatetoaddress(1, fork.getnewaddress('', 'bech32'))
         assert_equal(fork.getblockcount(), 37)
         assert_finalizationstate(fork, {'currentDynasty': 3,
@@ -127,7 +137,7 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         #    |                J
         #    ..] - [ e6 ] - [ e7 ] - [ e8 ] fork
         node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
-        self.wait_for_vote_and_disconnect(finalizer=finalizer1, node=node)
+        self.wait_for_vote_and_disconnect(finalizer=finalizer, node=node)
         node.generatetoaddress(4, node.getnewaddress('', 'bech32'))
         assert_equal(node.getblockcount(), 30)
         assert_finalizationstate(node, {'currentDynasty': 3,
@@ -141,7 +151,7 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         #    |                J
         #    ..] - [ e6 ] - [ e7 ] - [ e8 ] fork
         node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
-        self.wait_for_vote_and_disconnect(finalizer=finalizer1, node=node)
+        self.wait_for_vote_and_disconnect(finalizer=finalizer, node=node)
         node.generatetoaddress(4, node.getnewaddress('', 'bech32'))
         assert_equal(node.getblockcount(), 35)
         assert_finalizationstate(node, {'currentDynasty': 4,
@@ -173,44 +183,35 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         # cleanup
         self.stop_node(node.index)
         self.stop_node(fork.index)
-        self.stop_node(finalizer1.index)
-        self.stop_node(finalizer2.index)
+        self.stop_node(finalizer.index)
 
     def test_fork_on_justified_epoch(self):
-        node = self.nodes[4]
-        fork = self.nodes[5]
-
-        finalizer1 = self.nodes[6]
-        finalizer2 = self.nodes[7]
+        node = self.nodes[3]
+        fork = self.nodes[4]
+        finalizer = self.nodes[5]
 
         self.start_node(node.index)
         self.start_node(fork.index)
-        self.start_node(finalizer1.index)
-        self.start_node(finalizer2.index)
+        self.start_node(finalizer.index)
 
-        finalizer1.importmasterkey(regtest_mnemonics[0]['mnemonics'])
-        finalizer2.importmasterkey(regtest_mnemonics[0]['mnemonics'])
+        finalizer.importmasterkey(regtest_mnemonics[0]['mnemonics'])
         node.importmasterkey(regtest_mnemonics[1]['mnemonics'])
         fork.importmasterkey(regtest_mnemonics[2]['mnemonics'])
 
         connect_nodes(node, fork.index)
-        connect_nodes(node, finalizer1.index)
-        connect_nodes(node, finalizer2.index)
+        connect_nodes(node, finalizer.index)
 
         # leave IBD
         node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
-        sync_blocks([node, fork, finalizer1])
+        sync_blocks([node, fork, finalizer])
 
         # create deposit
-        disconnect_nodes(node, finalizer2.index)
-        payto = finalizer1.getnewaddress('', 'legacy')
-        txid1 = finalizer1.deposit(payto, 1500)
-        finalizer2.setaccount(payto, '')
-        txid2 = finalizer2.deposit(payto, 1500)
-        assert_equal(txid1, txid2)
+        payto = finalizer.getnewaddress('', 'legacy')
+        finalizer_address = bytes_to_hex_str(BinaryData.from_base58check(payto).to_bytes()[::-1])
+        finalizer.deposit(payto, 1500)
         wait_until(lambda: len(node.getrawmempool()) > 0, timeout=10)
         node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
-        disconnect_nodes(node, finalizer1.index)
+        disconnect_nodes(node, finalizer.index)
 
         # leave instant justification
         #   F        F        F        F        J
@@ -228,7 +229,8 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         #       F        J
         # ... [ e4 ] - [ e5 ] - [ e6 ] node, fork
         node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
-        self.wait_for_vote_and_disconnect(finalizer=finalizer1, node=node)
+        vote = self.wait_for_vote_and_disconnect(finalizer=finalizer, node=node)
+        vote_tx_id = node.decoderawtransaction(vote)['txid']
         node.generatetoaddress(4, node.getnewaddress('', 'bech32'))
         sync_blocks([node, fork], timeout=10)
         assert_equal(node.getblockcount(), 30)
@@ -257,8 +259,11 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         #                          |
         #                          |                J
         #                         .. ] - [ e7 ] - [ e8 ] - [ e9 ] fork
+        target = fork.getbestblockhash()
         fork.generatetoaddress(1, fork.getnewaddress('', 'bech32'))
-        self.wait_for_vote_and_disconnect(finalizer=finalizer2, node=fork)
+        vtx = make_vote_tx(finalizer, finalizer_address, target,
+                           source_epoch=5, target_epoch=8, input_tx_id=vote_tx_id)
+        fork.sendrawtransaction(ToHex(vtx))
         fork.generatetoaddress(4, fork.getnewaddress('', 'bech32'))
         assert_equal(fork.getblockcount(), 45)
         assert_finalizationstate(fork, {'currentDynasty': 4,
@@ -273,7 +278,7 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         #                          |                J
         #                         .. ] - [ e7 ] - [ e8 ] - [ e9 ] fork
         node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
-        self.wait_for_vote_and_disconnect(finalizer=finalizer1, node=node)
+        self.wait_for_vote_and_disconnect(finalizer=finalizer, node=node)
         node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
         assert_equal(node.getblockcount(), 32)
         assert_finalizationstate(node, {'currentDynasty': 4,
@@ -304,8 +309,7 @@ class ForkChoiceForkedFinalizeEpochTest(UnitETestFramework):
         # cleanup
         self.stop_node(node.index)
         self.stop_node(fork.index)
-        self.stop_node(finalizer1.index)
-        self.stop_node(finalizer2.index)
+        self.stop_node(finalizer.index)
 
     def run_test(self):
         self.stop_nodes()

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -779,3 +779,30 @@ def bytes_to_base58(bytes):
         string = char_map[idx] + string
 
     return string
+
+
+def make_vote_tx(finalizer, finalizer_address, target_hash, source_epoch, target_epoch, input_tx_id):
+    """
+    Make and sign a vote transaction.
+
+    Args:
+        finalizer (AuthServiceProxy): the node which signs vote and vote transaction.
+        finalizer_address (string): the finalizer's address in legacy Base58Check format.
+        target_hash (string): the target hash.
+        source_epoch (int): the source epoch.
+        target_epoch (int): the target epoch
+        input_tx_id (string): the hash of the previous commit transaction. Used as an input to the generated vote.
+
+    Returns:
+        Raw vote transaction as a hex string.
+    """
+    finalizer_address = bytes_to_hex_str(base58check_to_bytes(finalizer_address)[::-1])
+    vote = {
+        'validator_address': finalizer_address,
+        'target_hash': target_hash,
+        'target_epoch': target_epoch,
+        'source_epoch': source_epoch
+    }
+    vtx = finalizer.createvotetransaction(vote, input_tx_id)
+    vtx = finalizer.signrawtransaction(vtx)
+    return vtx['hex']


### PR DESCRIPTION
Fixes #978 and makes feature_fork_choice_forked_finalize_epoch.py stable.

In #978, @frolosofsky wrote why the test was floating:
> The issue happens because test creates two finalizers which act like being one. Once finalizer2 processes block which includes vote from finalizer1 and at the same moment tries to vote itself, it cannot find corresponding prev transaction in its wallet. This started to happen once #937 is merged, that PR makes validator, when voting, using global validator state instead of local one, and because of two finalizer are actually the same, it made a glitch between two finalizers which started sharing the same validator state.

> I think it's not an issue for production code, we can simply rewrite test to use one validator, but make votes on different branches via rpc, like we double vote in #906.