### PR TITLE
Increase the max line length for pep8speaks to 120 characters

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,6 @@
+scanner:
+  diff_only: True
+  linter: flake8
+
+flake8:
+  max-line-length: 120  # The default of 79 is too restrictive


### PR DESCRIPTION
Based on the example config from https://pep8speaks.com/.

Rationale: The default PEP8 line length is sometimes not enough for expressivity. See also https://medium.com/@drb/pep-8-beautiful-code-and-the-tyranny-of-guidelines-f96499f5ac17 .