### PR TITLE
Fix compilation warnings appeared after bitcoin-0.17 merge

### DIFF
--- a/src/better-enums/enum_set.h
+++ b/src/better-enums/enum_set.h
@@ -63,7 +63,7 @@ class EnumSet {
   EnumSet() : m_bits(0){};
   EnumSet(const EnumSet<Enum> &) = default;
   EnumSet(std::initializer_list<Enum> es) : m_bits(0) {
-    for (const auto e : es) {
+    for (const auto &e : es) {
       Add(e);
     }
   }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -73,15 +73,6 @@ static UniValue prioritisetransaction(const JSONRPCRequest& request)
     return true;
 }
 
-static std::string gbt_vb_name(const Consensus::DeploymentPos pos) {
-    const struct VBDeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
-    std::string s = vbinfo.name;
-    if (!vbinfo.gbt_force) {
-        s.insert(s.begin(), '!');
-    }
-    return s;
-}
-
 static UniValue estimatefee(const JSONRPCRequest& request)
 {
     throw JSONRPCError(RPC_METHOD_DEPRECATED, "estimatefee was removed in v0.17.\n"

--- a/src/test/better_enum_set_tests.cpp
+++ b/src/test/better_enum_set_tests.cpp
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE(check_iterator) {
 
   std::set<SomeTestEnum> s2;
 
-  for (const auto &e : s) {
+  for (const auto e : s) {
     s2.emplace(e);
   }
 
@@ -248,7 +248,7 @@ BOOST_AUTO_TEST_CASE(check_initializer_list) {
 BOOST_AUTO_TEST_CASE(empty_iterator) {
   EnumSet<SomeTestEnum> s{};
   std::size_t count = 0;
-  for (const auto &e : s) {
+  for (const auto e : s) {
     std::ignore = e;
     BOOST_CHECK(++count <= s.GetSize());
   }
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE(iterator_with_one_element) {
   EnumSet<SomeTestEnum> s{SomeTestEnum::A};
   std::set<SomeTestEnum> s2;
   std::size_t count = 0;
-  for (const auto &e : s) {
+  for (const auto e : s) {
     std::ignore = e;
     BOOST_CHECK(++count <= s.GetSize());
   }
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE(iterator_checks) {
   EnumSet<SomeTestEnum> s{SomeTestEnum::C, SomeTestEnum::D, SomeTestEnum::G};
   std::set<SomeTestEnum> s2;
   std::size_t count = 0;
-  for (const auto &e : s) {
+  for (const auto e : s) {
     std::ignore = e;
     BOOST_CHECK(++count <= s.GetSize());
   }
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE(iterator_on_set_with_all_elements) {
                           SomeTestEnum::D, SomeTestEnum::E, SomeTestEnum::F,
                           SomeTestEnum::G, SomeTestEnum::H};
   std::size_t count = 0;
-  for (const auto &e : s) {
+  for (const auto e : s) {
     std::ignore = e;
     BOOST_CHECK(++count <= s.GetSize());
   }

--- a/src/wallet/rpcmnemonic.cpp
+++ b/src/wallet/rpcmnemonic.cpp
@@ -89,7 +89,7 @@ UniValue mnemonicinfo(const JSONRPCRequest &request) {
 
 UniValue mnemoniclistlanguages(const JSONRPCRequest &request) {
   UniValue response(UniValue::VOBJ);
-  for (const auto language : key::mnemonic::Language::_values()) {
+  for (const auto &language : key::mnemonic::Language::_values()) {
     response.pushKV(key::mnemonic::GetLanguageTag(language),
                     UniValue(key::mnemonic::GetLanguageDesc(language)));
   }

--- a/src/walletinitinterface.h
+++ b/src/walletinitinterface.h
@@ -11,7 +11,7 @@ class CScheduler;
 class CRPCTable;
 
 namespace esperanza {
-struct WalletExtensionDeps;
+class WalletExtensionDeps;
 }
 
 class WalletInitInterface {


### PR DESCRIPTION
Compressed list of fixed warnings:

* ./walletinitinterface.h:14:1: warning: struct 'WalletExtensionDeps' was previously declared as a class [-Wmismatched-tags]
* rpc/mining.cpp:76:20: warning: unused function 'gbt_vb_name' [-Wunused-function]
* wallet/rpcmnemonic.cpp:92:19: warning: loop variable 'language' of type 'const key::mnemonic::Language' creates a copy from type 'const key::mnemonic::Language' [-Wrange-loop-analysis]
* test/better_enum_set_tests.cpp:216:20: warning: loop variable 'e' is always a copy because the range of type 'EnumSet<SomeTestEnum>' does not return a reference [-Wrange-loop-analysis]
* ./better-enums/enum_set.h:66:21: warning: loop variable 'e' of type 'const SomeTestEnum' creates a copy from type 'const SomeTestEnum' [-Wrange-loop-analysis]
