### PR TITLE
Factor out generate_block function

### DIFF
--- a/test/functional/esperanza_slash_restart.py
+++ b/test/functional/esperanza_slash_restart.py
@@ -23,6 +23,7 @@ from test_framework.util import (
     bytes_to_hex_str,
     connect_nodes,
     disconnect_nodes,
+    generate_block,
     wait_until,
 )
 
@@ -60,7 +61,7 @@ class EsperanzaSlashRestart(UnitETestFramework):
             deptx = f.deposit(f.new_address, 1500)
             self.wait_for_transaction(deptx, nodes=[proposer])
 
-        proposer.generatetoaddress(21, proposer.getnewaddress('', 'bech32'))
+        generate_block(proposer, count=21)
         assert_equal(proposer.getblockcount(), 22)
 
     def make_double_vote_tx(self, vote_tx, input_tx, proposer, finalizer):

--- a/test/functional/feature_commits_forkchoice.py
+++ b/test/functional/feature_commits_forkchoice.py
@@ -16,6 +16,7 @@ from test_framework.util import (
     assert_finalizationstate,
     connect_nodes,
     disconnect_nodes,
+    generate_block,
     sync_blocks,
 )
 
@@ -32,7 +33,7 @@ def setup_deposit(self, proposer, validators):
 
     # the validator will be ready to operate in epoch 4
     # TODO: UNIT - E: it can be 2 epochs as soon as #572 is fixed
-    proposer.generatetoaddress(30, proposer.getnewaddress('', 'bech32'))
+    generate_block(proposer, count=30)
 
     assert_equal(proposer.getblockcount(), 31)
 
@@ -75,7 +76,7 @@ class FinalizationForkChoice(UnitETestFramework):
 
         self.log.info("Setup test prerequisites")
         # get to up to block 49, just one before the new checkpoint
-        p0.generatetoaddress(18, p0.getnewaddress('', 'bech32'))
+        generate_block(p0, count=18)
 
         assert_equal(p0.getblockcount(), 49)
         sync_blocks([p0, p1, p2, v0])
@@ -109,7 +110,7 @@ class FinalizationForkChoice(UnitETestFramework):
         # generate long chain in p0 but don't justify it
         #  F     J
         # 30 .. 40 .. 89    -- p0
