### PR TITLE
Fix unit test: util_tests_datadir/test_LockDirectory 

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1249,7 +1249,7 @@ static void TestOtherProcess(fs::path dirname, std::string lockname, int fd)
                 break;
             case ExitCommand:
                 close(fd);
-                exit(0);
+                _Exit(0);
             default:
                 assert(0);
         }


### PR DESCRIPTION
On macOS the following call:

```
src/test/test_unite --run_test=util_tests_datadir/test_LockDirectory
```

Fails:

```
Running 1 test case...
libc++abi.dylib: terminating with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument
test/util_tests.cpp:1342: error: in "util_tests_datadir/test_LockDirectory": check processstatus == 0 has failed [11 != 0]

*** 1 failure is detected in the test module "Unit-e Test Suite"
```

The test itself fails as the `BOOST_CHECK` which checks that the child process terminated correctly is trigger (as the child does not terminate correctly). The unit test actually forks (sic!) the process. The forked process actually works fine too and only blows up on calling `exit`.

This pull request changes the call to [`exit`](https://en.cppreference.com/w/cpp/utility/program/exit) to `_Exit`. `_Exit` is available on [Linux](http://man7.org/linux/man-pages/man3/on_exit.3.html) as well as on bsd systems (so [macOS](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/exit.3.html), freeBSD etc should work). It is already excluded from windows builds, as windows does not support `fork`.

[`_Exit`](https://en.cppreference.com/w/cpp/utility/program/_Exit) does not call the destructors of statically allocated variables, nor any functions registered using [`atexit`](https://en.cppreference.com/w/cpp/utility/program/atexit) (we do not have any functions registered using `atexit` anyhow).

This fix makes the test pass as the test is not broken, but there seems to be an order-of-initialization-and-destruction with some static variables which is not fixed by this "fix". Then again it only shows in this particular test when forking the process and during shutdown. It does not happen during any functional test apparently and has not been seen to happen in any other scenario.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
