### PR TITLE
Adjust types in CBloomFilter

### DIFF
--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -24,13 +24,13 @@ size_t CBloomFilter::ComputeEntriesSize(size_t n_elements, double fpr) {
      * The ideal size for a bloom filter with a given number of elements and false positive rate is:
      * - n_elements * log(fpr) / ln(2)^2
      */
-    const auto n_entries = static_cast<unsigned int>(-1 / LN2SQUARED * n_elements * log(fpr));
+    const auto n_entries = static_cast<size_t>(-1 / LN2SQUARED * n_elements * log(fpr));
 
     // Bloom filter packs 8 entries into 1 byte
     return n_entries / 8;
 }
 
-CBloomFilter::CBloomFilter(const unsigned int nElements, const double nFPRate, const unsigned int nTweakIn, unsigned char nFlagsIn, size_t max_filter_size_bytes, size_t max_hash_funcs) :
+CBloomFilter::CBloomFilter(const size_t nElements, const double nFPRate, const uint32_t nTweakIn, const uint8_t nFlagsIn, size_t max_filter_size_bytes, size_t max_hash_funcs) :
 
     // We ignore filter parameters which will create a bloom filter larger than the protocol limits
     vData(std::min(ComputeEntriesSize(nElements, nFPRate), max_filter_size_bytes)),
@@ -48,11 +48,11 @@ CBloomFilter::CBloomFilter(const unsigned int nElements, const double nFPRate, c
 }
 
 // Private constructor used by CRollingBloomFilter
-CBloomFilter::CBloomFilter(const unsigned int nElements, const double nFPRate, const unsigned int nTweakIn) :
-    vData((unsigned int)(-1  / LN2SQUARED * nElements * log(nFPRate)) / 8),
+CBloomFilter::CBloomFilter(const size_t nElements, const double nFPRate, const uint32_t nTweakIn) :
+    vData((size_t)(-1  / LN2SQUARED * nElements * log(nFPRate)) / 8),
     isFull(false),
     isEmpty(true),
-    nHashFuncs((unsigned int)(vData.size() * 8 / nElements * LN2)),
+    nHashFuncs((uint32_t)(vData.size() * 8 / nElements * LN2)),
     nTweak(nTweakIn),
     nFlags(BLOOM_UPDATE_NONE)
 {

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -49,10 +49,10 @@ CBloomFilter::CBloomFilter(const size_t nElements, const double nFPRate, const u
 
 // Private constructor used by CRollingBloomFilter
 CBloomFilter::CBloomFilter(const size_t nElements, const double nFPRate, const uint32_t nTweakIn) :
-    vData((size_t)(-1  / LN2SQUARED * nElements * log(nFPRate)) / 8),
+    vData(static_cast<size_t>(-1  / LN2SQUARED * nElements * log(nFPRate)) / 8),
     isFull(false),
     isEmpty(true),
-    nHashFuncs((uint32_t)(vData.size() * 8 / nElements * LN2)),
+    nHashFuncs(static_cast<uint32_t>(vData.size() * 8 / nElements * LN2)),
     nTweak(nTweakIn),
     nFlags(BLOOM_UPDATE_NONE)
 {

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -14,8 +14,8 @@ class CTransaction;
 class uint256;
 
 //! 20,000 items with fp rate < 0.1% or 10,000 items and <0.0001%
-static const unsigned int MAX_BLOOM_FILTER_SIZE = 36000; // bytes
-static const unsigned int MAX_HASH_FUNCS = 50;
+static const size_t MAX_BLOOM_FILTER_SIZE = 36000; // bytes
+static const size_t MAX_HASH_FUNCS = 50;
 
 /**
  * First two bits of nFlags control how much IsRelevantAndUpdate actually updates
@@ -46,17 +46,17 @@ enum bloomflags
 class CBloomFilter
 {
 private:
-    std::vector<unsigned char> vData;
+    std::vector<uint8_t> vData;
     bool isFull;
     bool isEmpty;
-    unsigned int nHashFuncs;
-    unsigned int nTweak;
-    unsigned char nFlags;
+    uint32_t nHashFuncs;
+    uint32_t nTweak;
+    uint8_t nFlags;
 
     unsigned int Hash(unsigned int nHashNum, const std::vector<unsigned char>& vDataToHash) const;
 
     // Private constructor for CRollingBloomFilter, no restrictions on size
-    CBloomFilter(const unsigned int nElements, const double nFPRate, const unsigned int nTweak);
+    CBloomFilter(size_t nElements, double nFPRate, uint32_t nTweak);
     friend class CRollingBloomFilter;
 
 public:
@@ -69,7 +69,7 @@ public:
      * It should generally always be a random value (and is largely only exposed for unit testing)
      * nFlags can be MATCH_ESPERANZA_TRANSACTIONS and one of the BLOOM_UPDATE_* enums (not _MASK)
      */
-    CBloomFilter(const unsigned int nElements, const double nFPRate, const unsigned int nTweak, unsigned char nFlagsIn, size_t max_filter_size_bytes = MAX_BLOOM_FILTER_SIZE, size_t max_hash_funcs = MAX_HASH_FUNCS);
+    CBloomFilter(size_t nElements, double nFPRate, uint32_t nTweak, uint8_t nFlagsIn, size_t max_filter_size_bytes = MAX_BLOOM_FILTER_SIZE, size_t max_hash_funcs = MAX_HASH_FUNCS);
     CBloomFilter() : isFull(true), isEmpty(false), nHashFuncs(0), nTweak(0), nFlags(0) {}
 
     ADD_SERIALIZE_METHODS;
@@ -95,7 +95,7 @@ public:
     bool contains(const uint256& hash) const;
 
     void clear();
-    void reset(const unsigned int nNewTweak);
+    void reset(const uint32_t nNewTweak);
 
     //! True if the size is <= MAX_BLOOM_FILTER_SIZE and the number of hash functions is <= MAX_HASH_FUNCS
     //! (catch a filter which was just deserialized which was too big)


### PR DESCRIPTION
As you know, C++ standard does not explicitly define how many bits should be there in `char` or `int`. And while currently, in absolute majority of cases, it is 8 and 32 bits respectively, leaving the things as is a potential way to shoot yourself in a leg.
[sizeof operator](https://en.cppreference.com/w/cpp/language/sizeof)
[fundamental types](https://en.cppreference.com/w/cpp/language/types)

And while we can follow this rule and change everything, I believe that we should start with protocol first. Because compiling unit-e on a system, which uses 16 bit int, or a char that is >8 bits will break the CBloomFilter.

Signed-off-by: Aleksandr Mikhailov <aleksandr@thirdhash.com>