-        p0.generatetoaddress(40, p0.getnewaddress('', 'bech32'))
+        generate_block(p0, count=40)
 
         assert_equal(p0.getblockcount(), 89)
         assert_finalizationstate(p0, {'currentEpoch': 9,
@@ -124,13 +125,13 @@ class FinalizationForkChoice(UnitETestFramework):
         #                50 .. 60 .. 69          -- p1
         #                 F     J
         # get to the 6th epoch
-        p1.generatetoaddress(2, p1.getnewaddress('', 'bech32'))
+        generate_block(p1, count=2)
         self.wait_for_vote_and_disconnect(finalizer=v0, node=p1)
         # get to the 7th epoch
-        p1.generatetoaddress(10, p1.getnewaddress('', 'bech32'))
+        generate_block(p1, count=10)
         self.wait_for_vote_and_disconnect(finalizer=v0, node=p1)
         # generate the rest of the blocks
-        p1.generatetoaddress(8, p1.getnewaddress('', 'bech32'))
+        generate_block(p1, count=8)
         connect_nodes(p1, v0.index)
         sync_blocks([p1, v0])
 
@@ -175,15 +176,15 @@ class FinalizationForkChoice(UnitETestFramework):
 
         # generate more blocks to make sure they're processed
         self.log.info("Test all nodes continue to work as usual")
-        p0.generatetoaddress(30, p0.getnewaddress('', 'bech32'))
+        generate_block(p0, count=30)
         sync_blocks([p0, p1, p2, v0])
         assert_equal(p0.getblockcount(), 99)
 
-        p1.generatetoaddress(30, p1.getnewaddress('', 'bech32'))
+        generate_block(p1, count=30)
         sync_blocks([p0, p1, p2, v0])
         assert_equal(p1.getblockcount(), 129)
 
-        p2.generatetoaddress(30, p2.getnewaddress('', 'bech32'))
+        generate_block(p2, count=30)
         sync_blocks([p0, p1, p2, v0])
         assert_equal(p2.getblockcount(), 159)
 
@@ -198,9 +199,9 @@ class FinalizationForkChoice(UnitETestFramework):
         disconnect_nodes(p0, p2.index)
         disconnect_nodes(p1, p2.index)
 
-        p0.generatetoaddress(10, p0.getnewaddress('', 'bech32'))
-        p1.generatetoaddress(20, p1.getnewaddress('', 'bech32'))
-        p2.generatetoaddress(30, p2.getnewaddress('', 'bech32'))
+        generate_block(p0, count=10)
+        generate_block(p1, count=20)
+        generate_block(p2, count=30)
 
         assert_equal(p0.getblockcount(), 169)
         assert_equal(p1.getblockcount(), 179)

--- a/test/functional/feature_finalizer.py
+++ b/test/functional/feature_finalizer.py
@@ -12,12 +12,13 @@ from test_framework.util import (
     assert_equal,
     assert_finalizationstate,
     connect_nodes,
+    generate_block,
     sync_blocks,
 )
 
 
 def generate_block(node):
-    node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
+    generate_block(node)
 
 
 class FeatureFinalizerTest(UnitETestFramework):
@@ -44,7 +45,7 @@ class FeatureFinalizerTest(UnitETestFramework):
         v.new_address = v.getnewaddress("", "legacy")
         tx = v.deposit(v.new_address, 1500)
         self.wait_for_transaction(tx)
-        p.generatetoaddress(1, p.getnewaddress('', 'bech32'))
+        generate_block(p)
         sync_blocks([p, v])
 
         self.log.info("Restart validator")

--- a/test/functional/feature_finalizer.py
+++ b/test/functional/feature_finalizer.py
@@ -16,11 +16,6 @@ from test_framework.util import (
     sync_blocks,
 )
 
-
-def generate_block(node):
-    generate_block(node)
-
-
 class FeatureFinalizerTest(UnitETestFramework):
     def set_test_params(self):
         self.num_nodes = 2

--- a/test/functional/feature_fork_choice_parallel_justifications.py
+++ b/test/functional/feature_fork_choice_parallel_justifications.py
@@ -19,10 +19,11 @@ from test_framework.util import (
     assert_equal,
     assert_finalizationstate,
     assert_not_equal,
-    connect_nodes,
     base58check_to_bytes,
     bytes_to_hex_str,
+    connect_nodes,
     disconnect_nodes,
+    generate_block,
     sync_blocks,
     wait_until,
 )

--- a/test/functional/feature_fork_choice_parallel_justifications.py
+++ b/test/functional/feature_fork_choice_parallel_justifications.py
@@ -77,13 +77,13 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
             assert node.getblockcount() % 5 == 0
             fs = node.getfinalizationstate()
             checkpoint = node.getbestblockhash()
-            node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
+            generate_block(node)
             vtx = make_vote_tx(finalizer, finalizer_address, checkpoint,
                                source_epoch=fs['lastJustifiedEpoch'],
                                target_epoch=fs['currentEpoch'],
                                input_tx_id=prevtx)
             node.sendrawtransaction(vtx)
-            checkpoint = node.generatetoaddress(4, fork1.getnewaddress('', 'bech32'))
+            generate_block(node, count=4)
             vtx = FromHex(CTransaction(), vtx)
             vtx.rehash()
             return vtx.hash
@@ -115,7 +115,7 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
         # e0 - e1 - e2 - e3 - e4 - e5 -  node
         #                             |
         #                             -  fork2
-        node.generatetoaddress(24, node.getnewaddress('', 'bech32'))
+        generate_block(node, count=24)
         assert_equal(node.getblockcount(), 25)
         sync_blocks([node, finalizer])
         assert_finalizationstate(node, {'currentDynasty': 2,
@@ -136,9 +136,9 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
         #                             |
         #                             -  fork2
 
-        fork1.generatetoaddress(5, fork1.getnewaddress('', 'bech32'))
+        generate_block(fork1, count=5)
         vtx1 = generate_epoch_and_vote(fork1, finalizer, finalizer_address, deptx)
-        fork1.generatetoaddress(5, fork1.getnewaddress('', 'bech32'))
+        generate_block(fork1, count=5)
         assert_equal(fork1.getblockcount(), 40)
         assert_finalizationstate(fork1, {'currentDynasty': 3,
                                          'currentEpoch': 8,
@@ -165,7 +165,7 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
         #                             |       J
         #                             - e6 - e7 - e8 fork2 node
 
-        fork2.generatetoaddress(10, fork2.getnewaddress('', 'bech32'))
+        generate_block(fork2, count=10)
         vtx2 = generate_epoch_and_vote(fork2, finalizer, finalizer_address, deptx)
         assert_equal(fork2.getblockcount(), 40)
         assert_finalizationstate(fork2, {'currentDynasty': 3,
@@ -192,7 +192,7 @@ class ForkChoiceParallelJustificationsTest(UnitETestFramework):
         # e0 - e1 - e2 - e3 - e4 - e5 -
         #                             |       J
         #                             - e6 - e7 - e8 fork2
-        fork1.generatetoaddress(5, fork1.getnewaddress('', 'bech32'))
+        generate_block(fork1, count=5)
         sync_node_to_fork(finalizer, fork1)
         vtx1 = generate_epoch_and_vote(fork1, finalizer, finalizer_address, vtx1)
         assert_equal(fork1.getblockcount(), 50)

--- a/test/functional/feature_reindex_commits.py
+++ b/test/functional/feature_reindex_commits.py
@@ -15,6 +15,7 @@ from test_framework.util import (
     assert_finalizationstate,
     connect_nodes_bi,
     disconnect_nodes,
+    generate_block,
     json,
     sync_blocks,
     wait_until,
@@ -118,9 +119,7 @@ class FeatureReindexCommits(UnitETestFramework):
                 "", "legacy"), MIN_DEPOSIT)
         self.wait_for_transaction(deposit_tx)
 
-        self.proposer.generatetoaddress(
-            24, self.proposer.getnewaddress(
-                '', 'bech32'))
+        generate_block(self.proposer, count=24)
         assert_equal(self.proposer.getblockcount(), 25)
 
     def assert_finalizer_status(self, status):

--- a/test/functional/feature_snapshot.py
+++ b/test/functional/feature_snapshot.py
@@ -11,6 +11,7 @@ from test_framework.util import (
     assert_equal,
     connect_nodes,
     disconnect_nodes,
+    generate_block,
     sync_blocks,
     wait_until,
 )
@@ -99,7 +100,7 @@ class SnapshotTest(UnitETestFramework):
         # | isd_node
         # | rework_node
         # | blank_node
-        full_node.generatetoaddress(5 + 5, full_node.getnewaddress('', 'bech32'))
+        generate_block(full_node, count=5 + 5)
         assert_equal(full_node.getblockcount(), 10)
         wait_until(lambda: has_snapshot(full_node, 4), timeout=3)
         wait_until(lambda: has_snapshot(full_node, 9), timeout=3)
@@ -112,7 +113,7 @@ class SnapshotTest(UnitETestFramework):
         connect_nodes(rework_node, full_node.index)
         sync_blocks([rework_node, full_node])
         disconnect_nodes(rework_node, full_node.index)
-        rework_node.generatetoaddress(5, rework_node.getnewaddress('', 'bech32'))
+        generate_block(rework_node, count=5)
         assert_equal(rework_node.getblockcount(), 15)
 
         # generate 1 more block creates new epoch and instantly finalizes the previous one
@@ -121,7 +122,7 @@ class SnapshotTest(UnitETestFramework):
         # G------------(h=4)...(h=9)-(h=10)-(h=11) full_node, blank_node
         # | isd_node                   \
         #                               -------------------(h=15) rework_node
-        full_node.generatetoaddress(1, full_node.getnewaddress('', 'bech32'))
+        generate_block(full_node)
         assert_equal(full_node.getblockcount(), 11)
         wait_until(lambda: has_finalized_snapshot(full_node, height=4), timeout=5)
         wait_until(lambda: has_snapshot(full_node, height=9), timeout=5)
@@ -176,7 +177,7 @@ class SnapshotTest(UnitETestFramework):
         fund_proof = isd_node.gettxoutproof([funding_txid])
         isd_node.importprunedfunds(genesis_tx_hex, fund_proof)
 
-        isd_node.generatetoaddress(1, isd_node.getnewaddress('', 'bech32'))
+        generate_block(isd_node)
         assert_equal(isd_node.getblockcount(), 12)
 
         # test that reorg one epoch after finalization is possible
@@ -199,7 +200,7 @@ class SnapshotTest(UnitETestFramework):
 
         self.setup_stake_coins(full_node)
 
-        full_node.generatetoaddress(5, full_node.getnewaddress('', 'bech32'))
+        generate_block(full_node, count=5)
         wait_until(lambda: len(full_node.listsnapshots()) == 1, timeout=10)
         for res in full_node.listsnapshots():
             full_node.deletesnapshot(res['snapshot_hash'])

--- a/test/functional/feature_snapshot_finalization.py
+++ b/test/functional/feature_snapshot_finalization.py
@@ -23,6 +23,7 @@ from test_framework.util import (
     bytes_to_hex_str,
     connect_nodes,
     disconnect_nodes,
+    generate_block,
     sync_blocks,
     wait_until,
 )
@@ -37,7 +38,7 @@ def setup_deposit(self, proposer, validators):
         deptx = n.deposit(n.new_address, 1500)
         self.wait_for_transaction(deptx, nodes=[proposer])
 
-    proposer.generatetoaddress(21, proposer.getnewaddress('', 'bech32'))
+    generate_block(proposer, count=21)
 
     assert_equal(proposer.getblockcount(), 22)
 

--- a/test/functional/finalization_state_restoration.py
+++ b/test/functional/finalization_state_restoration.py
@@ -22,9 +22,6 @@ from test_framework.util import (
 )
 
 
-def generate_block(proposer, count=1):
-    generate_block(proposer, count=count)
-
 def setup_deposit(self, proposer, validators):
     for _, n in enumerate(validators):
         n.new_address = n.getnewaddress("", "legacy")

--- a/test/functional/finalization_state_restoration.py
+++ b/test/functional/finalization_state_restoration.py
@@ -14,14 +14,16 @@ from test_framework.util import (
     cleanup_datadir,
     connect_nodes,
     disconnect_nodes,
+    generate_block,
     initialize_datadir,
     sync_blocks,
     sync_mempools,
     wait_until,
 )
 
+
 def generate_block(proposer, count=1):
-    proposer.generatetoaddress(count, proposer.getnewaddress('', 'bech32'))
+    generate_block(proposer, count=count)
 
 def setup_deposit(self, proposer, validators):
     for _, n in enumerate(validators):

--- a/test/functional/p2p_snapshot.py
+++ b/test/functional/p2p_snapshot.py
@@ -58,9 +58,10 @@ from test_framework.blocktools import (
 )
 from test_framework.util import (
     assert_equal,
-    wait_until,
     bytes_to_hex_str,
+    generate_block,
     hex_str_to_bytes,
+    wait_until,
 )
 
 import math
@@ -300,7 +301,7 @@ class P2PSnapshotTest(UnitETestFramework):
         self.setup_stake_coins(serving_node)
 
         # generate 2 epochs + 1 block to create the first finalized snapshot
-        serving_node.generatetoaddress(5 + 5 + 1, serving_node.getnewaddress('', 'bech32'))
+        generate_block(serving_node, count=5 + 5 + 1)
         assert_equal(serving_node.getblockcount(), 11)
         wait_until(lambda: has_valid_snapshot(serving_node, 4), timeout=10)
 
@@ -383,7 +384,7 @@ class P2PSnapshotTest(UnitETestFramework):
         self.setup_stake_coins(snap_node)
 
         # generate 2 epochs + 1 block to create the first finalized snapshot
-        snap_node.generatetoaddress(5 + 5 + 1, snap_node.getnewaddress('', 'bech32'))
+        generate_block(snap_node, count=5 + 5 + 1)
         assert_equal(snap_node.getblockcount(), 11)
         wait_until(lambda: has_valid_snapshot(snap_node, 4), timeout=10)
 
@@ -477,7 +478,7 @@ class P2PSnapshotTest(UnitETestFramework):
 
         # generate 2 epochs + 1 block to create the first finalized snapshot
         # and store it in valid_p2p
-        snap_node.generatetoaddress(5 + 5 + 1, snap_node.getnewaddress('', 'bech32'))
+        generate_block(snap_node, count=5 + 5 + 1)
         assert_equal(snap_node.getblockcount(), 11)
         wait_until(lambda: has_valid_snapshot(snap_node, 4), timeout=10)
 
@@ -485,7 +486,7 @@ class P2PSnapshotTest(UnitETestFramework):
         valid_p2p.update_snapshot_from(snap_node)
 
         # create the second snapshot and store it in broken_p2p
-        snap_node.generatetoaddress(5, snap_node.getnewaddress('', 'bech32'))
+        generate_block(snap_node, count=5)
         assert_equal(snap_node.getblockcount(), 16)
         wait_until(lambda: has_valid_snapshot(snap_node, 9), timeout=10)
 
@@ -566,7 +567,7 @@ class P2PSnapshotTest(UnitETestFramework):
         self.setup_stake_coins(snap_node)
 
         # add 2nd best snapshot to full_snap_p2p
-        snap_node.generatetoaddress(5 + 5 + 1, snap_node.getnewaddress('', 'bech32'))
+        generate_block(snap_node, count=5 + 5 + 1)
         assert_equal(snap_node.getblockcount(), 11)
         wait_until(lambda: has_valid_snapshot(snap_node, 4), timeout=10)
         full_snap_p2p = WaitNode()
@@ -575,7 +576,7 @@ class P2PSnapshotTest(UnitETestFramework):
             p2p.update_snapshot_from(snap_node)
 
         # add the best snapshot to half_snap_p2p
-        snap_node.generatetoaddress(5, snap_node.getnewaddress('', 'bech32'))
+        generate_block(snap_node, count=5)
         assert_equal(snap_node.getblockcount(), 16)
         wait_until(lambda: has_valid_snapshot(snap_node, 9), timeout=10)
         half_snap_p2p = WaitNode()

--- a/test/functional/rpc_finalization.py
+++ b/test/functional/rpc_finalization.py
@@ -13,6 +13,7 @@ from test_framework.util import (
     assert_equal,
     connect_nodes,
     disconnect_nodes,
+    generate_block,
     wait_until,
     sync_blocks,
 )
@@ -62,7 +63,7 @@ class RpcFinalizationTest(UnitETestFramework):
         # e0 - e1[1]
         connect_nodes(node, finalizer1.index)
         connect_nodes(node, finalizer2.index)
-        node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
+        generate_block(node)
         sync_blocks([node, finalizer1, finalizer2])
         disconnect_nodes(node, finalizer1.index)
         disconnect_nodes(node, finalizer2.index)
@@ -81,7 +82,7 @@ class RpcFinalizationTest(UnitETestFramework):
         # test instant justification 1
         # F
         # e0 - e1
-        node.generatetoaddress(4, node.getnewaddress('', 'bech32'))
+        generate_block(node, count=4)
         assert_equal(node.getblockcount(), 5)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 0)
@@ -94,7 +95,7 @@ class RpcFinalizationTest(UnitETestFramework):
         # test instant justification 2
         # F    J
         # e0 - e1 - e2
-        node.generatetoaddress(5, node.getnewaddress('', 'bech32'))
+        generate_block(node, count=5)
         assert_equal(node.getblockcount(), 10)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 0)
@@ -107,7 +108,7 @@ class RpcFinalizationTest(UnitETestFramework):
         # test instant justification 3
         # F    F    J
         # e0 - e1 - e2 - e3
-        node.generatetoaddress(5, node.getnewaddress('', 'bech32'))
+        generate_block(node, count=5)
         assert_equal(node.getblockcount(), 15)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 0)
@@ -120,7 +121,7 @@ class RpcFinalizationTest(UnitETestFramework):
         # test instant justification 4
         # F    F    F    J
         # e0 - e1 - e2 - e3 - e4
-        node.generatetoaddress(5, node.getnewaddress('', 'bech32'))
+        generate_block(node, count=5)
         assert_equal(node.getblockcount(), 20)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 1)
@@ -133,7 +134,7 @@ class RpcFinalizationTest(UnitETestFramework):
         # test instant justification 5 (must be last one)
         # F    F    F    F    J
         # e0 - e1 - e2 - e3 - e4 - e5
-        node.generatetoaddress(5, node.getnewaddress('', 'bech32'))
+        generate_block(node, count=5)
         assert_equal(node.getblockcount(), 25)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 2)
@@ -145,7 +146,7 @@ class RpcFinalizationTest(UnitETestFramework):
         # no justification
         # F    F    F    F    J
         # e0 - e1 - e2 - e3 - e4 - e5 - e6
-        node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
+        generate_block(node)
         assert_equal(node.getblockcount(), 26)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 3)
@@ -154,7 +155,7 @@ class RpcFinalizationTest(UnitETestFramework):
         assert_equal(state['lastFinalizedEpoch'], 3)
         assert_equal(state['validators'], 1)
 
-        node.generatetoaddress(4, node.getnewaddress('', 'bech32'))
+        generate_block(node, count=4)
         assert_equal(node.getblockcount(), 30)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 3)
