### PR TITLE
New RPC propose and proposetoaddress

### DIFF
--- a/src/injector.h
+++ b/src/injector.h
@@ -127,6 +127,7 @@ class UnitEInjector : public Injector<UnitEInjector> {
             Settings)
 
   COMPONENT(ProposerRPC, proposer::ProposerRPC, proposer::ProposerRPC::New,
+            Settings,
             proposer::MultiWallet,
             staking::Network,
             staking::ActiveChain,

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -168,7 +168,6 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     // make them still work.
     bool success = false;
     CValidationState state;
-    const staking::ActiveChain *active_chain = GetComponent<staking::ActiveChain>();
     for (const staking::Coin &coin : stakeable_coins) {
       proposer::EligibleCoin eligible_coin = {
           coin,

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -163,19 +163,20 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
       throw std::runtime_error(strprintf("%s: no stakeable coins.", __func__));
     }
 
+    // TODO UNIT-E: We can completely remove the whole `CreateNewBlock` once we
+    // migrated all the functional tests. At the moment this is a workaround to
+    // make them still work.
     bool success = false;
     CValidationState state;
     const staking::ActiveChain *active_chain = GetComponent<staking::ActiveChain>();
     for (const staking::Coin &coin : stakeable_coins) {
       proposer::EligibleCoin eligible_coin = {
-          staking::Coin(active_chain->GetBlockIndex(coin.GetTransactionId()),
-              COutPoint(coin.GetTransactionId(), coin.GetOutputIndex()),
-              CTxOut(coin.GetAmount(), scriptPubKeyIn)),
-          GetRandHash(), //TODO UNIT-E: At the moment is not used, since we still have PoW here
+          coin,
+          GetRandHash(),
           GetComponent<blockchain::Behavior>()->CalculateBlockReward(nHeight),
-          0, //TODO UNIT-E: At the moment is not used, since we still have PoW here
-          0, //TODO UNIT-E: At the moment is not used, since we still have PoW here
-          0 //TODO UNIT-E: At the moment is not used, since we still have PoW here
+          0,
+          0,
+          0
       };
 
       const CTransactionRef coinbase = GetComponent<proposer::BlockBuilder>()->BuildCoinbaseTransaction(uint256(snapshot_hash), eligible_coin, staking::CoinSet(), nFees, scriptPubKeyIn, pwallet->GetWalletExtension());

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -178,7 +178,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
           0 //TODO UNIT-E: At the moment is not used, since we still have PoW here
       };
 
-      const CTransactionRef coinbase = GetComponent<proposer::BlockBuilder>()->BuildCoinbaseTransaction(uint256(snapshot_hash), eligible_coin, staking::CoinSet(), nFees, pwallet->GetWalletExtension());
+      const CTransactionRef coinbase = GetComponent<proposer::BlockBuilder>()->BuildCoinbaseTransaction(uint256(snapshot_hash), eligible_coin, staking::CoinSet(), nFees, scriptPubKeyIn, pwallet->GetWalletExtension());
       pblocktemplate->block.vtx[0] = coinbase;
 
       LogPrintf("%s: block weight=%u txs=%u fees=%ld sigops=%d\n", __func__, GetBlockWeight(*pblock), nBlockTx, nFees, nBlockSigOpsCost);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -168,14 +168,17 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     // make them still work.
     bool success = false;
     CValidationState state;
+    const staking::ActiveChain *active_chain = GetComponent<staking::ActiveChain>();
     for (const staking::Coin &coin : stakeable_coins) {
       proposer::EligibleCoin eligible_coin = {
-          coin,
-          GetRandHash(),
+          staking::Coin(active_chain->GetBlockIndex(coin.GetTransactionId()),
+              COutPoint(coin.GetTransactionId(), coin.GetOutputIndex()),
+              CTxOut(coin.GetAmount(), scriptPubKeyIn)),
+          GetRandHash(), //TODO UNIT-E: At the moment is not used, since we still have PoW here
           GetComponent<blockchain::Behavior>()->CalculateBlockReward(nHeight),
-          0,
-          0,
-          0
+          0, //TODO UNIT-E: At the moment is not used, since we still have PoW here
+          0, //TODO UNIT-E: At the moment is not used, since we still have PoW here
+          0 //TODO UNIT-E: At the moment is not used, since we still have PoW here
       };
 
       const CTransactionRef coinbase = GetComponent<proposer::BlockBuilder>()->BuildCoinbaseTransaction(uint256(snapshot_hash), eligible_coin, staking::CoinSet(), nFees, scriptPubKeyIn, pwallet->GetWalletExtension());

--- a/src/proposer/block_builder.cpp
+++ b/src/proposer/block_builder.cpp
@@ -138,7 +138,7 @@ class BlockBuilderImpl : public BlockBuilder {
     CScript reward_script;
 
     if (coinbase_script) {
-      reward_script = CScript(coinbase_script->begin(), coinbase_script->end());
+      reward_script = CScript(coinbase_script.get());
     } else if (m_settings->reward_destination) {
       reward_script = GetScriptForDestination(*m_settings->reward_destination);
     } else {

--- a/src/proposer/block_builder.cpp
+++ b/src/proposer/block_builder.cpp
@@ -138,7 +138,7 @@ class BlockBuilderImpl : public BlockBuilder {
     CScript reward_script;
 
     if (coinbase_script) {
-      reward_script = CScript(coinbase_script.get());
+      reward_script = coinbase_script.get();
     } else if (m_settings->reward_destination) {
       reward_script = GetScriptForDestination(*m_settings->reward_destination);
     } else {

--- a/src/proposer/block_builder.h
+++ b/src/proposer/block_builder.h
@@ -24,22 +24,24 @@ class BlockBuilder {
  public:
   //! \brief Builds a coinbase transaction.
   virtual const CTransactionRef BuildCoinbaseTransaction(
-      const uint256 &snapshot_hash,       //!< The snapshot hash to be included.
-      const EligibleCoin &eligible_coin,  //!< The eligible coin to reference as stake. Also contains the target height.
-      const staking::CoinSet &coins,      //!< Any other coins that should be combined into the coinbase tx.
-      CAmount fees,                       //!< The amount of fees to be included (for the reward).
-      staking::StakingWallet &wallet      //!< The wallet to be used for signing the transaction.
+      const uint256 &snapshot_hash,                     //!< The snapshot hash to be included.
+      const EligibleCoin &eligible_coin,                //!< The eligible coin to reference as stake. Also contains the target height.
+      const staking::CoinSet &coins,                    //!< Any other coins that should be combined into the coinbase tx.
+      CAmount fees,                                     //!< The amount of fees to be included (for the reward).
+      const boost::optional<CScript> &coinbase_script,  //!< The scriptpubkey to be used for the coinbase reward and fees.
+      staking::StakingWallet &wallet                    //!< The wallet to be used for signing the transaction.
       ) const = 0;
 
   //! \brief Builds a brand new block.
   virtual std::shared_ptr<const CBlock> BuildBlock(
-      const CBlockIndex &index,                 //!< The previous block / current tip.
-      const uint256 &snapshot_hash,             //!< The snapshot hash to be included in the new block.
-      const EligibleCoin &stake_coin,           //!< The coin to use as stake.
-      const staking::CoinSet &coins,            //!< Other coins to combine with the stake.
-      const std::vector<CTransactionRef> &txs,  //!< Transactions to include in the block.
-      CAmount,                                  //!< The fees on the transactions.
-      staking::StakingWallet &                  //!< A wallet used to sign blocks and stake.
+      const CBlockIndex &index,                         //!< The previous block / current tip.
+      const uint256 &snapshot_hash,                     //!< The snapshot hash to be included in the new block.
+      const EligibleCoin &stake_coin,                   //!< The coin to use as stake.
+      const staking::CoinSet &coins,                    //!< Other coins to combine with the stake.
+      const std::vector<CTransactionRef> &txs,          //!< Transactions to include in the block.
+      CAmount fees,                                     //!< The fees on the transactions.
+      const boost::optional<CScript> &coinbase_script,  //!< The scriptpubkey to be used for the coinbase reward and fees.
+      staking::StakingWallet &wallet                    //!< A wallet used to sign blocks and stake.
       ) const = 0;
 
   virtual ~BlockBuilder() = default;

--- a/src/proposer/proposer.cpp
+++ b/src/proposer/proposer.cpp
@@ -66,8 +66,8 @@ static std::shared_ptr<const CBlock> GenerateBlock(staking::ActiveChain &active_
 class PassiveProposerImpl : public Proposer {
  private:
   const Dependency<staking::ActiveChain> m_active_chain;
-  const Dependency<staking::TransactionPicker> m_transaction_picker;
   const Dependency<proposer::BlockBuilder> m_block_builder;
+  const Dependency<staking::TransactionPicker> m_transaction_picker;
   const Dependency<proposer::Logic> m_proposer_logic;
 
  public:
@@ -166,7 +166,6 @@ class ActiveProposerImpl : public Proposer {
           // To pick up to date coins for staking we need to make sure that the wallet is synced to the current chain.
           wallet->BlockUntilSyncedToCurrentChain();
           LOCK2(m_active_chain->GetLock(), wallet_ext.GetLock());
-          const CBlockIndex &tip = *m_active_chain->GetTip();
           const staking::CoinSet coins = wallet_ext.GetStakeableCoins();
           if (coins.empty()) {
             LogPrint(BCLog::PROPOSING, "Not proposing, not enough balance (wallet=%s)\n", wallet_name);
@@ -185,7 +184,7 @@ class ActiveProposerImpl : public Proposer {
           LogPrint(BCLog::PROPOSING, "Failed to assemble block.\n");
           continue;
         }
-        const std::string &hash = block->GetHash().GetHex();
+        const std::string hash = block->GetHash().GetHex();
         if (!m_active_chain->ProposeBlock(block)) {
           LogPrint(BCLog::PROPOSING, "Failed to propose block (hash=%s).\n", hash);
           continue;

--- a/src/proposer/proposer.cpp
+++ b/src/proposer/proposer.cpp
@@ -6,6 +6,7 @@
 #include <proposer/proposer.h>
 
 #include <chainparams.h>
+#include <key_io.h>
 #include <net.h>
 #include <proposer/block_builder.h>
 #include <proposer/multiwallet.h>
@@ -29,15 +30,83 @@
 
 namespace proposer {
 
-class ProposerStub : public Proposer {
+bool GenerateBlock(staking::ActiveChain &active_chain,
+                   staking::TransactionPicker &transaction_picker,
+                   proposer::BlockBuilder &block_builder,
+                   proposer::Logic &logic,
+                   CWallet *wallet,
+                   const CBlockIndex &tip,
+                   const staking::CoinSet &coins,
+                   const boost::optional<CScript> &coinbase_script,
+                   std::shared_ptr<const CBlock> &block_out) {
+
+  auto &wallet_ext = wallet->GetWalletExtension();
+  const auto wallet_name = wallet->GetName();
+
+  const boost::optional<EligibleCoin> &winning_ticket = logic.TryPropose(coins);
+  if (!winning_ticket) {
+    LogPrint(BCLog::PROPOSING, "Not proposing this time (wallet=%s)\n", wallet_name);
+    return false;
+  }
+  const EligibleCoin &coin = winning_ticket.get();
+  LogPrint(BCLog::PROPOSING, "Proposing... (wallet=%s, coin=%s)\n",
+           wallet_name, util::to_string(coin.utxo));
+  staking::TransactionPicker::PickTransactionsParameters parameters{};
+  staking::TransactionPicker::PickTransactionsResult result =
+      transaction_picker.PickTransactions(parameters);
+
+  if (!result) {
+    LogPrint(BCLog::PROPOSING, "Failed to pick transactions (wallet=%s, error=%s) – proposing empty block.\n", wallet_name, result.error);
+  }
+  const CAmount fees = std::accumulate(result.fees.begin(), result.fees.end(), CAmount(0));
+  const uint256 snapshot_hash = active_chain.ComputeSnapshotHash();
+
+  block_out = block_builder.BuildBlock(
+      tip, snapshot_hash, coin, coins, result.transactions, fees, coinbase_script, wallet_ext);
+
+  return block_out != nullptr;
+}
+
+class PassiveProposerImpl : public Proposer {
+ private:
+  const Dependency<staking::ActiveChain> m_active_chain;
+  const Dependency<staking::TransactionPicker> m_transaction_picker;
+  const Dependency<proposer::BlockBuilder> m_block_builder;
+  const Dependency<proposer::Logic> m_proposer_logic;
+
  public:
+  PassiveProposerImpl(Dependency<staking::ActiveChain> const active_chain,
+                      Dependency<proposer::BlockBuilder> const block_builder,
+                      Dependency<staking::TransactionPicker> const transaction_picker,
+                      Dependency<proposer::Logic> const proposer_logic)
+      : m_active_chain(active_chain),
+        m_block_builder(block_builder),
+        m_transaction_picker(transaction_picker),
+        m_proposer_logic(proposer_logic) {}
+
   void Wake() override {}
   void Start() override {}
   void Stop() override {}
   bool IsStarted() override { return false; }
+  bool GenerateBlock(CWallet *wallet,
+                     const CBlockIndex &tip,
+                     const staking::CoinSet &coins,
+                     const boost::optional<CScript> &coinbase_script,
+                     std::shared_ptr<const CBlock> &block_out) override {
+
+    return proposer::GenerateBlock(*m_active_chain,
+                                   *m_transaction_picker,
+                                   *m_block_builder,
+                                   *m_proposer_logic,
+                                   wallet,
+                                   tip,
+                                   coins,
+                                   coinbase_script,
+                                   block_out);
+  }
 };
 
-class ProposerImpl : public Proposer {
+class ActiveProposerImpl : public Proposer {
  private:
   static constexpr const char *THREAD_NAME = "unite-proposer";
 
@@ -89,7 +158,7 @@ class ProposerImpl : public Proposer {
         SetStatusOfAllWallets(Status::NOT_PROPOSING_SYNCING_BLOCKCHAIN);
         continue;
       }
-      for (auto wallet : m_multi_wallet->GetWallets()) {
+      for (const auto &wallet : m_multi_wallet->GetWallets()) {
         auto &wallet_ext = wallet->GetWalletExtension();
         const auto wallet_name = wallet->GetName();
         if (wallet->IsLocked()) {
@@ -114,26 +183,7 @@ class ProposerImpl : public Proposer {
           }
           wallet_ext.GetProposerState().m_status = Status::IS_PROPOSING;
           wallet_ext.GetProposerState().m_number_of_search_attempts += 1;
-          const boost::optional<EligibleCoin> &winning_ticket = m_proposer_logic->TryPropose(coins);
-          if (!winning_ticket) {
-            LogPrint(BCLog::PROPOSING, "Not proposing this time (wallet=%s)\n", wallet_name);
-            continue;
-          }
-          const EligibleCoin &coin = winning_ticket.get();
-          LogPrint(BCLog::PROPOSING, "Proposing... (wallet=%s, coin=%s)\n",
-                   wallet_name, util::to_string(coin.utxo));
-          staking::TransactionPicker::PickTransactionsParameters parameters{};
-          staking::TransactionPicker::PickTransactionsResult result =
-              m_transaction_picker->PickTransactions(parameters);
-
-          if (!result) {
-            LogPrint(BCLog::PROPOSING, "Failed to pick transactions (wallet=%s, error=%s) – proposing empty block.\n", wallet_name, result.error);
-          }
-          const CAmount fees = std::accumulate(result.fees.begin(), result.fees.end(), CAmount(0));
-          const uint256 snapshot_hash = m_active_chain->ComputeSnapshotHash();
-
-          block = m_block_builder->BuildBlock(
-              tip, snapshot_hash, coin, coins, result.transactions, fees, wallet_ext);
+          GenerateBlock(wallet.get(), tip, coins, boost::none, block);
         }
         wallet_ext.GetProposerState().m_number_of_searches += 1;
         if (m_interrupted) {
@@ -157,13 +207,13 @@ class ProposerImpl : public Proposer {
   }
 
  public:
-  ProposerImpl(const Dependency<blockchain::Behavior> blockchain_behavior,
-               const Dependency<MultiWallet> multi_wallet,
-               const Dependency<staking::Network> network,
-               const Dependency<staking::ActiveChain> active_chain,
-               const Dependency<staking::TransactionPicker> transaction_picker,
-               const Dependency<proposer::BlockBuilder> block_builder,
-               const Dependency<proposer::Logic> proposer_logic)
+  ActiveProposerImpl(const Dependency<blockchain::Behavior> blockchain_behavior,
+                     const Dependency<MultiWallet> multi_wallet,
+                     const Dependency<staking::Network> network,
+                     const Dependency<staking::ActiveChain> active_chain,
+                     const Dependency<staking::TransactionPicker> transaction_picker,
+                     const Dependency<proposer::BlockBuilder> block_builder,
+                     const Dependency<proposer::Logic> proposer_logic)
       : m_blockchain_behavior(blockchain_behavior),
         m_multi_wallet(multi_wallet),
         m_network(network),
@@ -178,13 +228,30 @@ class ProposerImpl : public Proposer {
     m_waiter.Wake();
   }
 
+  bool GenerateBlock(CWallet *wallet,
+                     const CBlockIndex &tip,
+                     const staking::CoinSet &coins,
+                     const boost::optional<CScript> &coinbase_script,
+                     std::shared_ptr<const CBlock> &block_out) override {
+
+    return proposer::GenerateBlock(*m_active_chain,
+                                   *m_transaction_picker,
+                                   *m_block_builder,
+                                   *m_proposer_logic,
+                                   wallet,
+                                   tip,
+                                   coins,
+                                   boost::none,
+                                   block_out);
+  }
+
   void Start() override {
     LOCK(m_startstop_lock);
     if (m_state != INITIALIZED) {
       LogPrint(BCLog::PROPOSING, "Proposer already started, not starting again.\n");
       return;
     }
-    m_thread = std::thread(&ProposerImpl::Run, this);
+    m_thread = std::thread(&ActiveProposerImpl::Run, this);
     m_state = STARTED;
   }
 
@@ -205,7 +272,7 @@ class ProposerImpl : public Proposer {
     return m_state == STARTED;
   }
 
-  ~ProposerImpl() override {
+  ~ActiveProposerImpl() override {
     Stop();
   };
 };
@@ -220,9 +287,9 @@ std::unique_ptr<Proposer> Proposer::New(
     const Dependency<BlockBuilder> block_builder,
     const Dependency<Logic> proposer_logic) {
   if (settings->node_is_proposer) {
-    return std::unique_ptr<Proposer>(new ProposerImpl(behavior, multi_wallet, network, active_chain, transaction_picker, block_builder, proposer_logic));
+    return std::unique_ptr<Proposer>(new ActiveProposerImpl(behavior, multi_wallet, network, active_chain, transaction_picker, block_builder, proposer_logic));
   } else {
-    return std::unique_ptr<Proposer>(new ProposerStub());
+    return std::unique_ptr<Proposer>(new PassiveProposerImpl(active_chain, block_builder, transaction_picker, proposer_logic));
   }
 }
 

--- a/src/proposer/proposer.cpp
+++ b/src/proposer/proposer.cpp
@@ -175,7 +175,13 @@ class ActiveProposerImpl : public Proposer {
           }
           wallet_ext.GetProposerState().m_status = Status::IS_PROPOSING;
           wallet_ext.GetProposerState().m_number_of_search_attempts += 1;
-          block = GenerateBlock(wallet->GetWalletExtension(), coins, boost::none);
+          block = proposer::GenerateBlock(*m_active_chain,
+                                          *m_transaction_picker,
+                                          *m_block_builder,
+                                          *m_proposer_logic,
+                                          wallet_ext,
+                                          coins,
+                                          boost::none /* coinbase_script */);
         }
         wallet_ext.GetProposerState().m_number_of_searches += 1;
         if (m_interrupted) {
@@ -224,13 +230,7 @@ class ActiveProposerImpl : public Proposer {
                                               const staking::CoinSet &coins,
                                               const boost::optional<CScript> &) override {
 
-    return proposer::GenerateBlock(*m_active_chain,
-                                   *m_transaction_picker,
-                                   *m_block_builder,
-                                   *m_proposer_logic,
-                                   wallet,
-                                   coins,
-                                   boost::none /* coinbase_script */);
+    assert(!"GenerateBlock not supported for active proposer.");
   }
 
   void Start() override {

--- a/src/proposer/proposer.cpp
+++ b/src/proposer/proposer.cpp
@@ -210,10 +210,10 @@ class ActiveProposerImpl : public Proposer {
         m_transaction_picker(transaction_picker),
         m_block_builder(block_builder),
         m_proposer_logic(proposer_logic),
-        m_interrupted(false),
         m_blockchain_behavior(blockchain_behavior),
         m_multi_wallet(multi_wallet),
-        m_network(network) {
+        m_network(network),
+        m_interrupted(false) {
   }
 
   void Wake() override {

--- a/src/proposer/proposer.h
+++ b/src/proposer/proposer.h
@@ -42,11 +42,9 @@ class Proposer {
 
   virtual bool IsStarted() = 0;
 
-  virtual bool GenerateBlock(CWallet *wallet,
-                             const CBlockIndex &tip,
-                             const staking::CoinSet &coins,
-                             const boost::optional<CScript> &coinbase_script,
-                             std::shared_ptr<const CBlock> &block_out) = 0;
+  virtual std::shared_ptr<const CBlock> GenerateBlock(CWallet &wallet,
+                                                      const staking::CoinSet &coins,
+                                                      const boost::optional<CScript> &coinbase_script) = 0;
 
   virtual ~Proposer() = default;
 

--- a/src/proposer/proposer.h
+++ b/src/proposer/proposer.h
@@ -7,9 +7,13 @@
 
 #include <dependency.h>
 
+#include <chain.h>
+#include <primitives/block.h>
+#include <staking/coin.h>
 #include <memory>
 
 struct Settings;
+class CWallet;
 
 namespace blockchain {
 class Behavior;
@@ -37,6 +41,12 @@ class Proposer {
   virtual void Stop() = 0;
 
   virtual bool IsStarted() = 0;
+
+  virtual bool GenerateBlock(CWallet *wallet,
+                             const CBlockIndex &tip,
+                             const staking::CoinSet &coins,
+                             const boost::optional<CScript> &coinbase_script,
+                             std::shared_ptr<const CBlock> &block_out) = 0;
 
   virtual ~Proposer() = default;
 

--- a/src/proposer/proposer.h
+++ b/src/proposer/proposer.h
@@ -6,6 +6,7 @@
 #define UNITE_PROPOSER_PROPOSER_H
 
 #include <dependency.h>
+#include <staking/stakingwallet.h>
 
 #include <chain.h>
 #include <primitives/block.h>
@@ -42,7 +43,7 @@ class Proposer {
 
   virtual bool IsStarted() = 0;
 
-  virtual std::shared_ptr<const CBlock> GenerateBlock(CWallet &wallet,
+  virtual std::shared_ptr<const CBlock> GenerateBlock(staking::StakingWallet &wallet,
                                                       const staking::CoinSet &coins,
                                                       const boost::optional<CScript> &coinbase_script) = 0;
 

--- a/src/proposer/proposer_logic.cpp
+++ b/src/proposer/proposer_logic.cpp
@@ -48,8 +48,11 @@ class LogicImpl final : public Logic {
     if (!current_tip) {
       return boost::none;
     }
-    const blockchain::Height current_height = m_active_chain->GetHeight();
-    const blockchain::Height target_height = current_height + 1;
+
+    const blockchain::Height current_height =
+        m_active_chain->GetHeight();
+    const blockchain::Height target_height =
+        current_height + 1;
 
     int64_t best_time = std::max(m_active_chain->GetTip()->GetMedianTimePast() + 1, m_network->GetTime());
     const blockchain::Time target_time =

--- a/src/proposer/proposer_logic.cpp
+++ b/src/proposer/proposer_logic.cpp
@@ -44,7 +44,8 @@ class LogicImpl final : public Logic {
   boost::optional<proposer::EligibleCoin> TryPropose(const staking::CoinSet &eligible_coins) override {
     AssertLockHeld(m_active_chain->GetLock());
 
-    const CBlockIndex *current_tip = m_active_chain->GetTip();
+    const CBlockIndex *current_tip =
+        m_active_chain->GetTip();
     if (!current_tip) {
       return boost::none;
     }

--- a/src/proposer/proposer_logic.cpp
+++ b/src/proposer/proposer_logic.cpp
@@ -44,15 +44,14 @@ class LogicImpl final : public Logic {
   boost::optional<proposer::EligibleCoin> TryPropose(const staking::CoinSet &eligible_coins) override {
     AssertLockHeld(m_active_chain->GetLock());
 
-    const CBlockIndex *current_tip =
-        m_active_chain->GetTip();
+    const CBlockIndex *current_tip = m_active_chain->GetTip();
     if (!current_tip) {
       return boost::none;
     }
-    const blockchain::Height current_height =
-        m_active_chain->GetHeight();
-    const blockchain::Height target_height =
-        current_height + 1;
+    const blockchain::Height current_height = m_active_chain->GetHeight();
+    const blockchain::Height target_height = current_height + 1;
+
+    int64_t best_time = std::max(m_active_chain->GetTip()->GetMedianTimePast() + 1, m_network->GetTime());
     const blockchain::Time target_time =
         m_blockchain_behavior->CalculateProposingTimestampAfter(m_network->GetTime());
     const blockchain::Difficulty target_difficulty =
@@ -60,16 +59,22 @@ class LogicImpl final : public Logic {
 
     for (const staking::Coin &coin : eligible_coins) {
       const uint256 kernel_hash = m_stake_validator->ComputeKernelHash(current_tip, coin, target_time);
-      if (m_stake_validator->CheckKernel(coin.GetAmount(), kernel_hash, target_difficulty)) {
-        const CAmount reward = m_blockchain_behavior->CalculateBlockReward(
-            target_height);
-        return {{coin,
-                 kernel_hash,
-                 reward,
-                 target_height,
-                 target_time,
-                 target_difficulty}};
+
+      if (!m_stake_validator->CheckKernel(coin.GetAmount(), kernel_hash, target_difficulty)) {
+        if (m_blockchain_behavior->GetParameters().mine_blocks_on_demand) {
+          LogPrint(BCLog::VALIDATION, "Letting artificial block generation succeed nevertheless (mine_blocks_on_demand=true)\n");
+        } else {
+          continue;
+        }
       }
+
+      const CAmount reward = m_blockchain_behavior->CalculateBlockReward(target_height);
+      return {{coin,
+               kernel_hash,
+               reward,
+               target_height,
+               target_time,
+               target_difficulty}};
     }
     return boost::none;
   }

--- a/src/proposer/proposer_logic.cpp
+++ b/src/proposer/proposer_logic.cpp
@@ -53,7 +53,7 @@ class LogicImpl final : public Logic {
 
     int64_t best_time = std::max(m_active_chain->GetTip()->GetMedianTimePast() + 1, m_network->GetTime());
     const blockchain::Time target_time =
-        m_blockchain_behavior->CalculateProposingTimestampAfter(m_network->GetTime());
+        m_blockchain_behavior->CalculateProposingTimestampAfter(best_time);
     const blockchain::Difficulty target_difficulty =
         m_blockchain_behavior->CalculateDifficulty(target_height, *m_active_chain);
 

--- a/src/proposer/proposer_logic.cpp
+++ b/src/proposer/proposer_logic.cpp
@@ -55,7 +55,7 @@ class LogicImpl final : public Logic {
     const blockchain::Height target_height =
         current_height + 1;
 
-    int64_t best_time = std::max(m_active_chain->GetTip()->GetMedianTimePast() + 1, m_network->GetTime());
+    int64_t best_time = std::max(current_tip->GetMedianTimePast() + 1, m_network->GetTime());
     const blockchain::Time target_time =
         m_blockchain_behavior->CalculateProposingTimestampAfter(best_time);
     const blockchain::Difficulty target_difficulty =

--- a/src/proposer/proposer_logic.cpp
+++ b/src/proposer/proposer_logic.cpp
@@ -55,7 +55,7 @@ class LogicImpl final : public Logic {
     const blockchain::Height target_height =
         current_height + 1;
 
-    int64_t best_time = std::max(current_tip->GetMedianTimePast() + 1, m_network->GetTime());
+    const int64_t best_time = std::max(current_tip->GetMedianTimePast() + 1, m_network->GetTime());
     const blockchain::Time target_time =
         m_blockchain_behavior->CalculateProposingTimestampAfter(best_time);
     const blockchain::Difficulty target_difficulty =
@@ -66,7 +66,7 @@ class LogicImpl final : public Logic {
 
       if (!m_stake_validator->CheckKernel(coin.GetAmount(), kernel_hash, target_difficulty)) {
         if (m_blockchain_behavior->GetParameters().mine_blocks_on_demand) {
-          LogPrint(BCLog::VALIDATION, "Letting artificial block generation succeed nevertheless (mine_blocks_on_demand=true)\n");
+          LogPrint(BCLog::PROPOSING, "Letting artificial block generation succeed nevertheless (mine_blocks_on_demand=true)\n");
         } else {
           continue;
         }

--- a/src/proposer/proposer_rpc.cpp
+++ b/src/proposer/proposer_rpc.cpp
@@ -177,11 +177,6 @@ class ProposerRPCImpl : public ProposerRPC {
 
     proposer::Proposer *proposer = GetComponent<proposer::Proposer>();
 
-    staking::ActiveChain *active_chain;
-    {  // Don't keep cs_main locked
-      LOCK(cs_main);
-      active_chain = GetComponent<staking::ActiveChain>();
-    }
     UniValue block_hashes(UniValue::VARR);
 
     // To pick up to date coins for staking we need to make sure that the wallet is synced to the current chain.
@@ -229,7 +224,7 @@ class ProposerRPCImpl : public ProposerRPC {
     }
     assert(pwallet);
 
-    if (request.fHelp || request.params.size() < 1 || request.params.size() > 2) {
+    if (request.fHelp || request.params.size() != 1) {
       throw std::runtime_error(
           "propose nblocks ( maxtries )\n"
           "\nPropose up to nblocks blocks immediately (before the RPC call returns) to an address in the wallet.\n"
@@ -261,7 +256,7 @@ class ProposerRPCImpl : public ProposerRPC {
     }
     assert(pwallet);
 
-    if (request.fHelp || request.params.size() < 2 || request.params.size() > 3)
+    if (request.fHelp || request.params.size() != 2)
       throw std::runtime_error(
           "proposetoaddress nblocks address (maxtries)\n"
           "\nProposer blocks immediately to a specified address (before the RPC call returns)\n"

--- a/src/proposer/proposer_rpc.cpp
+++ b/src/proposer/proposer_rpc.cpp
@@ -220,7 +220,7 @@ class ProposerRPCImpl : public ProposerRPC {
     return block_hashes;
   }
 
-  UniValue propose(const JSONRPCRequest &request) const {
+  UniValue propose(const JSONRPCRequest &request) const override {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet *const pwallet = wallet.get();
 
@@ -252,7 +252,7 @@ class ProposerRPCImpl : public ProposerRPC {
     return ProposeBlocks(*pwallet, boost::none, num_generate);
   }
 
-  UniValue proposetoaddress(const JSONRPCRequest &request) const {
+  UniValue proposetoaddress(const JSONRPCRequest &request) const override {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet *const pwallet = wallet.get();
 

--- a/src/proposer/proposer_rpc.cpp
+++ b/src/proposer/proposer_rpc.cpp
@@ -196,8 +196,13 @@ class ProposerRPCImpl : public ProposerRPC {
                              "Not proposing, not enough balance.");
         }
 
+        // We don't want to combine coins when we use the rpc, so we don't need
+        // to pass all of them.
+        staking::CoinSet first_coin;
+        first_coin.insert(*stakeable_coins.begin());
+
         block = proposer->GenerateBlock(wallet,
-                                        stakeable_coins,
+                                        first_coin,
                                         coinbase_script);
         if (!block) {
           throw JSONRPCError(RPC_INTERNAL_ERROR, "Failed to generate a block.");

--- a/src/proposer/proposer_rpc.cpp
+++ b/src/proposer/proposer_rpc.cpp
@@ -198,8 +198,7 @@ class ProposerRPCImpl : public ProposerRPC {
 
         // We don't want to combine coins when we use the rpc, so we don't need
         // to pass all of them.
-        staking::CoinSet first_coin;
-        first_coin.insert(*stakeable_coins.begin());
+        const staking::CoinSet first_coin = {*stakeable_coins.begin()};
 
         block = proposer->GenerateBlock(wallet,
                                         first_coin,

--- a/src/proposer/proposer_rpc.h
+++ b/src/proposer/proposer_rpc.h
@@ -6,6 +6,7 @@
 #define UNIT_E_PROPOSER_RPC_H
 
 #include <dependency.h>
+#include <settings.h>
 
 #include <univalue.h>
 
@@ -47,6 +48,7 @@ class ProposerRPC {
   virtual ~ProposerRPC() = default;
 
   static std::unique_ptr<ProposerRPC> New(
+      Dependency<Settings> settings,
       Dependency<MultiWallet>,
       Dependency<staking::Network>,
       Dependency<staking::ActiveChain>,

--- a/src/proposer/proposer_rpc.h
+++ b/src/proposer/proposer_rpc.h
@@ -28,7 +28,7 @@ class Proposer;
 //! Usually RPC commands are statically bound by referencing function pointers.
 //! For the proposer RPC commands to be part of the dependency injector a
 //! proper module is defined and the commands are bound slightly differently
-//! (see rpc/proposer.cpp).
+//! (see rpc/proposing.cpp).
 //!
 //! This class is an interface.
 class ProposerRPC {
@@ -39,6 +39,10 @@ class ProposerRPC {
   virtual UniValue proposerwake(const JSONRPCRequest &request) const = 0;
 
   virtual UniValue liststakeablecoins(const JSONRPCRequest &request) const = 0;
+
+  virtual UniValue propose(const JSONRPCRequest &request) const = 0;
+
+  virtual UniValue proposetoaddress(const JSONRPCRequest &request) const = 0;
 
   virtual ~ProposerRPC() = default;
 

--- a/src/rpc/parameter_conversion.cpp
+++ b/src/rpc/parameter_conversion.cpp
@@ -194,6 +194,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "tracestake", 0, "start" },
     { "tracestake", 1, "length" },
     { "tracestake", 2, "reverse" },
+
+    { "propose", 0, "nblocks" },
+    { "proposetoaddress", 0, "nblocks" },
 };
 
 class CRPCConvertTable

--- a/src/rpc/proposing.cpp
+++ b/src/rpc/proposing.cpp
@@ -19,8 +19,8 @@
   t.appendCommand(NAME.name, &NAME);
 
 void RegisterProposerRPCCommands(CRPCTable &t) {
-  PROPOSER_RPC_COMMAND(propose);
-  PROPOSER_RPC_COMMAND(proposetoaddress);
+  PROPOSER_RPC_COMMAND(propose, "nblocks");
+  PROPOSER_RPC_COMMAND(proposetoaddress, "nblocks", "address");
   PROPOSER_RPC_COMMAND(liststakeablecoins);
   PROPOSER_RPC_COMMAND(proposerstatus);
   PROPOSER_RPC_COMMAND(proposerwake);

--- a/src/rpc/proposing.cpp
+++ b/src/rpc/proposing.cpp
@@ -19,6 +19,8 @@
   t.appendCommand(NAME.name, &NAME);
 
 void RegisterProposerRPCCommands(CRPCTable &t) {
+  PROPOSER_RPC_COMMAND(propose);
+  PROPOSER_RPC_COMMAND(proposetoaddress);
   PROPOSER_RPC_COMMAND(liststakeablecoins);
   PROPOSER_RPC_COMMAND(proposerstatus);
   PROPOSER_RPC_COMMAND(proposerwake);

--- a/src/staking/block_validator.cpp
+++ b/src/staking/block_validator.cpp
@@ -156,10 +156,19 @@ class BlockValidatorImpl : public AbstractBlockValidator {
     if (block_header.hashPrevBlock != *previous_block.phashBlock) {
       result.AddError(Error::PREVIOUS_BLOCK_DOESNT_MATCH);
     }
-    if (block_header.GetBlockTime() <= previous_block.GetMedianTimePast()) {
+
+    const int64_t block_time = block_header.GetBlockTime();
+
+    if (block_time < previous_block.GetMedianTimePast()) {
       result.AddError(Error::BLOCKTIME_TOO_EARLY);
     }
-    if (block_header.GetBlockTime() > adjusted_time + m_blockchain_behavior->GetParameters().max_future_block_time_seconds) {
+
+    const bool on_demand = m_blockchain_behavior->GetParameters().mine_blocks_on_demand;
+    if (!on_demand && block_time == previous_block.GetMedianTimePast()) {
+      result.AddError(Error::BLOCKTIME_TOO_EARLY);
+    }
+
+    if (block_time > adjusted_time + m_blockchain_behavior->GetParameters().max_future_block_time_seconds) {
       result.AddError(Error::BLOCKTIME_TOO_FAR_INTO_FUTURE);
     }
   }

--- a/src/staking/block_validator.cpp
+++ b/src/staking/block_validator.cpp
@@ -159,12 +159,7 @@ class BlockValidatorImpl : public AbstractBlockValidator {
 
     const int64_t block_time = block_header.GetBlockTime();
 
-    if (block_time < previous_block.GetMedianTimePast()) {
-      result.AddError(Error::BLOCKTIME_TOO_EARLY);
-    }
-
-    const bool on_demand = m_blockchain_behavior->GetParameters().mine_blocks_on_demand;
-    if (!on_demand && block_time == previous_block.GetMedianTimePast()) {
+    if (block_time <= previous_block.GetMedianTimePast()) {
       result.AddError(Error::BLOCKTIME_TOO_EARLY);
     }
 

--- a/src/test/esperanza/walletextension_tests.cpp
+++ b/src/test/esperanza/walletextension_tests.cpp
@@ -138,7 +138,7 @@ BOOST_FIXTURE_TEST_CASE(sign_coinbase_transaction, WalletTestingSetup) {
 
   // BuildCoinbaseTransaction() will also sign it
   CTransactionRef coinbase_transaction =
-      block_builder->BuildCoinbaseTransaction(uint256(), eligible_coin, coins, 700, m_wallet->GetWalletExtension());
+      block_builder->BuildCoinbaseTransaction(uint256(), eligible_coin, coins, 700, boost::none, m_wallet->GetWalletExtension());
 
   // check that a coinbase transaction was built successfully
   BOOST_REQUIRE(static_cast<bool>(coinbase_transaction));

--- a/src/test/proposer/block_builder_tests.cpp
+++ b/src/test/proposer/block_builder_tests.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(build_block_and_validate) {
   CAmount fees(0);
 
   auto block = builder->BuildBlock(
-      current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, f.wallet);
+      current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, boost::none, f.wallet);
   BOOST_REQUIRE(static_cast<bool>(block));
   auto is_valid = validator->CheckBlock(*block, nullptr);
   BOOST_CHECK(is_valid);
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE(split_amount) {
     CAmount fees(0);
 
     std::shared_ptr<const CBlock> block = builder->BuildBlock(
-        current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, f.wallet);
+        current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, boost::none, f.wallet);
     BOOST_REQUIRE(static_cast<bool>(block));
     const staking::BlockValidationResult is_valid = validator->CheckBlock(*block, nullptr);
     // must have a coinbase transaction
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE(check_reward_destination) {
   CAmount fees(5);
 
   std::shared_ptr<const CBlock> block = builder->BuildBlock(
-      current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, f.wallet);
+      current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, boost::none, f.wallet);
   BOOST_REQUIRE(static_cast<bool>(block));
   const staking::BlockValidationResult is_valid = validator->CheckBlock(*block, nullptr);
   BOOST_CHECK(static_cast<bool>(is_valid));
@@ -267,7 +267,7 @@ BOOST_AUTO_TEST_CASE(combine_stake) {
   CAmount fees(0);
 
   std::shared_ptr<const CBlock> block = builder->BuildBlock(
-      current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, f.wallet);
+      current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, boost::none, f.wallet);
   BOOST_REQUIRE(static_cast<bool>(block));
   const staking::BlockValidationResult is_valid = validator->CheckBlock(*block, nullptr);
   BOOST_CHECK(static_cast<bool>(is_valid));
@@ -324,7 +324,7 @@ BOOST_AUTO_TEST_CASE(remote_staking) {
     staking::CoinSet coins{eligible_coin.utxo, coin1, coin2};
 
     std::shared_ptr<const CBlock> block = builder->BuildBlock(
-        current_tip, f.snapshot_hash, eligible_coin, coins, transactions, fees, f.wallet);
+        current_tip, f.snapshot_hash, eligible_coin, coins, transactions, fees, boost::none, f.wallet);
     BOOST_REQUIRE(static_cast<bool>(block));
     const staking::BlockValidationResult is_valid = validator->CheckBlock(*block, nullptr);
     BOOST_CHECK(static_cast<bool>(is_valid));
@@ -348,7 +348,7 @@ BOOST_AUTO_TEST_CASE(remote_staking) {
     staking::CoinSet coins{f.eligible_coin.utxo, coin1, coin2, rs_coin1, rs_coin2};
 
     std::shared_ptr<const CBlock> block = builder->BuildBlock(
-        current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, f.wallet);
+        current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, boost::none, f.wallet);
     BOOST_REQUIRE(static_cast<bool>(block));
     const staking::BlockValidationResult is_valid = validator->CheckBlock(*block, nullptr);
     BOOST_CHECK(static_cast<bool>(is_valid));

--- a/src/test/proposer/proposer_tests.cpp
+++ b/src/test/proposer/proposer_tests.cpp
@@ -118,6 +118,7 @@ struct Fixture {
         const proposer::EligibleCoin &,
         const staking::CoinSet &,
         CAmount,
+        const boost::optional<CScript> &coinbase_script,
         staking::StakingWallet &) const override { return nullptr; };
     std::shared_ptr<const CBlock> BuildBlock(
         const CBlockIndex &,
@@ -126,6 +127,7 @@ struct Fixture {
         const staking::CoinSet &,
         const std::vector<CTransactionRef> &,
         const CAmount,
+        const boost::optional<CScript> &coinbase_script,
         staking::StakingWallet &) const override { return nullptr; }
   };
 

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -736,7 +736,7 @@ class FullBlockTest(UnitETestFramework):
 
         self.log.info("Reject a block with timestamp before MedianTimePast")
         b54 = self.next_block(54, self.get_staking_coin(), spend=out[15])
-        b54.nTime = b33.nTime - 1
+        b54.nTime = b35.nTime - 1
         b54.solve()
         self.sync_blocks([b54], False, request_block=False)
         self.comp_snapshot_hash(44)

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -736,7 +736,7 @@ class FullBlockTest(UnitETestFramework):
 
         self.log.info("Reject a block with timestamp before MedianTimePast")
         b54 = self.next_block(54, self.get_staking_coin(), spend=out[15])
-        b54.nTime = b35.nTime - 1
+        b54.nTime = b33.nTime - 1
         b54.solve()
         self.sync_blocks([b54], False, request_block=False)
         self.comp_snapshot_hash(44)

--- a/test/functional/proposer_settings.py
+++ b/test/functional/proposer_settings.py
@@ -27,7 +27,7 @@ class ProposerSettingsTest(UnitETestFramework):
         assert_equal(self.nodes[1].proposerstatus()['wallets'][0]['status'], 'NOT_PROPOSING')
 
         # Leave IBD
-        self.nodes[2].generatetoaddress(1, self.nodes[2].getnewaddress("", "legacy"))
+        self.nodes[2].proposetoaddress(1, self.nodes[2].getnewaddress("", "legacy"))
 
         # If we pass -proposing=1 then the node should propose
         wait_until(lambda: self.nodes[2].proposerstatus()['wallets'][0]['status'] == "IS_PROPOSING", timeout=150)

--- a/test/functional/proposer_settings.py
+++ b/test/functional/proposer_settings.py
@@ -27,7 +27,7 @@ class ProposerSettingsTest(UnitETestFramework):
         assert_equal(self.nodes[1].proposerstatus()['wallets'][0]['status'], 'NOT_PROPOSING')
 
         # Leave IBD
-        self.nodes[2].proposetoaddress(1, self.nodes[2].getnewaddress("", "legacy"))
+        self.nodes[0].proposetoaddress(1, self.nodes[2].getnewaddress("", "legacy"))
 
         # If we pass -proposing=1 then the node should propose
         wait_until(lambda: self.nodes[2].proposerstatus()['wallets'][0]['status'] == "IS_PROPOSING", timeout=150)

--- a/test/functional/proposer_stake_maturity.py
+++ b/test/functional/proposer_stake_maturity.py
@@ -120,9 +120,9 @@ class ProposerStakeMaturityTest(UnitETestFramework):
         self.setup_stake_coins(*self.nodes)
 
         # Generate stakeable outputs on both nodes
-        nodes[0].generatetoaddress(1, nodes[0].getnewaddress('', 'bech32'))
+        nodes[0].proposetoaddress(1, nodes[0].getnewaddress('', 'bech32'))
         sync_blocks(nodes)
-        nodes[1].generatetoaddress(1, nodes[1].getnewaddress('', 'bech32'))
+        nodes[1].proposetoaddress(1, nodes[1].getnewaddress('', 'bech32'))
         sync_blocks(nodes)
 
         # Current chain length doesn't overcome stake threshold, so
@@ -131,21 +131,21 @@ class ProposerStakeMaturityTest(UnitETestFramework):
             self.check_node_balance(nodes[i], 10000, 10000)
 
         # Generate another block to overcome the stake threshold
-        nodes[0].generatetoaddress(1, nodes[0].getnewaddress('', 'bech32'))
+        nodes[0].proposetoaddress(1, nodes[0].getnewaddress('', 'bech32'))
         sync_blocks(nodes)
 
         # Maturity check in action and we have one immature stake output
         self.check_node_balance(nodes[0], 10000, 9000)
 
-        # Let's go further and generate yet another block
-        nodes[0].generatetoaddress(1, nodes[0].getnewaddress('', 'bech32'))
+        # Let's go further and propose yet another block
+        nodes[0].proposetoaddress(1, nodes[0].getnewaddress('', 'bech32'))
         sync_blocks(nodes)
 
         # Now we have two immature stake outputs
         self.check_node_balance(nodes[0], 10000, 8000)
 
         # Generate two more blocks at another node
-        nodes[1].generatetoaddress(2, nodes[1].getnewaddress('', 'bech32'))
+        nodes[1].proposetoaddress(2, nodes[1].getnewaddress('', 'bech32'))
         sync_blocks(nodes)
 
         # Thus all stake ouputs of the first node are mature

--- a/test/functional/rpc_propose.py
+++ b/test/functional/rpc_propose.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Unit-e developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test RPC calls propose and proposetoaddress
+
+Tests correspond to code in proposer/proposer_rpc.cpp .
+"""
+
+from test_framework.test_framework import UnitETestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+
+class RpcProposeTest(UnitETestFramework):
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [['-stakesplitthreshold=0']]
+
+    def run_test(self):
+        node = self.nodes[0]
+        self.setup_stake_coins(node)
+
+        assert_equal(len(node.propose(10)), 10)
+        assert_equal(node.getblockcount(), 10)
+
+        address = node.getnewaddress('', 'bech32')
+
+        proposed_blocks = node.proposetoaddress(5, address)
+        assert_equal(len(proposed_blocks), 5)
+        assert_equal(node.getblockcount(), 15)
+
+        for i in proposed_blocks:
+            txs = node.getblock(i)['tx']
+            assert_equal(len(txs), 1)
+            details = node.gettransaction(txs[0])['details']
+            assert_equal(len(details), 1)
+            assert_equal(details[0]['address'], address)
+
+
+if __name__ == '__main__':
+    RpcProposeTest().main()

--- a/test/functional/rpc_propose.py
+++ b/test/functional/rpc_propose.py
@@ -36,7 +36,8 @@ class RpcProposeTest(UnitETestFramework):
         self.setup_stake_coins(node0, node1)
 
         assert_raises_rpc_error(-32603, "Node is automatically proposing.", node1.propose, 1)
-        assert_raises_rpc_error(-32603, "Node is automatically proposing.", node1.proposetoaddress, 1, node1.getnewaddress('', 'bech32'))
+        assert_raises_rpc_error(-32603, "Node is automatically proposing.",
+                                node1.proposetoaddress, 1, node1.getnewaddress('', 'bech32'))
 
         assert_equal(len(node0.propose(10)), 10)
         assert_equal(node0.getblockcount(), 10)
@@ -59,8 +60,9 @@ class RpcProposeTest(UnitETestFramework):
         assert_equal(len(node0.liststakeablecoins()['stakeable_coins']), 1)
 
         block_id = node0.propose(1)[0]
-        coinbase = node0.getblock(block_id)['tx'][0]
-        coinbase_scriptpubkey = node0.decoderawtransaction(node0.getrawtransaction(coinbase))['vout'][0]['scriptPubKey']['hex']
+        coinbase_id = node0.getblock(block_id)['tx'][0]
+        coinbase = node0.decoderawtransaction(node0.getrawtransaction(coinbase_id))
+        coinbase_scriptpubkey = coinbase['vout'][0]['scriptPubKey']['hex']
         coin_scriptpubkey = node0.liststakeablecoins()['stakeable_coins'][0]['coin']['script_pub_key']['hex']
         assert_equal(coin_scriptpubkey, coinbase_scriptpubkey)
 

--- a/test/functional/rpc_propose.py
+++ b/test/functional/rpc_propose.py
@@ -11,35 +11,58 @@ Tests correspond to code in proposer/proposer_rpc.cpp .
 from test_framework.test_framework import UnitETestFramework
 from test_framework.util import (
     assert_equal,
+    assert_raises_rpc_error,
+    disconnect_nodes
 )
 
 
 class RpcProposeTest(UnitETestFramework):
 
     def set_test_params(self):
-        self.num_nodes = 1
+        self.num_nodes = 2
         self.setup_clean_chain = True
-        self.extra_args = [['-stakesplitthreshold=0']]
+        self.extra_args = [['-stakesplitthreshold=0'], ["-proposing=1"]]
+
+    def setup_network(self):
+        self.setup_nodes()
+        node0 = self.nodes[0]
+        node1 = self.nodes[1]
+        disconnect_nodes(node0, node1.index)
+        disconnect_nodes(node1, node0.index)
 
     def run_test(self):
-        node = self.nodes[0]
-        self.setup_stake_coins(node)
+        node0 = self.nodes[0]
+        node1 = self.nodes[1]
+        self.setup_stake_coins(node0, node1)
 
-        assert_equal(len(node.propose(10)), 10)
-        assert_equal(node.getblockcount(), 10)
+        assert_raises_rpc_error(-32603, "Node is automatically proposing.", node1.propose, 1)
+        assert_raises_rpc_error(-32603, "Node is automatically proposing.", node1.proposetoaddress, 1, node1.getnewaddress('', 'bech32'))
 
-        address = node.getnewaddress('', 'bech32')
+        assert_equal(len(node0.propose(10)), 10)
+        assert_equal(node0.getblockcount(), 10)
 
-        proposed_blocks = node.proposetoaddress(5, address)
+        address = node0.getnewaddress('', 'bech32')
+
+        proposed_blocks = node0.proposetoaddress(5, address)
         assert_equal(len(proposed_blocks), 5)
-        assert_equal(node.getblockcount(), 15)
+        assert_equal(node0.getblockcount(), 15)
 
         for i in proposed_blocks:
-            txs = node.getblock(i)['tx']
+            txs = node0.getblock(i)['tx']
             assert_equal(len(txs), 1)
-            details = node.gettransaction(txs[0])['details']
+            details = node0.gettransaction(txs[0])['details']
             assert_equal(len(details), 1)
             assert_equal(details[0]['address'], address)
+
+        # Check that the script pubkey of the coin staked is also
+        # used for the output
+        assert_equal(len(node0.liststakeablecoins()['stakeable_coins']), 1)
+
+        block_id = node0.propose(1)[0]
+        coinbase = node0.getblock(block_id)['tx'][0]
+        coinbase_scriptpubkey = node0.decoderawtransaction(node0.getrawtransaction(coinbase))['vout'][0]['scriptPubKey']['hex']
+        coin_scriptpubkey = node0.liststakeablecoins()['stakeable_coins'][0]['coin']['script_pub_key']['hex']
+        assert_equal(coin_scriptpubkey, coinbase_scriptpubkey)
 
 
 if __name__ == '__main__':

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -204,6 +204,7 @@ BASE_SCRIPTS = [
     'rpc_named_arguments.py',
     'rpc_addressbook.py',
     'feature_dersig.py',
+    'rpc_propose.py',
     'feature_cltv.py',
     'rpc_uptime.py',
     'feature_remote_staking.py',


### PR DESCRIPTION
This PR introduces two 2 RPC commands, `propose` and `proposetoaddress` their goal is to mimic bitcoin's `generate` and `generatetoaddress`, with the difference that they use our new proposing mechanism instead. The goal is to migrate all the calls from all the functional tests to this new RPCs.
