### PR TITLE
Show failing unit tests at the bottom in run-unit-tests.sh

### DIFF
--- a/contrib/devtools/run-unit-tests.sh
+++ b/contrib/devtools/run-unit-tests.sh
@@ -16,4 +16,5 @@ src/test/test_unite --list_content 2>&1 | \
   tr -d '*' | \
   awk '{ f = $0 ".log"; print "src/test/test_unite --run_test=" $0 " > \"" f "\" 2>&1 && (echo \"- [x] " $0 "\"; rm \"" f "\"; true) || (echo \"- [ ] " $0 " (see " f ")\"; false)"}' | \
   parallel -j 0 bash -c 2> /dev/null | \
-  sort
+  # Sort test results alphabetically, with the failing ones grouped at the bottom
+  sort -t / -k 1.6 | sort -s -t / -k 1.3,1.5 -r


### PR DESCRIPTION
This commit modifies the sort order for the results of run-unit-tests.sh.

Previously, they were sorted lexicographically, which meant that the
failing tests showed on top and could potentially disappear off-screen.
Now, the test results are sorted first by name (from character 6 to the
end of the line), then by status (characters 3 to 5) in reverse order.

Tested on Linux, however, [according to the manpage](https://ss64.com/osx/sort.html), the same options should work on MacOS as well.