### PR TITLE
Disable flaky wallet_labels test

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -114,7 +114,6 @@ BASE_SCRIPTS = [
     'feature_snapshot.py',
     'wallet_importmulti.py',
     'rpc_tracestake.py',
-    'wallet_labels.py',
     'wallet_listreceivedby.py',
     'feature_commits_forkchoice.py',
     'feature_ltor.py',
@@ -252,7 +251,7 @@ USBDEVICE_SCRIPTS = [
     'wallet_hwsign.py',
 ]
 
-DISABLED_SCRIPTS = []
+DISABLED_SCRIPTS = ['wallet_labels.py']
 
 # Place EXTENDED_SCRIPTS first since it has the 3 longest running tests
 ALL_SCRIPTS = EXTENDED_SCRIPTS + BASE_SCRIPTS + DISABLED_SCRIPTS + USBDEVICE_SCRIPTS


### PR DESCRIPTION
Disable it at the memont, because it flakes too often and disturbs further development by triggering
Travis builds. There is an issue (#1042) to fix the test.
