### PR TITLE
Minor adjustments for the tests and codestyle

### DIFF
--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -248,8 +248,7 @@ bool WalletExtension::SetMasterKeyFromSeed(const key::mnemonic::Seed &seed,
 }
 
 bool WalletExtension::BackupWallet() {
-  const std::string wallet_file_name = m_enclosing_wallet.GetName().empty() ?
-          "wallet.dat" : m_enclosing_wallet.GetName();
+  const std::string wallet_file_name = m_enclosing_wallet.GetName().empty() ? "wallet.dat" : m_enclosing_wallet.GetName();
   const int64_t current_time = GetTime();
 
   const std::string backup_wallet_filename =
@@ -611,7 +610,6 @@ void WalletExtension::VoteIfNeeded() {
              validatorState->m_last_source_epoch, validatorState->m_last_target_epoch);
     return;
   }
-
 
   const CWalletTx *prev_tx = m_enclosing_wallet.GetWalletTx(validator->m_last_transaction_hash);
   assert(prev_tx);

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -309,7 +309,7 @@ BOOST_AUTO_TEST_CASE(MempoolAncestorIndexingTest)
     tx2.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
     tx2.vout[0].nValue = 2 * UNIT;
     pool.addUnchecked(tx2.GetHash(), entry.Fee(20000LL).FromTx(tx2));
-    uint64_t tx2Size = GetVirtualTransactionSize(tx2);
+    uint64_t tx2Size = GetVirtualTransactionSize(tx2, entry.sigOpCost);
 
     /* lowest fee */
     CMutableTransaction tx3 = CMutableTransaction();
@@ -357,7 +357,7 @@ BOOST_AUTO_TEST_CASE(MempoolAncestorIndexingTest)
     tx6.vout.resize(1);
     tx6.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
     tx6.vout[0].nValue = 20 * UNIT;
-    uint64_t tx6Size = GetVirtualTransactionSize(tx6);
+    uint64_t tx6Size = GetVirtualTransactionSize(tx6, entry.sigOpCost);
 
     pool.addUnchecked(tx6.GetHash(), entry.Fee(0LL).FromTx(tx6));
     BOOST_CHECK_EQUAL(pool.size(), 6U);
@@ -376,7 +376,7 @@ BOOST_AUTO_TEST_CASE(MempoolAncestorIndexingTest)
     tx7.vout.resize(1);
     tx7.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
     tx7.vout[0].nValue = 10 * UNIT;
-    uint64_t tx7Size = GetVirtualTransactionSize(tx7);
+    uint64_t tx7Size = GetVirtualTransactionSize(tx7, entry.sigOpCost);
 
     /* set the fee to just below tx2's feerate when including ancestor */
     CAmount fee = (20000/tx2Size)*(tx7Size + tx6Size) - 1;
@@ -464,12 +464,12 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     BOOST_CHECK(pool.exists(tx2.GetHash()));
     BOOST_CHECK(pool.exists(tx3.GetHash()));
 
-    pool.TrimToSize(GetVirtualTransactionSize(tx1)); // mempool is limited to tx1's size in memory usage, so nothing fits
+    pool.TrimToSize(GetVirtualTransactionSize(tx1, entry.sigOpCost)); // mempool is limited to tx1's size in memory usage, so nothing fits
     BOOST_CHECK(!pool.exists(tx1.GetHash()));
     BOOST_CHECK(!pool.exists(tx2.GetHash()));
     BOOST_CHECK(!pool.exists(tx3.GetHash()));
 
-    CFeeRate maxFeeRateRemoved(25000, GetVirtualTransactionSize(tx3) + GetVirtualTransactionSize(tx2));
+    CFeeRate maxFeeRateRemoved(25000, GetVirtualTransactionSize(tx3, entry.sigOpCost) + GetVirtualTransactionSize(tx2, entry.sigOpCost));
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
 
     CMutableTransaction tx4 = CMutableTransaction();

--- a/src/usbdevice/rpcusbdevice.cpp
+++ b/src/usbdevice/rpcusbdevice.cpp
@@ -3,9 +3,9 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <key_io.h>
 #include <extkey.h>
 #include <key.h>
+#include <key_io.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
 #include <usbdevice/usbdevice.h>

--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -102,7 +102,6 @@ class P2PFingerprintTest(UnitETestFramework):
         snapshot_meta = get_tip_snapshot_meta(self.nodes[0])
         unspent_outputs = get_unspent_coins(self.nodes[0], 5, lock=True)
         block_hashes += self.nodes[0].generate(nblocks=2)
-        unspent_outputs = get_unspent_coins(self.nodes[0], 5)
 
         # Create longer chain starting 2 blocks before current tip
         height = len(block_hashes) - 2


### PR DESCRIPTION
During the #1062 a couple of minor problems was found:

- `GetVirtualTransactionSize` must have a `sigOpCost` as an argument. Right now this test passes just by coincidence.
- In `p2p_fingerprint.py` we need to take unspent coins before the substituted subchain.
- Clang formatting

Signed-off-by: Dmitry Saveliev <dima@thirdhash.com>