@@ -166,7 +167,7 @@ class RpcFinalizationTest(UnitETestFramework):
         # no justification
         # F    F    F    F    J
         # e0 - e1 - e2 - e3 - e4 - e5 - e6 - e7[31]
-        node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
+        generate_block(node)
         assert_equal(node.getblockcount(), 31)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 3)
@@ -180,7 +181,7 @@ class RpcFinalizationTest(UnitETestFramework):
         # F    F    F    F    J         J
         # e0 - e1 - e2 - e3 - e4 - e5 - e6 - e7[31, 32]
         self.wait_for_vote_and_disconnect(finalizer=finalizer1, node=node)
-        node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
+        generate_block(node)
 
         assert_equal(node.getblockcount(), 32)
         state = node.getfinalizationstate()
@@ -194,7 +195,7 @@ class RpcFinalizationTest(UnitETestFramework):
         # skip 1 justification
         # F    F    F    F    J         J
         # e0 - e1 - e2 - e3 - e4 - e5 - e6 - e7 - e8 - e9[41]
-        node.generatetoaddress(9, node.getnewaddress('', 'bech32'))
+        generate_block(node, count=9)
         assert_equal(node.getblockcount(), 41)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 3)
@@ -208,7 +209,7 @@ class RpcFinalizationTest(UnitETestFramework):
         # F    F    F    J              J         J
         # e0 - e1 - e2 - e3 - e4 - e5 - e6 - e7 - e8 - e9[41, 42]
         self.wait_for_vote_and_disconnect(finalizer=finalizer1, node=node)
