### PR TITLE
Workaround for issue 962

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1135,7 +1135,22 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const CBlockI
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(txin.prevout);
                 while (range.first != range.second) {
                     if (range.first->second != tx.GetHash()) {
-                        LogPrintf("Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n", tx.GetHash().ToString(), pIndex->GetBlockHash().ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n);
+                        if (tx.IsCoinBase() && mapWallet.find(range.first->second)->second.IsCoinBase()) {
+                            // We show different messages depending on whether the transactions are coinbase because
+                            // this case will be more common (& also less problematic, since we have maturity).
+                            LogPrintf(
+                                "After re-org, new coinbase tx %s (in block %s) uses same input (%s:%i) as the old & discarded coinbase tx %s.\n",
+                                tx.GetHash().ToString(), pIndex->GetBlockHash().ToString(), range.first->first.hash.ToString(), range.first->first.n, range.first->second.ToString()
+                            );
+                            // TODO UNIT-E: In case we have transactions depending on the discarded coinbase tx, and we
+                            //              are the emitters of all of them, we could copy them replacing the inputs to
+                            //              decrease the re-org's impact.
+                        } else {
+                            LogPrintf(
+                                "Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n",
+                                tx.GetHash().ToString(), pIndex->GetBlockHash().ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n
+                            );
+                        }
                         MarkConflicted(pIndex->GetBlockHash(), range.first->second);
                     }
                     range.first++;


### PR DESCRIPTION
Workaround for issue #962 .

Although the ideal would be to remove the "deprecated" coinbase
transaction from the wallet, we don't do that because it's not yet clear
what should we do with other transactions that use as input the outputs
of the former one.

So for now I opted for changing the log message in order to distinguish
the coinbase case, which will be far more common than the case where the
user manually generates conflicting transactions after a re-org.

Signed-off-by: Andres Correa Casablanca <andres@thirdhash.com>