### PR TITLE
Validate deposit prior adding to the wallet

### DIFF
--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -286,6 +286,12 @@ bool WalletExtension::SendDeposit(const CKeyID &keyID, CAmount amount,
   const FinalizationState *fin_state = m_dependencies.GetFinalizationStateRepository().GetTipState();
   assert(fin_state);
 
+  const esperanza::Result is_valid = fin_state->ValidateDeposit(keyID, amount);
+  if (is_valid != +esperanza::Result::SUCCESS) {
+    LogPrintf("Cannot send deposit to %s, check above logs for details\n", keyID.GetHex());
+    return false;
+  }
+
   const ValidatorState::Phase cur_phase = GetFinalizerPhase(*fin_state);
   const ValidatorState::Phase exp_phase = ValidatorState::Phase::NOT_VALIDATING;
   if (cur_phase != exp_phase) {

--- a/test/functional/esperanza_admin_full_cycle.py
+++ b/test/functional/esperanza_admin_full_cycle.py
@@ -4,7 +4,12 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 from test_framework.test_framework import UnitETestFramework
-from test_framework.util import json, connect_nodes_bi, assert_raises_rpc_error
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    connect_nodes_bi,
+    json,
+)
 from test_framework.admin import Admin
 
 MIN_DEPOSIT_SIZE = 1000
@@ -63,9 +68,12 @@ class AdminFullCycle(UnitETestFramework):
             framework.wait_for_transaction(tx, timeout=20)
 
         def deposit_reject(self):
+            balance = self.node.getbalance()
             assert_raises_rpc_error(None, "Cannot create deposit",
                                     self.node.deposit, self.address,
                                     MIN_DEPOSIT_SIZE)
+            # Make sure deposit doesn't disappear when rejected.
+            assert_equal(self.node.getbalance(), balance)
 
         def deposit_ok(self, deposit_amount=MIN_DEPOSIT_SIZE):
             tx = self.node.deposit(self.address, deposit_amount)


### PR DESCRIPTION
At the moment, when a user prepares deposit, the node creates a transaction and adds it to the
wallet.  It, in turn, tries to accept it to the memory pool and could fail when the deposit is
invalid (for example validator is blacklisted). That leads to disappearing of the deposit from the
balance.

This commit fixes that by validating deposit before adding transaction to the wallet.

Fixes #996.