### PR TITLE
Speedup feature_commits_forkchoice.py

### DIFF
--- a/test/functional/feature_commits_forkchoice.py
+++ b/test/functional/feature_commits_forkchoice.py
@@ -21,10 +21,6 @@ from test_framework.util import (
 )
 
 
-def generate_block(node):
-    node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
-
-
 def setup_deposit(self, proposer, validators):
     for i, n in enumerate(validators):
         n.new_address = n.getnewaddress("", "legacy")
@@ -37,8 +33,7 @@ def setup_deposit(self, proposer, validators):
 
     # the validator will be ready to operate in epoch 4
     # TODO: UNIT - E: it can be 2 epochs as soon as #572 is fixed
-    for n in range(0, 30):
-        generate_block(proposer)
+    proposer.generatetoaddress(30, proposer.getnewaddress('', 'bech32'))
 
     assert_equal(proposer.getblockcount(), 31)
 
@@ -81,8 +76,7 @@ class FinalizationForkChoice(UnitETestFramework):
 
         self.log.info("Setup test prerequisites")
         # get to up to block 49, just one before the new checkpoint
-        for _ in range(18):
-            generate_block(p0)
+        p0.generatetoaddress(18, p0.getnewaddress('', 'bech32'))
 
         assert_equal(p0.getblockcount(), 49)
         sync_blocks([p0, p1, p2, v0])
@@ -116,8 +110,7 @@ class FinalizationForkChoice(UnitETestFramework):
         # generate long chain in p0 but don't justify it
         #  F     J
         # 30 .. 40 .. 89    -- p0
