### PR TITLE
Add GetName to staking wallet

### DIFF
--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -252,7 +252,8 @@ bool WalletExtension::SetMasterKeyFromSeed(const key::mnemonic::Seed &seed,
 }
 
 bool WalletExtension::BackupWallet() {
-  const std::string wallet_file_name = m_enclosing_wallet.GetName().empty() ? "wallet.dat" : m_enclosing_wallet.GetName();
+  const std::string wallet_file_name = m_enclosing_wallet.GetName().empty() ?
+      "wallet.dat" : m_enclosing_wallet.GetName();
   const int64_t current_time = GetTime();
 
   const std::string backup_wallet_filename =

--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -253,7 +253,7 @@ bool WalletExtension::SetMasterKeyFromSeed(const key::mnemonic::Seed &seed,
 
 bool WalletExtension::BackupWallet() {
   const std::string wallet_file_name = m_enclosing_wallet.GetName().empty() ?
-      "wallet.dat" : m_enclosing_wallet.GetName();
+          "wallet.dat" : m_enclosing_wallet.GetName();
   const int64_t current_time = GetTime();
 
   const std::string backup_wallet_filename =

--- a/src/esperanza/walletextension.cpp
+++ b/src/esperanza/walletextension.cpp
@@ -228,6 +228,10 @@ bool WalletExtension::SignCoinbaseTransaction(CMutableTransaction &tx) {
   return true;
 }
 
+const std::string &WalletExtension::GetName() const {
+  return m_enclosing_wallet.GetName();
+}
+
 bool WalletExtension::SetMasterKeyFromSeed(const key::mnemonic::Seed &seed,
                                            bool brand_new,
                                            std::string &error) {
@@ -248,8 +252,7 @@ bool WalletExtension::SetMasterKeyFromSeed(const key::mnemonic::Seed &seed,
 }
 
 bool WalletExtension::BackupWallet() {
-  const std::string wallet_file_name = m_enclosing_wallet.GetName().empty() ?
-          "wallet.dat" : m_enclosing_wallet.GetName();
+  const std::string wallet_file_name = m_enclosing_wallet.GetName().empty() ? "wallet.dat" : m_enclosing_wallet.GetName();
   const int64_t current_time = GetTime();
 
   const std::string backup_wallet_filename =
@@ -611,7 +614,6 @@ void WalletExtension::VoteIfNeeded() {
              validatorState->m_last_source_epoch, validatorState->m_last_target_epoch);
     return;
   }
-
 
   const CWalletTx *prev_tx = m_enclosing_wallet.GetWalletTx(validator->m_last_transaction_hash);
   assert(prev_tx);

--- a/src/esperanza/walletextension.h
+++ b/src/esperanza/walletextension.h
@@ -118,6 +118,8 @@ class WalletExtension : public staking::StakingWallet {
   // defined in staking::StakingWallet
   bool SignCoinbaseTransaction(CMutableTransaction &) override;
 
+  const std::string &GetName() const override;
+
   // defined in staking::StakingWallet
   proposer::State &GetProposerState() override;
 

--- a/src/staking/stakingwallet.h
+++ b/src/staking/stakingwallet.h
@@ -60,6 +60,9 @@ class StakingWallet {
   //! \brief signs the staking input in a coinbase transaction
   virtual bool SignCoinbaseTransaction(CMutableTransaction &) = 0;
 
+  //! \brief get a name for this wallet for debug/logging purposes
+  virtual const std::string &GetName() const = 0;
+
   virtual ~StakingWallet() = default;
 };
 

--- a/src/test/proposer/block_builder_tests.cpp
+++ b/src/test/proposer/block_builder_tests.cpp
@@ -47,6 +47,7 @@ struct Fixture {
   class Wallet : public staking::StakingWallet {
     mutable CCriticalSection lock;
     proposer::State state;
+    std::string name = "test-wallet";
 
    public:
     CKey key;
@@ -59,6 +60,7 @@ struct Fixture {
     proposer::State &GetProposerState() override { return state; }
     boost::optional<CKey> GetKey(const CPubKey &) const override { return key; }
     bool SignCoinbaseTransaction(CMutableTransaction &tx) override { return signfunc(tx); }
+    const std::string &GetName() const override { return name; }
   };
 
   Wallet wallet;


### PR DESCRIPTION
This PR adds a new method `GetName()` to `staking::StakingWallet`. This is a prerequisite to https://github.com/dtr-org/unit-e/pull/1051. The main reason is that is convenient to have a label attached to each wallet so that we can distinguish between them while logging/debugging.