-        node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
+        generate_block(node)
         assert_equal(node.getblockcount(), 42)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 3)
@@ -219,9 +220,9 @@ class RpcFinalizationTest(UnitETestFramework):
 
         # F    F    F    F    J         J         F    J
         # e0 - e1 - e2 - e3 - e4 - e5 - e6 - e7 - e8 - e9 - e10[46, 47]
-        node.generatetoaddress(4, node.getnewaddress('', 'bech32'))
+        generate_block(node, count=4)
         self.wait_for_vote_and_disconnect(finalizer=finalizer1, node=node)
-        node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
+        generate_block(node)
         assert_equal(node.getblockcount(), 47)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 3)
@@ -232,7 +233,7 @@ class RpcFinalizationTest(UnitETestFramework):
 
         # F    F    F    F    J         J         F    J
         # e0 - e1 - e2 - e3 - e4 - e5 - e6 - e7 - e8 - e9 - e10
-        node.generatetoaddress(3, node.getnewaddress('', 'bech32'))
+        generate_block(node, count=3)
         assert_equal(node.getblockcount(), 50)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 3)
@@ -245,7 +246,7 @@ class RpcFinalizationTest(UnitETestFramework):
 
         # F    F    F    F    J              J    F    J
         # e0 - e1 - e2 - e3 - e4 - e5 - e6 - e7 - e8 - e9 - e10 - e11[51]
