### PR TITLE
Functional tests witness messages follow up

### DIFF
--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -418,7 +418,7 @@ class CompactBlocksTest(UnitETestFramework):
             assert_equal(absolute_indexes, [0])  # should be a coinbase request
 
             # Send the coinbase, and verify that the tip advances.
-            msg = msg_witness_blocktxn()
+            msg = msg_blocktxn()
             msg.block_transactions.blockhash = block.sha256
             msg.block_transactions.transactions = [block.vtx[0]]
             test_node.send_and_ping(msg)
@@ -472,7 +472,7 @@ class CompactBlocksTest(UnitETestFramework):
 
         test_getblocktxn_response(block, comp_block, test_node, block.vtx[1:])
 
-        msg_bt = msg_witness_blocktxn() # serialize with witnesses
+        msg_bt = msg_blocktxn() # serialize with witnesses
         msg_bt.block_transactions = BlockTransactions(block.sha256, block.vtx[1:])
         test_tip_after_message(node, test_node, msg_bt, block.sha256)
 
@@ -556,7 +556,7 @@ class CompactBlocksTest(UnitETestFramework):
         # different peer provide the block further down, so that we're still
         # verifying that the block isn't marked bad permanently. This is good
         # enough for now.
-        msg = msg_witness_blocktxn()
+        msg = msg_blocktxn()
 
         missing_txs = block.middle_txs[6:] + [block.unspent_tx]
 

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -19,8 +19,8 @@ MAX_SIGOP_COST = 80000
 # Calculate the virtual size of a witness block:
 # (base + witness/4)
 def get_virtual_size(witness_block):
-    base_size = len(witness_block.serialize(with_witness=False))
-    total_size = len(witness_block.serialize(with_witness=True))
+    base_size = len(witness_block.serialize_without_witness())
+    total_size = len(witness_block.serialize())
     # the "+3" is so we round up
     vsize = int((3*base_size + total_size + 3)/4)
     return vsize
@@ -227,7 +227,7 @@ class SegWitTest(UnitETestFramework):
         self.update_witness_block_with_transactions(block, [parent_tx, child_tx])
 
         # Calculate exact additional bytes (get_virtual_size would round it)
-        additional_bytes = 1 + (4 * MAX_BLOCK_BASE_SIZE) - (3 * len(block.serialize(with_witness=False)) + len(block.serialize(with_witness=True)))
+        additional_bytes = 1 + (4 * MAX_BLOCK_BASE_SIZE) - (3 * len(block.serialize_without_witness()) + len(block.serialize()))
 
         i = 0
         while additional_bytes > 0:
@@ -239,11 +239,11 @@ class SegWitTest(UnitETestFramework):
 
         block.compute_merkle_trees()
         block.solve()
-        segwit_size = 3 * len(block.serialize(with_witness=False)) + len(block.serialize(with_witness=True))
+        segwit_size = 3 * len(block.serialize_without_witness()) + len(block.serialize())
         assert_equal(segwit_size, (4 * MAX_BLOCK_BASE_SIZE) + 1)
         # Make sure that our test case would exceed the old max-network-message
         # limit
-        assert len(block.serialize(True)) > 2*1024*1024
+        assert len(block.serialize()) > 2*1024*1024
 
         test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=False)
 
@@ -636,15 +636,15 @@ class SegWitTest(UnitETestFramework):
         rpc_block = self.nodes[0].getblock(block.hash, False)
         non_wit_block = self.test_node.request_block(block.sha256, 2)
         wit_block = self.test_node.request_block(block.sha256, 2|MSG_WITNESS_FLAG)
-        assert_equal(wit_block.serialize(True), hex_str_to_bytes(rpc_block))
-        assert_equal(wit_block.serialize(False), non_wit_block.serialize())
-        assert_equal(wit_block.serialize(True), block.serialize(True))
+        assert_equal(wit_block.serialize(), hex_str_to_bytes(rpc_block))
+        assert_equal(wit_block.serialize_without_witness(), non_wit_block.serialize())
+        assert_equal(wit_block.serialize(), block.serialize())
 
         # Test size, vsize, weight
         rpc_details = self.nodes[0].getblock(block.hash, True)
-        assert_equal(rpc_details["size"], len(block.serialize(True)))
-        assert_equal(rpc_details["strippedsize"], len(block.serialize(False)))
-        weight = 3*len(block.serialize(False)) + len(block.serialize(True))
+        assert_equal(rpc_details["size"], len(block.serialize()))
+        assert_equal(rpc_details["strippedsize"], len(block.serialize_without_witness()))
+        weight = 3*len(block.serialize_without_witness()) + len(block.serialize())
         assert_equal(rpc_details["weight"], weight)
 
     # V0 segwit outputs should be standard

--- a/test/functional/test_framework/blockstore.py
+++ b/test/functional/test_framework/blockstore.py
@@ -94,7 +94,7 @@ class BlockStore():
         block.calc_sha256()
         try:
             self.blockDB[repr(block.sha256)] = bytes(block.serialize())
-            self.wblockDB[repr(block.sha256)] = bytes(block.serialize(with_witness=True))
+            self.wblockDB[repr(block.sha256)] = bytes(block.serialize())
         except TypeError as e:
             logger.exception("Unexpected error")
         self.currentBlock = block.sha256

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1489,11 +1489,6 @@ class msg_blocktxn():
     def __repr__(self):
         return "msg_blocktxn(block_transactions=%s)" % (repr(self.block_transactions))
 
-class msg_witness_blocktxn(msg_blocktxn):
-    def serialize(self):
-        r = b""
-        r += self.block_transactions.serialize()
-        return r
 
 class msg_getsnaphead:
     command = b"getsnaphead"

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1478,7 +1478,7 @@ class msg_blocktxn():
 
     def serialize(self):
         r = b""
-        r += self.block_transactions.serialize(with_witness=False)
+        r += self.block_transactions.serialize(with_witness=True)
         return r
 
     def __repr__(self):


### PR DESCRIPTION
Fixes #1032, Follow up to #1029

Removes the `with_witness` named argument from `CBlock.serialize()`. `p2p_segwit` requires non-witness serialization for computing the proper block weight, which is why an explicit `serialize_without_witness` has been added (this is the same as existing design on `CTransaction`).

Drops `msg_witness_blocktxn` in favor of `msg_blocktxn`, which now uses serialization with witness by default and unconditionally.