### PR TITLE
Fix wallet_multiwallet.py

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -235,7 +235,10 @@ class TestNode():
         try:
             self.drain_main_signal_callbacks_pending()
             self.stop(wait=wait)
-        except (http.client.CannotSendRequest, subprocess.CalledProcessError):
+        except (JSONRPCException, ConnectionError, http.client.HTTPException, subprocess.CalledProcessError):
+            # Most likely, the node is already stopped or stopping. Print the exception and continue.
+            # Note: it's better to use TestFramework.stop_node, instead of TestNode.stop_node directly,
+            # since the former checks that process has ended and cleans up.
             self.log.exception("Unable to stop node.")
 
         # Check that stderr is as expected


### PR DESCRIPTION
This commit hardens the regular `wallet_multiwallet.py`, which can fail
just like the `--usecli` version, for the reasons detailed in commit ad7c2e72:
when the node is already stopping, we can get all kinds of network exceptions
when trying to stop it a second time, so we want to ignore those exceptions.