### PR TITLE
Replace ADR-21 with UIP-21 in protocol.h

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -262,12 +262,12 @@ extern const char *GETSNAPSHOT;
  */
 extern const char *SNAPSHOT;
 /**
- * Contains a getcommits request as described in ADR-21.
+ * Contains a getcommits request as described in UIP-21.
  * Peer should respond with the "commits" message.
  */
 extern const char *GETCOMMITS;
 /**
- * Contains commits message as described in ADR-21.
+ * Contains commits message as described in UIP-21.
  * Sent in respose to a "getcommits" message.
  */
 extern const char *COMMITS;


### PR DESCRIPTION
ADR-21 has been replaced by UIP-21 but we didn't reflect this change in the source code,
that leads to having inconsistent description in [the documentation](https://docs.unit-e.io/reference/p2p/commits.html).