-        for _ in range(40):
-            generate_block(p0)
+        p0.generatetoaddress(40, p0.getnewaddress('', 'bech32'))
 
         assert_equal(p0.getblockcount(), 89)
         assert_finalizationstate(p0, {'currentEpoch': 9,
@@ -183,16 +176,15 @@ class FinalizationForkChoice(UnitETestFramework):
 
         # generate more blocks to make sure they're processed
         self.log.info("Test all nodes continue to work as usual")
-        for _ in range(30):
-            generate_block(p0)
+        p0.generatetoaddress(30, p0.getnewaddress('', 'bech32'))
         sync_chain([p0, p1, p2, v0])
         assert_equal(p0.getblockcount(), 99)
-        for _ in range(30):
-            generate_block(p1)
+
+        p1.generatetoaddress(30, p1.getnewaddress('', 'bech32'))
         sync_chain([p0, p1, p2, v0])
         assert_equal(p1.getblockcount(), 129)
-        for _ in range(30):
-            generate_block(p2)
+
+        p2.generatetoaddress(30, p2.getnewaddress('', 'bech32'))
         sync_chain([p0, p1, p2, v0])
         assert_equal(p2.getblockcount(), 159)
 
@@ -206,12 +198,11 @@ class FinalizationForkChoice(UnitETestFramework):
         disconnect_nodes(p0, p1.index)
         disconnect_nodes(p0, p2.index)
         disconnect_nodes(p1, p2.index)
-        for _ in range(10):
-            generate_block(p0)
-        for _ in range(20):
-            generate_block(p1)
-        for _ in range(30):
-            generate_block(p2)
+
+        p0.generatetoaddress(10, p0.getnewaddress('', 'bech32'))
+        p1.generatetoaddress(20, p1.getnewaddress('', 'bech32'))
+        p2.generatetoaddress(30, p2.getnewaddress('', 'bech32'))
+
         assert_equal(p0.getblockcount(), 169)
         assert_equal(p1.getblockcount(), 179)
         assert_equal(p2.getblockcount(), 189)


### PR DESCRIPTION
By invoking `generatetoaddress`/`getnewaddress` once per batch
the execution time is reduced by 2.5 times.

On my MacBook 2.8 GHz Intel Core i7 I see the following gain.

Before:
```
/usr/local/bin/python3.7 /Users/kostiantyn/github.com/kostyantyn/unit-e/test/functional/feature_commits_forkchoice.py
2019-04-29 16:23:33.309000 TestFramework (INFO): Initializing test directory /var/folders/r9/s635cnq5265dp3bgh1kcw7b40000gn/T/testipslakwa
2019-04-29 16:23:33.310000 TestFramework (INFO): Debug file at /var/folders/r9/s635cnq5265dp3bgh1kcw7b40000gn/T/testipslakwa/node0/regtest/debug.log
Starting node 0 with args: -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500}
Starting node 1 with args: -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500}
Starting node 2 with args: -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500}
Starting node 3 with args: -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500} -validating=1
2019-04-29 16:23:33.312000 TestFramework.node0 (INFO): Running command: unit-e -datadir=/var/folders/r9/s635cnq5265dp3bgh1kcw7b40000gn/T/testipslakwa/node0 -server -keypool=1 -discover=0 -rest -logtimemicros -debug -debugexclude=libevent -debugexclude=leveldb -mocktime=0 -uacomment=testnode0 -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500}
2019-04-29 16:23:33.317000 TestFramework.node1 (INFO): Running command: unit-e -datadir=/var/folders/r9/s635cnq5265dp3bgh1kcw7b40000gn/T/testipslakwa/node1 -server -keypool=1 -discover=0 -rest -logtimemicros -debug -debugexclude=libevent -debugexclude=leveldb -mocktime=0 -uacomment=testnode1 -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500}
2019-04-29 16:23:33.321000 TestFramework.node2 (INFO): Running command: unit-e -datadir=/var/folders/r9/s635cnq5265dp3bgh1kcw7b40000gn/T/testipslakwa/node2 -server -keypool=1 -discover=0 -rest -logtimemicros -debug -debugexclude=libevent -debugexclude=leveldb -mocktime=0 -uacomment=testnode2 -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500}
2019-04-29 16:23:33.324000 TestFramework.node3 (INFO): Running command: unit-e -datadir=/var/folders/r9/s635cnq5265dp3bgh1kcw7b40000gn/T/testipslakwa/node3 -server -keypool=1 -discover=0 -rest -logtimemicros -debug -debugexclude=libevent -debugexclude=leveldb -mocktime=0 -uacomment=testnode3 -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500} -validating=1
2019-04-29 16:23:36.217000 TestFramework (INFO): Setup deposit
2019-04-29 16:23:42.901000 TestFramework (INFO): Setup test prerequisites
2019-04-29 16:23:55.654000 TestFramework (INFO): Test fresh node sync
2019-04-29 16:23:56.911000 TestFramework (INFO): Test longest node reverts to justified
2019-04-29 16:23:58.013000 TestFramework (INFO): Test all nodes continue to work as usual
2019-04-29 16:24:16.444000 TestFramework (INFO): Test nodes sync after reconnection
2019-04-29 16:24:30.597000 TestFramework (INFO): Stopping nodes
2019-04-29 16:24:31.666000 TestFramework (INFO): Cleaning up
2019-04-29 16:24:31.709000 TestFramework (INFO): Tests successful
```

After:
```
/usr/local/bin/python3.7 /Users/kostiantyn/github.com/kostyantyn/unit-e/test/functional/feature_commits_forkchoice.py
2019-04-29 16:27:12.668000 TestFramework (INFO): Initializing test directory /var/folders/r9/s635cnq5265dp3bgh1kcw7b40000gn/T/testvdc8vqvc
2019-04-29 16:27:12.668000 TestFramework (INFO): Debug file at /var/folders/r9/s635cnq5265dp3bgh1kcw7b40000gn/T/testvdc8vqvc/node0/regtest/debug.log
Starting node 0 with args: -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500}
Starting node 1 with args: -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500}
Starting node 2 with args: -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500}
Starting node 3 with args: -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500} -validating=1
2019-04-29 16:27:12.671000 TestFramework.node0 (INFO): Running command: unit-e -datadir=/var/folders/r9/s635cnq5265dp3bgh1kcw7b40000gn/T/testvdc8vqvc/node0 -server -keypool=1 -discover=0 -rest -logtimemicros -debug -debugexclude=libevent -debugexclude=leveldb -mocktime=0 -uacomment=testnode0 -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500}
2019-04-29 16:27:12.679000 TestFramework.node1 (INFO): Running command: unit-e -datadir=/var/folders/r9/s635cnq5265dp3bgh1kcw7b40000gn/T/testvdc8vqvc/node1 -server -keypool=1 -discover=0 -rest -logtimemicros -debug -debugexclude=libevent -debugexclude=leveldb -mocktime=0 -uacomment=testnode1 -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500}
2019-04-29 16:27:12.682000 TestFramework.node2 (INFO): Running command: unit-e -datadir=/var/folders/r9/s635cnq5265dp3bgh1kcw7b40000gn/T/testvdc8vqvc/node2 -server -keypool=1 -discover=0 -rest -logtimemicros -debug -debugexclude=libevent -debugexclude=leveldb -mocktime=0 -uacomment=testnode2 -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500}
2019-04-29 16:27:12.684000 TestFramework.node3 (INFO): Running command: unit-e -datadir=/var/folders/r9/s635cnq5265dp3bgh1kcw7b40000gn/T/testvdc8vqvc/node3 -server -keypool=1 -discover=0 -rest -logtimemicros -debug -debugexclude=libevent -debugexclude=leveldb -mocktime=0 -uacomment=testnode3 -esperanzaconfig={"epochLength": 10, "minDepositSize": 1500} -validating=1
2019-04-29 16:27:15.632000 TestFramework (INFO): Setup deposit
2019-04-29 16:27:17.817000 TestFramework (INFO): Setup test prerequisites
2019-04-29 16:27:21.430000 TestFramework (INFO): Test fresh node sync
2019-04-29 16:27:22.641000 TestFramework (INFO): Test longest node reverts to justified
2019-04-29 16:27:23.755000 TestFramework (INFO): Test all nodes continue to work as usual
2019-04-29 16:27:29.628000 TestFramework (INFO): Test nodes sync after reconnection
2019-04-29 16:27:34.418000 TestFramework (INFO): Stopping nodes
2019-04-29 16:27:35.433000 TestFramework (INFO): Cleaning up
2019-04-29 16:27:35.462000 TestFramework (INFO): Tests successful
```

We can also make an improvement by changing the `epochLength` from 10 to 5
but this will require to change all the asserts.

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>