-        node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
+        generate_block(node)
         assert_equal(node.getblockcount(), 51)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 4)
@@ -261,7 +262,7 @@ class RpcFinalizationTest(UnitETestFramework):
         # F    F    F    F    J              J    F    F    J
         # e0 - e1 - e2 - e3 - e4 - e5 - e6 - e7 - e8 - e9 - e10 - e11
         self.wait_for_vote_and_disconnect(finalizer=finalizer1, node=node)
-        node.generatetoaddress(4, node.getnewaddress('', 'bech32'))
+        generate_block(node, count=4)
         assert_equal(node.getblockcount(), 55)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 4)
@@ -272,9 +273,9 @@ class RpcFinalizationTest(UnitETestFramework):
 
         # F    F    F    F    J              J    F    F    F     J
         # e0 - e1 - e2 - e3 - e4 - e5 - e6 - e7 - e8 - e9 - e10 - e11 - e12
-        node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
+        generate_block(node)
         self.wait_for_vote_and_disconnect(finalizer=finalizer1, node=node)
-        node.generatetoaddress(4, node.getnewaddress('', 'bech32'))
+        generate_block(node, count=4)
         assert_equal(node.getblockcount(), 60)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 5)
@@ -285,9 +286,9 @@ class RpcFinalizationTest(UnitETestFramework):
 
         # F    F    F    J                   J    F    F    F     F     J
         # e0 - e1 - e2 - e3 - e4 - e5 - e6 - e7 - e8 - e9 - e10 - e11 - e12 - e13
