### PR TITLE
Reduce Travis log spam

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -250,8 +250,7 @@ if EMBEDDED_UNIVALUE
 endif
 
 %.cpp.test: %.cpp
-	for test_suite in `cat $< | grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1`; do \
-	    echo $${test_suite}... \
+	@for test_suite in `cat $< | grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1`; do \
 	    $(TEST_BINARY) -l test_suite -t $$test_suite > $<"-"$$test_suite".log" 2>&1 && (echo "Success: $$test_suite from $<") || ((echo "Failure: $$test_suite from $<"); cat $<"-"$$test_suite".log" && false) \
 	done
 


### PR DESCRIPTION
Previously, the Makefile scripts for each individual unit test were
displayed for debugging purposes. This commit suppresses this output,
which should make the Travis log smaller.

Note that, just after the unit tests, we also test `unit-e-tx`, which also
prints its testcases. This output should not be suppressed, since the
test takes a long time, and the Travis build can timeout if it doesn't
see any output for a while.