### PR TITLE
Fix proposer_stakeable_balance.py

### DIFF
--- a/test/functional/proposer_stakeable_balance.py
+++ b/test/functional/proposer_stakeable_balance.py
@@ -17,6 +17,9 @@ class ProposerStakeableBalanceTest(UnitETestFramework):
         ] for i in range(0, self.num_nodes))
         self.setup_clean_chain = True
 
+    def setup_network(self):
+        self.setup_nodes()
+
     def run_test(self):
         num_keys = 4
         nodes = self.nodes


### PR DESCRIPTION
The test expects nodes not to be connected.
The test is failing if one of the nodes takes too long to spin up, as some of the other nodes already connect to each other and `assert_equal(wallet['status'], 'NOT_PROPOSING_NO_PEERS')` no longer holds (it's `NOT_PROPOSING_NOT_ENOUGH_BALANCE`).

Signed-off-by: Mateusz Morusiewicz <mateusz@thirdhash.com>