-        node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
+        generate_block(node)
         self.wait_for_vote_and_disconnect(finalizer=finalizer1, node=node)
-        node.generatetoaddress(4, node.getnewaddress('', 'bech32'))
+        generate_block(node, count=4)
         assert_equal(node.getblockcount(), 65)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 6)
@@ -298,7 +299,7 @@ class RpcFinalizationTest(UnitETestFramework):
 
         # F    F    F    F    J              J    F    F    F     F     J
         # e0 - e1 - e2 - e3 - e4 - e5 - e6 - e7 - e8 - e9 - e10 - e11 - e12 - e13 - e14[66]
-        node.generatetoaddress(1, node.getnewaddress('', 'bech32'))
+        generate_block(node)
         assert_equal(node.getblockcount(), 66)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 7)
@@ -312,7 +313,7 @@ class RpcFinalizationTest(UnitETestFramework):
         # e0 - e1 - e2 - e3 - e4 - e5 - e6 - e7 - e8 - e9 - e10 - e11 - e12 - e13 - e14
         self.wait_for_vote_and_disconnect(finalizer=finalizer1, node=node)
         self.wait_for_vote_and_disconnect(finalizer=finalizer2, node=node)
-        node.generatetoaddress(4, node.getnewaddress('', 'bech32'))
+        generate_block(node, count=4)
         assert_equal(node.getblockcount(), 70)
         state = node.getfinalizationstate()
         assert_equal(state['currentDynasty'], 7)

