### PR TITLE
Eliminate timing issue with the node syncing in example_test.py

### DIFF
--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -214,6 +214,7 @@ class ExampleTest(UnitETestFramework):
         self.nodes[2].p2p.wait_for_verack()
 
         self.log.info("Wait for node2 reach current tip. Test that it has propagated all the blocks to us")
+        self.nodes[2].waitforblockheight(height)
 
         getdata_request = msg_getdata()
         for block in blocks:


### PR DESCRIPTION
Fixes #993 
Wait until the second node will get all blocks.
I ran `example_test.py` ~1000 times with 12 jobs - the issue is gone.

Signed-off-by: Dmitry Saveliev <dima@thirdhash.com>

