### PR TITLE
Make VoteRecorder independent DB storage

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -72,6 +72,7 @@ UNITE_TESTS = \
   test/esperanza/finalizationparams_tests.cpp \
   test/esperanza/finalizationstate_tests.cpp \
   test/esperanza/finalizationstate_deposit_tests.cpp \
+  test/esperanza/finalizationstate_vote_recorder_tests.cpp \
   test/esperanza/finalizationstate_vote_tests.cpp \
   test/esperanza/finalizationstate_logout_tests.cpp \
   test/esperanza/finalizationstate_withdraw_tests.cpp \

--- a/src/esperanza/checks.cpp
+++ b/src/esperanza/checks.cpp
@@ -6,6 +6,7 @@
 #include <esperanza/adminparams.h>
 #include <esperanza/checks.h>
 #include <esperanza/finalizationstate.h>
+#include <finalization/vote_recorder.h>
 #include <script/interpreter.h>
 #include <script/sign.h>
 #include <script/standard.h>
@@ -350,6 +351,7 @@ bool ContextualCheckVoteTx(const CTransaction &tx, CValidationState &err_state,
   }
 
   const Result res = fin_state.ValidateVote(vote);
+  fin_state.RecordVoteIfNeeded(res, vote, vote_sig);
   switch (+res) {
     case Result::SUCCESS:
       break;

--- a/src/esperanza/finalizationstate.h
+++ b/src/esperanza/finalizationstate.h
@@ -6,6 +6,7 @@
 #define UNITE_ESPERANZA_FINALIZATIONSTATE_H
 
 #include <better-enums/enum.h>
+#include <consensus/validation.h>
 #include <esperanza/admincommand.h>
 #include <esperanza/finalizationparams.h>
 #include <esperanza/finalizationstate_data.h>
@@ -188,6 +189,31 @@ class FinalizationState : public FinalizationStateData {
 
   //! \brief Returns true if finalizer can vote in current dynasty
   bool IsFinalizerVoting(const Validator &finalizer) const;
+
+  //! \brief Records the vote
+  //!
+  //! Extract the vote from tx, validate it and record it.
+  //! In case of the offensive vote provided, emit a slash event.
+  //!
+  //! \param tx must be a vote transaction
+  //! \param err_state
+  //! \param log_errors
+  bool RecordVote(const CTransaction &tx,
+                  CValidationState &err_state,
+                  bool log_errors = true) const;
+
+  //! \brief Record the vote based on its validated status
+  //!
+  //! In case of the offensive vote provided, emit a slash event.
+  //!
+  //! \param vote_validation_result
+  //! \param vote
+  //! \param vote_sig
+  //! \param log_errors
+  void RecordVoteIfNeeded(Result vote_validation_result,
+                          const esperanza::Vote &vote,
+                          const std::vector<unsigned char> &vote_sig,
+                          bool log_errors = true) const;
 
  private:
   //!In case there is nobody available to justify we justify automatically.

--- a/src/finalization/vote_recorder.h
+++ b/src/finalization/vote_recorder.h
@@ -70,33 +70,24 @@ class VoteRecorder : private boost::noncopyable {
   static CCriticalSection cs_recorder;
   static std::shared_ptr<VoteRecorder> g_voteRecorder;
 
-  boost::optional<VoteRecord> FindOffendingVote(const esperanza::Vote &vote);
   void LoadFromDB();
   void SaveVoteToDB(const VoteRecord &record);
 
  public:
   void RecordVote(const esperanza::Vote &vote,
-                  const std::vector<unsigned char> &voteSig,
-                  const FinalizationState &fin_state,
-                  bool log_errors = true);
+                  const std::vector<unsigned char> &voteSig);
 
+  boost::optional<VoteRecord> FindOffendingVote(const esperanza::Vote &vote) const;
   boost::optional<VoteRecord> GetVote(const uint160 &validatorAddress,
                                       uint32_t epoch) const;
+
+  //! \brief calculate total number of votes in DB
+  uint32_t Count();
 
   static void Init(const DBParams &params);
   static void Reset(const DBParams &params);
   static std::shared_ptr<VoteRecorder> GetVoteRecorder();
 };
-
-//! \brief Records the vote.
-//!
-//! tx must be a vote transaction
-//! fin_state is a FinalizationState VoteRecorder must rely on when it checks transaction validity
-//!           and slashable condition. It must be best known finalization state on a moment.
-bool RecordVote(const CTransaction &tx,
-                CValidationState &err_state,
-                const FinalizationState &fin_state,
-                bool log_errors = true);
 
 }  // namespace finalization
 

