### PR TITLE
Return transaction finalization state in filtertransactions

### DIFF
--- a/src/wallet/rpcwalletext.cpp
+++ b/src/wallet/rpcwalletext.cpp
@@ -776,14 +776,13 @@ UniValue filtertransactions(const JSONRPCRequest &request) {
 
       // Get the transaction finalization state
       const CBlockIndex *block_index = nullptr;
+      bool finalized = false;
       if (pwtx->GetDepthInMainChain(block_index) > 0) {
         const finalization::FinalizationState *tip_fin_state = fin_repo->GetTipState();
-
-        if (tip_fin_state != nullptr) {
-          bool finalized = tip_fin_state->GetLastFinalizedEpoch() >= tip_fin_state->GetEpoch(*block_index);
-          entry.pushKV("finalized", UniValue(finalized));
-        }
+        assert(tip_fin_state != nullptr);
+        finalized = tip_fin_state->GetLastFinalizedEpoch() >= tip_fin_state->GetEpoch(*block_index);
       }
+      entry.pushKV("finalized", UniValue(finalized));
 
       transactions.push_back(entry);
     }

--- a/src/wallet/rpcwalletext.cpp
+++ b/src/wallet/rpcwalletext.cpp
@@ -5,6 +5,7 @@
 
 #include <consensus/validation.h>
 #include <core_io.h>
+#include <injector.h>
 #include <net.h>
 #include <policy/policy.h>
 #include <rpc/mining.h>
@@ -478,9 +479,9 @@ static bool OutputsContain(const UniValue &outputs, const std::string &search) {
   return false;
 }
 
-static void TxWithOutputsToJSON(const CWalletTx &wtx, CWallet *const pwallet,
+static bool TxWithOutputsToJSON(const CWalletTx &wtx, CWallet *const pwallet,
                                 const isminefilter &watchonly,
-                                const std::string &search, UniValue &entries) {
+                                const std::string &search, UniValue &result) {
   UniValue entry(UniValue::VOBJ);
 
   // GetAmounts variables
@@ -493,7 +494,7 @@ static void TxWithOutputsToJSON(const CWalletTx &wtx, CWallet *const pwallet,
   wtx.GetAmounts(list_received, list_sent, fee, sent_account, ISMINE_ALL);
 
   if (wtx.IsFromMe(ISMINE_WATCH_ONLY) && !(watchonly & ISMINE_WATCH_ONLY)) {
-    return;
+    return false;
   }
 
   std::vector<std::string> addresses;
@@ -521,7 +522,7 @@ static void TxWithOutputsToJSON(const CWalletTx &wtx, CWallet *const pwallet,
     for (const auto &s : list_sent) {
       UniValue output(UniValue::VOBJ);
       if (!OutputToJSON(output, s, pwallet, wtx, watchonly)) {
-        return;
+        return false;
       }
       amount -= s.amount;
       if (receive_outputs.count(s.vout) == 0) {
@@ -535,7 +536,7 @@ static void TxWithOutputsToJSON(const CWalletTx &wtx, CWallet *const pwallet,
   for (const auto &r : list_received) {
     UniValue output(UniValue::VOBJ);
     if (!OutputToJSON(output, r, pwallet, wtx, watchonly)) {
-      return;
+      return false;
     }
 
     output.pushKV("amount", ValueFromAmount(r.amount));
@@ -567,8 +568,11 @@ static void TxWithOutputsToJSON(const CWalletTx &wtx, CWallet *const pwallet,
   entry.pushKV("amount", ValueFromAmount(amount));
 
   if (search.empty() || OutputsContain(outputs, search)) {
-    entries.push_back(entry);
+    result = std::move(entry);
+    return true;
   }
+
+  return false;
 }
 
 static std::string GetAddress(const UniValue &transaction) {
@@ -746,8 +750,11 @@ UniValue filtertransactions(const JSONRPCRequest &request) {
 
   UniValue transactions(UniValue::VARR);
 
+  finalization::StateRepository *fin_repo = GetComponent<finalization::StateRepository>();
+
   {
     LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK(fin_repo->GetLock());
 
     // transaction processing
     const CWallet::TxItems &txOrdered = pwallet->wtxOrdered;
@@ -757,9 +764,28 @@ UniValue filtertransactions(const JSONRPCRequest &request) {
       if (txTime < timeFrom) {
         break;
       }
+
+      UniValue entry;
+      bool match_filter = false;
       if (txTime <= timeTo) {
-        TxWithOutputsToJSON(*pwtx, pwallet, watchonly, search, transactions);
+        match_filter = TxWithOutputsToJSON(*pwtx, pwallet, watchonly, search, entry);
       }
+      if (!match_filter) {
+        continue;
+      }
+
+      // Get the transaction finalization state
+      const CBlockIndex *block_index = nullptr;
+      if (pwtx->GetDepthInMainChain(block_index) > 0) {
+        const finalization::FinalizationState *tip_fin_state = fin_repo->GetTipState();
+
+        if (tip_fin_state != nullptr) {
+          bool finalized = tip_fin_state->GetLastFinalizedEpoch() >= tip_fin_state->GetEpoch(*block_index);
+          entry.pushKV("finalized", UniValue(finalized));
+        }
+      }
+
+      transactions.push_back(entry);
     }
   }
 

--- a/src/wallet/test/rpcwalletext_tests.cpp
+++ b/src/wallet/test/rpcwalletext_tests.cpp
@@ -35,6 +35,9 @@ BOOST_FIXTURE_TEST_CASE(genesis_block_coinbase, TestChain100Setup) {
 
   // The returned amount should equal the amount credited to us
   BOOST_CHECK_EQUAL(find_value(genesis_coinbase, "amount").get_real(), 10000);
+
+  // The coinbase should be finalized
+  BOOST_CHECK_EQUAL(find_value(genesis_coinbase, "finalized").get_bool(), true);
 }
 
 BOOST_FIXTURE_TEST_CASE(regular_coinbase, TestChain100Setup) {
@@ -44,6 +47,8 @@ BOOST_FIXTURE_TEST_CASE(regular_coinbase, TestChain100Setup) {
 
   // The amount should equal the block reward
   BOOST_CHECK_EQUAL(find_value(regular_coinbase, "amount").get_real(), 3.75);
+
+  BOOST_CHECK_EQUAL(find_value(regular_coinbase, "finalized").get_bool(), false);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This commit adds a new field called `finalization` to the transactions returned by the `filtertransactions` RPC call, with a value of `true` for finalized transactions and `false` otherwise.