### PR TITLE
Increase timeout in feature_assumevalid.py

### DIFF
--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -243,7 +243,7 @@ class AssumeValidTest(UnitETestFramework):
         for i in range(2202):
             p2p1.send_message(msg_block(self.blocks[i]))
         # Syncing 2200 blocks can take a while on slow systems. Give it plenty of time to sync.
-        p2p1.sync_with_ping(120)
+        p2p1.sync_with_ping(360)
         assert_equal(self.nodes[1].getblock(self.nodes[1].getbestblockhash())['height'], 2203)
 
         self.log.info("Send blocks to node2. Block 102 will be rejected.")


### PR DESCRIPTION
On my machine, MacBook Pro 2.8 GHz Intel Core i7
120 sec is not enough to process 2202 blocks.
Here are logs of that step:
```
2019-05-03T13:38:40.194000Z TestFramework (INFO): Send all blocks to node1. All blocks will be accepted.
2019-05-03T13:44:56.843000Z TestFramework (INFO): Send blocks to node2. Block 102 will be rejected.
```

Bitcoin already increased this timeout to 200 secs https://github.com/dtr-org/unit-e/blob/master/test/functional/feature_assumevalid.py#L246
but I suggest to increase it even more to accommodate slower machines like mine :)

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>