### PR TITLE
Set epochLength=200 in feature_assumevalid.py

### DIFF
--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -65,14 +65,18 @@ class BaseNode(P2PInterface):
         headers_message.headers = [CBlockHeader(b) for b in new_blocks]
         self.send_message(headers_message)
 
+
+ESPERANZA_CONFIG = '-esperanzaconfig={"epochLength": 500}'
+
+
 class AssumeValidTest(UnitETestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
         self.extra_args = [
-            ['-createsnapshot=0'],
-            ['-createsnapshot=0'],
-            ['-createsnapshot=0'],
+            [ESPERANZA_CONFIG],
+            [ESPERANZA_CONFIG],
+            [ESPERANZA_CONFIG],
         ]
 
     def send_blocks_until_disconnected(self, p2p_conn):
@@ -226,8 +230,8 @@ class AssumeValidTest(UnitETestFramework):
         self.nodes[0].disconnect_p2ps()
 
         self.log.info("Start node1 and node2 with assumevalid so they accept a block with a bad signature.")
-        self.start_node(1, extra_args=["-assumevalid=" + hex(block102.sha256), '-createsnapshot=0'])
-        self.start_node(2, extra_args=["-assumevalid=" + hex(block102.sha256), '-createsnapshot=0'])
+        self.start_node(1, extra_args=["-assumevalid=" + hex(block102.sha256), ESPERANZA_CONFIG])
+        self.start_node(2, extra_args=["-assumevalid=" + hex(block102.sha256), ESPERANZA_CONFIG])
 
         p2p0 = self.nodes[0].add_p2p_connection(BaseNode())
         p2p1 = self.nodes[1].add_p2p_connection(BaseNode())

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -69,6 +69,11 @@ class AssumeValidTest(UnitETestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
+        self.extra_args = [
+            ['-createsnapshot=0'],
+            ['-createsnapshot=0'],
+            ['-createsnapshot=0'],
+        ]
 
     def send_blocks_until_disconnected(self, p2p_conn):
         """Keep sending blocks to the node until we're disconnected."""
@@ -221,8 +226,8 @@ class AssumeValidTest(UnitETestFramework):
         self.nodes[0].disconnect_p2ps()
 
         self.log.info("Start node1 and node2 with assumevalid so they accept a block with a bad signature.")
-        self.start_node(1, extra_args=["-assumevalid=" + hex(block102.sha256)])
-        self.start_node(2, extra_args=["-assumevalid=" + hex(block102.sha256)])
+        self.start_node(1, extra_args=["-assumevalid=" + hex(block102.sha256), '-createsnapshot=0'])
+        self.start_node(2, extra_args=["-assumevalid=" + hex(block102.sha256), '-createsnapshot=0'])
 
         p2p0 = self.nodes[0].add_p2p_connection(BaseNode())
         p2p1 = self.nodes[1].add_p2p_connection(BaseNode())

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -66,7 +66,7 @@ class BaseNode(P2PInterface):
         self.send_message(headers_message)
 
 
-ESPERANZA_CONFIG = '-esperanzaconfig={"epochLength": 500}'
+ESPERANZA_CONFIG = '-esperanzaconfig={"epochLength": 200}'
 
 
 class AssumeValidTest(UnitETestFramework):


### PR DESCRIPTION
This commit is an alternative to https://github.com/dtr-org/unit-e/pull/1056

The motivation for this change is to speed up the test, as by increasing the epoch length, we
reduce the number of snapshots the node generates.

I am still in favor of keeping snapshot generation enabled by default to ensure we test that component in every scenario possible.

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>