--- a/test/functional/rpc_getblocksnapshot.py
+++ b/test/functional/rpc_getblocksnapshot.py
@@ -18,6 +18,7 @@ from test_framework.util import (
     connect_nodes,
     sync_blocks,
     disconnect_nodes,
+    generate_block,
     wait_until,
 )
 
@@ -120,7 +121,7 @@ class RpcGetBlockSnapshotTest(UnitETestFramework):
 
         self.setup_stake_coins(node0, node1, node2)
 
-        node0.generatetoaddress(7, node0.getnewaddress('', 'bech32'))
+        generate_block(node0, count=7)
         connect_nodes(node1, node0.index)
         connect_nodes(node2, node0.index)
         sync_blocks([node0, node1])
@@ -130,7 +131,7 @@ class RpcGetBlockSnapshotTest(UnitETestFramework):
         disconnect_nodes(node2, node0.index)
 
         # generated shorter fork
-        forked_block_hash = node1.generatetoaddress(1, node1.getnewaddress('', 'bech32'))[0]
+        forked_block_hash = generate_block(node1)[0]
         connect_nodes(node0, node1.index)
         sync_blocks([node0, node1])
         disconnect_nodes(node0, node1.index)
@@ -138,7 +139,7 @@ class RpcGetBlockSnapshotTest(UnitETestFramework):
         assert_equal(node0.getblockhash(node0.getblockcount()), forked_block_hash)
 
         # generate longer fork
