### PR TITLE
Fix wallet_labels.py

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -114,6 +114,7 @@ BASE_SCRIPTS = [
     'feature_snapshot.py',
     'wallet_importmulti.py',
     'rpc_tracestake.py',
+    'wallet_labels.py',
     'wallet_listreceivedby.py',
     'feature_commits_forkchoice.py',
     'feature_ltor.py',
@@ -251,7 +252,7 @@ USBDEVICE_SCRIPTS = [
     'wallet_hwsign.py',
 ]
 
-DISABLED_SCRIPTS = ['wallet_labels.py']
+DISABLED_SCRIPTS = []
 
 # Place EXTENDED_SCRIPTS first since it has the 3 longest running tests
 ALL_SCRIPTS = EXTENDED_SCRIPTS + BASE_SCRIPTS + DISABLED_SCRIPTS + USBDEVICE_SCRIPTS

--- a/test/functional/wallet_labels.py
+++ b/test/functional/wallet_labels.py
@@ -113,6 +113,7 @@ class WalletLabelsTest(UnitETestFramework):
 
         # connect that other node
         connect_nodes_bi(self.nodes, node_index, some_other_node_index)
+        sync_blocks([node, some_other_node])
 
         # send everything (0 + 3.75 + 10003.75 = 10007.5)
         common_address = some_other_node.getnewaddress('', 'bech32')
@@ -158,9 +159,9 @@ class WalletLabelsTest(UnitETestFramework):
         # assert_raises_rpc_error(-1, "no stakeable coins.", node.generate, 1)
 
         # the other node should have funds to generate a block
-        sync_blocks([node, some_other_node])
         sync_mempools([node, some_other_node])
         some_other_node.generatetoaddress(1, common_address)
+        sync_blocks([node, some_other_node])
 
         assert_equal(some_other_node.getbalance(), Decimal(20007.5) - fee)
 

--- a/test/functional/wallet_labels.py
+++ b/test/functional/wallet_labels.py
@@ -150,14 +150,6 @@ class WalletLabelsTest(UnitETestFramework):
         # at some_other_node
         assert_equal(node.getbalance(), 0)
 
-        # common_address_privkey = some_other_node.dumpprivkey(common_address)
-        # # take back our funds
-        # node.importprivkey(common_address_privkey)
-        # assert_equal(node.getbalance(), Decimal(10007.5) - fee)
-        # # these coins should not be stakeable as they do not have any confirmations
-        # assert_equal(node.proposerstatus()['wallets'][0]['stakeable_balance'], 0)
-        # assert_raises_rpc_error(-1, "no stakeable coins.", node.generate, 1)
-
         # the other node should have funds to generate a block
         sync_mempools([node, some_other_node])
         some_other_node.generatetoaddress(1, common_address)


### PR DESCRIPTION
The test encountered two synchronization issues:

In the first case, node A generated blocks, then sent some of the
generated funds to node B. However, node B didn't always manage to sync
the blockchain before receiving the transaction, so it would discard the
transaction as an orphan, and not include it in the next mined block.

The second case was similar: node B generated funds to node A's address,
however, node A did not manage to sync the blockchain and add the funds
to the wallet before it was asked to create a new transaction with them.

Fixes #1042.