--- a/src/p2p/finalizer_commits_handler_impl.cpp
+++ b/src/p2p/finalizer_commits_handler_impl.cpp
@@ -358,7 +358,7 @@ bool FinalizerCommitsHandlerImpl::OnCommits(
 
       for (const auto &c : d.commits) {
         if (c->IsVote()) {
-          if (!finalization::RecordVote(*c, err_state, *fin_state, /*log_errors=*/false)) {
+          if (!fin_state->RecordVote(*c, err_state, /*log_errors=*/false)) {
             return false;
           }
         }

--- a/src/test/esperanza/finalizationstate_utils.h
+++ b/src/test/esperanza/finalizationstate_utils.h
@@ -6,6 +6,7 @@
 #define UNIT_E_TESTS_FINALIZATIONSTATE_UTILS_H
 
 #include <esperanza/finalizationstate.h>
+#include <finalization/vote_recorder.h>
 #include <random.h>
 #include <test/test_unite.h>
 #include <boost/test/unit_test.hpp>
@@ -21,7 +22,11 @@ class FinalizationStateSpy : public FinalizationState {
   FinalizationStateSpy(const FinalizationParams &_params,
                        const AdminParams &adminParams) : FinalizationState(_params, adminParams),
                                                          params(_params) {}
-  FinalizationStateSpy() : FinalizationState(params, AdminParams()) {}
+  FinalizationStateSpy() : FinalizationState(params, AdminParams()) {
+    finalization::VoteRecorder::DBParams p;
+    p.inmemory = true;
+    finalization::VoteRecorder::Reset(p);
+  }
   FinalizationStateSpy(const FinalizationParams &_params) : FinalizationState(_params, AdminParams()),
                                                             params(_params) {}
   FinalizationStateSpy(const FinalizationStateSpy &parent) : FinalizationState(parent) {}

--- a/src/test/esperanza/finalizationstate_vote_recorder_tests.cpp
+++ b/src/test/esperanza/finalizationstate_vote_recorder_tests.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <esperanza/finalizationstate.h>
+#include <finalization/vote_recorder.h>
+#include <test/esperanza/finalizationstate_utils.h>
+#include <test/test_unite.h>
+#include <tinyformat.h>
+#include <validationinterface.h>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_log.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(finalizationstate_vote_recorder_tests, TestingSetup)
+
+using namespace finalization;
+
+class SlashListener : public CValidationInterface {
+
+ public:
+  bool slashingDetected = false;
+
+ protected:
+  void SlashingConditionDetected(const finalization::VoteRecord &,
+                                 const finalization::VoteRecord &) override {
+    slashingDetected = true;
+  }
+};
+
+BOOST_AUTO_TEST_CASE(record_double_vote) {
+  // initialize
+  FinalizationStateSpy spy;
+  SlashListener listener;
+  RegisterValidationInterface(&listener);
+
+  // record first vote that the double vote will be checked against it
+  uint160 finalizer_address = RandValidatorAddr();
+  spy.CreateAndActivateDeposit(finalizer_address, spy.MinDepositSize());
+  esperanza::Vote first_vote{finalizer_address, GetRandHash(), 5, 10};
+  VoteRecorder::GetVoteRecorder()->RecordVote(first_vote, ToByteVector(GetRandHash()));
+
+  struct TestCase {
+    Result vote_validation_result;
+    bool slashing_detected;
+  };
+
+  std::vector<TestCase> test_cases{
+      TestCase{Result::SUCCESS, true},
+      TestCase{Result::VOTE_ALREADY_VOTED, true},
+      TestCase{Result::VOTE_WRONG_TARGET_HASH, true},
+      TestCase{Result::VOTE_WRONG_TARGET_EPOCH, true},
+      TestCase{Result::VOTE_SRC_EPOCH_NOT_JUSTIFIED, true},
+
+      TestCase{Result::VOTE_NOT_VOTABLE, false},
+      TestCase{Result::INIT_WRONG_EPOCH, false},
+      TestCase{Result::VOTE_NOT_BY_VALIDATOR, false},
+  };
+
+  for (size_t i = 0; i < test_cases.size(); ++i) {
+    listener.slashingDetected = false;
+
+    TestCase tc = test_cases[i];
+    esperanza::Vote double_vote{finalizer_address, GetRandHash(), 6, 10};
+    spy.RecordVoteIfNeeded(tc.vote_validation_result, double_vote, ToByteVector(GetRandHash()));
+
+    BOOST_CHECK_MESSAGE(listener.slashingDetected == tc.slashing_detected,
+                        strprintf("test_case=%d failed", i));
+  }
+
+  UnregisterValidationInterface(&listener);
+}
+
+BOOST_AUTO_TEST_CASE(record_surrounding_vote_inner_passed) {
+  // initialize
+  FinalizationStateSpy spy;
+  SlashListener listener;
+  RegisterValidationInterface(&listener);
+
+  // record first vote that the double vote will be checked against it
+  uint160 finalizer_address = RandValidatorAddr();
+  spy.CreateAndActivateDeposit(finalizer_address, spy.MinDepositSize());
+  esperanza::Vote first_vote{finalizer_address, GetRandHash(), 5, 10};
+  VoteRecorder::GetVoteRecorder()->RecordVote(first_vote, ToByteVector(GetRandHash()));
+
+  struct TestCase {
+    Result vote_validation_result;
+    bool slashing_detected;
+  };
+
+  std::vector<TestCase> test_cases{
+      TestCase{Result::SUCCESS, true},
+      TestCase{Result::VOTE_ALREADY_VOTED, true},
+      TestCase{Result::VOTE_WRONG_TARGET_HASH, true},
+      TestCase{Result::VOTE_WRONG_TARGET_EPOCH, true},
+      TestCase{Result::VOTE_SRC_EPOCH_NOT_JUSTIFIED, true},
+
+      TestCase{Result::VOTE_NOT_VOTABLE, false},
+      TestCase{Result::INIT_WRONG_EPOCH, false},
+      TestCase{Result::VOTE_NOT_BY_VALIDATOR, false},
+  };
+
+  for (size_t i = 0; i < test_cases.size(); ++i) {
+    listener.slashingDetected = false;
+
+    TestCase tc = test_cases[i];
+    esperanza::Vote double_vote{finalizer_address, GetRandHash(), 6, 9};
+    spy.RecordVoteIfNeeded(tc.vote_validation_result, double_vote, ToByteVector(GetRandHash()));
+
+    BOOST_CHECK_MESSAGE(listener.slashingDetected == tc.slashing_detected,
+                        strprintf("test_case=%d failed", i));
+  }
+
+  UnregisterValidationInterface(&listener);
+}
+
+BOOST_AUTO_TEST_CASE(record_surrounding_vote_outer_passed) {
+  // initialize
+  FinalizationStateSpy spy;
+  SlashListener listener;
+  RegisterValidationInterface(&listener);
+
+  // record first vote that the double vote will be checked against it
+  uint160 finalizer_address = RandValidatorAddr();
+  spy.CreateAndActivateDeposit(finalizer_address, spy.MinDepositSize());
+  esperanza::Vote first_vote{finalizer_address, GetRandHash(), 5, 10};
+  VoteRecorder::GetVoteRecorder()->RecordVote(first_vote, ToByteVector(GetRandHash()));
+
+  struct TestCase {
+    Result vote_validation_result;
+    bool slashing_detected;
+  };
+
+  std::vector<TestCase> test_cases{
+      TestCase{Result::SUCCESS, true},
+      TestCase{Result::VOTE_ALREADY_VOTED, true},
+      TestCase{Result::VOTE_WRONG_TARGET_HASH, true},
+      TestCase{Result::VOTE_WRONG_TARGET_EPOCH, true},
+      TestCase{Result::VOTE_SRC_EPOCH_NOT_JUSTIFIED, true},
+
+      TestCase{Result::VOTE_NOT_VOTABLE, false},
+      TestCase{Result::INIT_WRONG_EPOCH, false},
+      TestCase{Result::VOTE_NOT_BY_VALIDATOR, false},
+  };
+
+  for (size_t i = 0; i < test_cases.size(); ++i) {
+    listener.slashingDetected = false;
+
+    TestCase tc = test_cases[i];
+    esperanza::Vote double_vote{finalizer_address, GetRandHash(), 4, 11};
+    spy.RecordVoteIfNeeded(tc.vote_validation_result, double_vote, ToByteVector(GetRandHash()));
+
+    BOOST_CHECK_MESSAGE(listener.slashingDetected == tc.slashing_detected,
+                        strprintf("test_case=%d failed", i));
+  }
+
+  UnregisterValidationInterface(&listener);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -590,18 +590,10 @@ static BCLog::LogFlags GetTransactionLogCategory(const CTransaction &tx) {
 
 static bool ContextualCheckFinalizerCommit(const CTransaction &tx, CValidationState &err_state,
                                            const esperanza::FinalizationState &fin_state,
-                                           const esperanza::FinalizationState &tip_fin_state,
                                            const CCoinsView &view) {
     const auto log_cat = GetTransactionLogCategory(tx);
     LogPrint(log_cat, "Checking %s with id %s\n", tx.GetType()._to_string(), tx.GetHash().GetHex());
-    if (tx.IsVote()) {
-        if (!esperanza::CheckVoteTx(tx, err_state, /*vote_out=*/nullptr, /*vote_sig_out=*/nullptr)) {
-            return false;
-        }
-        if (!finalization::RecordVote(tx, err_state, tip_fin_state)) {
-            return false;
-        }
-    }
+
     if (!esperanza::ContextualCheckFinalizerCommit(tx, err_state, fin_state, view)) {
         LogPrint(log_cat, "ERROR: %s (%s) check failed: %s\n", tx.GetType()._to_string(), tx.GetHash().GetHex(),
                  err_state.GetRejectReason());
@@ -613,11 +605,10 @@ static bool ContextualCheckFinalizerCommit(const CTransaction &tx, CValidationSt
 static bool ContextualCheckBlockFinalizerCommits(const CBlock &block,
                                                  CValidationState &err_state,
                                                  const esperanza::FinalizationState &fin_state,
-                                                 const esperanza::FinalizationState &tip_fin_state,
                                                  const CCoinsView &view) {
     for (const auto &tx : block.vtx) {
         if (tx->IsFinalizerCommit()) {
-            if (!::ContextualCheckFinalizerCommit(*tx, err_state, fin_state, tip_fin_state, view)) {
+            if (!::ContextualCheckFinalizerCommit(*tx, err_state, fin_state, view)) {
                 return false;
             }
         }
@@ -685,7 +676,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
       GetComponent<finalization::StateRepository>()->GetTipState();
     assert(fin_state != nullptr);
     if (tx.IsFinalizerCommit() &&
-        !::ContextualCheckFinalizerCommit(tx, state, *fin_state, *fin_state, view)) {
+        !::ContextualCheckFinalizerCommit(tx, state, *fin_state, view)) {
         return false; // state already filled by ContextualCheckFinalizerTx
     }
 
@@ -2092,7 +2083,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         if (!isGenesisBlock &&
             has_finalization_tx &&
             !ContextualCheckBlockFinalizerCommits(
-                block,state, *fin_state, *tip_fin_state, view)) {
+                block, state, *fin_state, view)) {
             return false;
         }
     }


### PR DESCRIPTION
This commit makes the following changes:

1. ~`VoteRecorder` is now a simple DB without a logic about slashing.
It is responsible to store votes and provide function to check for offending ones.
`FinalizationState` is responsible to call `VoteRecorder` when it's appropriate
and create slash transactions when needed. Having this one-way relationship removes
circular dependency~ Fixed via https://github.com/dtr-org/unit-e/pull/1019
```
Circular dependency: esperanza/finalizationstate -> validation -> finalization/vote_recorder -> esperanza/finalizationstate
```
2. `FinalizationState` validates the vote only once (used to be twice on master)
and eliminates the following duplicate log.
```
2019-04-16 14:32:14 [finalization] ValidateVote: valid. validator=a7f4737d9a64c37a721fff3d360a537d0f51686d target=b67ca892128e553c627c86ee7ee5645e7eec09776beed18f5ab104bf83653dfc source_epoch=18 target_epoch=19
2019-04-16 14:32:14 [finalization] ValidateVote: valid. validator=a7f4737d9a64c37a721fff3d360a537d0f51686d target=b67ca892128e553c627c86ee7ee5645e7eec09776beed18f5ab104bf83653dfc source_epoch=18 target_epoch=19
```

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>