-        node2.generatetoaddress(22, node2.getnewaddress('', 'bech32'))
+        generate_block(node2, count=22)
         connect_nodes(node0, node2.index)
         sync_blocks([node0, node2])
         disconnect_nodes(node0, node2.index)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -782,3 +782,6 @@ def make_vote_tx(finalizer, finalizer_address, target_hash, source_epoch, target
     vtx = finalizer.createvotetransaction(vote, input_tx_id)
     vtx = finalizer.signrawtransactionwithwallet(vtx)
     return vtx['hex']
+
+def generate_block(proposer, count=1):
+    return proposer.generatetoaddress(count, proposer.getnewaddress('', 'bech32'))

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -783,5 +783,5 @@ def make_vote_tx(finalizer, finalizer_address, target_hash, source_epoch, target
     vtx = finalizer.signrawtransactionwithwallet(vtx)
     return vtx['hex']
 
-def generate_block(proposer, count=1):
-    return proposer.generatetoaddress(count, proposer.getnewaddress('', 'bech32'))
+def generate_block(node, count=1):
+    return node.generatetoaddress(count, node.getnewaddress('', 'bech32'))


### PR DESCRIPTION
At the moment, the way we generate blocks in functional tests is quite meditative and repeatable.
This commit factors out simple function generate_block that eliminates the need to copy-paste every
time we generate new blocks in tests.

Conceptually, the change is:
```diff
-node.generatetoaddress(10, node.getnewaddress('', 'bech32'))
+generate_block(node, count=10)
```

`count=1` is omitted.

The script which makes dirty job:

```bash
for f in $(git grep -l generatetoaddress '*finalization*.py' '*esperanza*.py' '*snapshot*.py' '*commits*.py' '*finalizer*.py' '*forkchoice*.py' '*fork_choice*.py'); do
    echo $f
    LANG=C LC_CTYPE=C sed -e 's/\([][a-z0-9_.]*\)\.generatetoaddress(1, \1\.getnewaddress(.*, .*))/generate_block(\1)/' -i '' $f
    LANG=C LC_CTYPE=C sed -e 's/\([][a-z0-9_.]*\)\.generatetoaddress(\([^,]*\), \1\.getnewaddress(.*, .*))/generate_block(\1, count=\2)/' -i '' $f
done
```

Also, applies alphabetical sort in affected files import sections.