### PR TITLE
Reduce circular dependencies in esperanza

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -120,6 +120,7 @@ UNITE_CORE_H = \
   esperanza/finalizationstate.h \
   esperanza/finalizationstate_data.h \
   esperanza/init.h \
+  esperanza/script.h \
   esperanza/validator.h \
   esperanza/validatorstate.h \
   esperanza/vote.h \
@@ -312,6 +313,7 @@ libunite_server_a_SOURCES = \
   esperanza/checks.cpp \
   esperanza/finalizationstate.cpp \
   esperanza/finalizationstate_data.cpp \
+  esperanza/script.cpp \
   esperanza/validator.cpp \
   finalization/state_db.cpp \
   finalization/state_processor.cpp \

--- a/src/esperanza/checks.h
+++ b/src/esperanza/checks.h
@@ -74,25 +74,6 @@ bool CheckAdminTx(const CTransaction &tx, CValidationState &err_state,
 bool ContextualCheckAdminTx(const CTransaction &tx, CValidationState &err_state,
                             const FinalizationState &fin_state);
 
-//! \brief Extracts the validator address from the transaction if applicable.
-//!
-//! The function supports only LOGOUT, DEPOSIT and WITHDRAW, anything else
-//! will return false.
-//! \param tx
-//! \param validatorAddressOut
-//! \return true if successful, false otherwise.
-bool ExtractValidatorAddress(const CTransaction &tx,
-                             uint160 &validatorAddressOut);
-
-//! \brief Extracts the validator pubkey from the transaction if applicable.
-//!
-//! The function supports only VOTE as tx type, anything else will return false.
-//! \param tx
-//! \param pubkeyOut
-//! \return true if successful, false otherwise.
-bool ExtractValidatorPubkey(const CTransaction &tx,
-                            CPubKey &pubkeyOut);
-
 }  // namespace esperanza
 
 #endif  // UNITE_ESPERANZA_CHECKS_H

--- a/src/esperanza/finalizationstate.cpp
+++ b/src/esperanza/finalizationstate.cpp
@@ -5,13 +5,12 @@
 #include <esperanza/finalizationstate.h>
 
 #include <chainparams.h>
-#include <esperanza/checks.h>
+#include <esperanza/script.h>
 #include <esperanza/vote.h>
 #include <script/ismine.h>
 #include <tinyformat.h>
 #include <ufp64.h>
 #include <util.h>
-#include <validation.h>
 
 #include <stdint.h>
 #include <algorithm>

--- a/src/esperanza/script.cpp
+++ b/src/esperanza/script.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <esperanza/script.h>
+
+#include <script/standard.h>
+
+namespace esperanza {
+
+bool ExtractValidatorPubkey(const CTransaction &tx, CPubKey &pubkeyOut) {
+  if (tx.IsVote()) {
+
+    std::vector<std::vector<unsigned char>> vSolutions;
+    txnouttype typeRet;
+
+    if (Solver(tx.vout[0].scriptPubKey, typeRet, vSolutions)) {
+      pubkeyOut = CPubKey(vSolutions[0]);
+      return true;
+    }
+  }
+  return false;
+}
+
+bool ExtractValidatorAddress(const CTransaction &tx,
+                             uint160 &validatorAddressOut) {
+
+  switch (tx.GetType()) {
+    case TxType::DEPOSIT:
+    case TxType::LOGOUT: {
+      std::vector<std::vector<unsigned char>> vSolutions;
+      txnouttype typeRet;
+
+      if (Solver(tx.vout[0].scriptPubKey, typeRet, vSolutions)) {
+        assert(typeRet == TX_COMMIT);
+        validatorAddressOut = CPubKey(vSolutions[0]).GetID();
+        return true;
+      }
+      return false;
+    }
+    case TxType::WITHDRAW: {
+
+      const CScript scriptSig = tx.vin[0].scriptSig;
+      auto pc = scriptSig.begin();
+      std::vector<unsigned char> vData;
+      opcodetype opcode;
+
+      // Skip the first value (signature)
+      scriptSig.GetOp(pc, opcode);
+
+      // Retrieve the public key
+      scriptSig.GetOp(pc, opcode, vData);
+      validatorAddressOut = CPubKey(vData).GetID();
+      return true;
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+}  // namespace esperanza

--- a/src/esperanza/script.h
+++ b/src/esperanza/script.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef ESPERANZA_SCRIPT_H
+#define ESPERANZA_SCRIPT_H
+
+class CTransaction;
+class uint160;
+class CPubKey;
+
+namespace esperanza {
+//! \brief Extracts the validator address from the transaction if applicable.
+//!
+//! The function supports only LOGOUT, DEPOSIT and WITHDRAW, anything else
+//! will return false.
+//! \param tx
+//! \param validatorAddressOut
+//! \return true if successful, false otherwise.
+bool ExtractValidatorAddress(const CTransaction &tx,
+                             uint160 &validatorAddressOut);
+
+//! \brief Extracts the validator pubkey from the transaction if applicable.
+//!
+//! The function supports only VOTE as tx type, anything else will return false.
+//! \param tx
+//! \param pubkeyOut
+//! \return true if successful, false otherwise.
+bool ExtractValidatorPubkey(const CTransaction &tx,
+                            CPubKey &pubkeyOut);
+}  // namespace esperanza
+
+#endif

--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -10,8 +10,8 @@
 #include <blockchain/blockchain_types.h>
 #include <chainparams.h>
 #include <consensus/validation.h>
-#include <esperanza/checks.h>
 #include <esperanza/finalizationstate.h>
+#include <esperanza/script.h>
 #include <finalization/state_repository.h>
 #include <net.h>
 #include <policy/policy.h>

--- a/src/test/esperanza/checks_tests.cpp
+++ b/src/test/esperanza/checks_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <esperanza/checks.h>
 #include <esperanza/finalizationstate.h>
+#include <esperanza/script.h>
 #include <finalization/params.h>
 #include <keystore.h>
 #include <random.h>


### PR DESCRIPTION
Moves ExtractValidatorPubKey and ExtractValidatorAddress to the esperanza/script.cpp

```diff
< Circular dependency: esperanza/checks -> esperanza/finalizationstate -> esperanza/checks
< Circular dependency: esperanza/finalizationstate -> validation -> esperanza/finalizationstate
< Circular dependency: consensus/tx_verify -> esperanza/finalizationstate -> validation -> consensus/tx_verify
< Circular dependency: esperanza/finalizationstate -> validation -> finalization/vote_recorder -> esperanza/finalizationstate
```