### PR TITLE
Remove P2PKH from stakeable scripts

### DIFF
--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -299,9 +299,7 @@ bool IsStakeableByMe(const CKeyStore &keystore, const CScript &script_pub_key)
     IsMineInfo is_mine_info;
     const isminetype is_mine = IsMine(keystore, script_pub_key, &is_mine_info);
 
-    // UNIT-E TODO: Restrict to witness programs only once #212 is merged (fixes #48)
     switch (is_mine_info.type) {
-        case TX_PUBKEYHASH:
         case TX_WITNESS_V0_KEYHASH: {
             if (is_mine != ISMINE_SPENDABLE) {
                 // Non-remote-staking scripts can be used as stake only if they

--- a/src/test/esperanza/walletextension_tests.cpp
+++ b/src/test/esperanza/walletextension_tests.cpp
@@ -288,7 +288,7 @@ BOOST_FIXTURE_TEST_CASE(get_stakeable_coins, TestChain100Setup) {
   }
 
   // Make the first coinbase mature
-  CScript coinbase_script = GetScriptForDestination(coinbaseKey.GetPubKey().GetID());
+  CScript coinbase_script = GetScriptForDestination(WitnessV0KeyHash(coinbaseKey.GetPubKey().GetID()));
   bool processed;
   CreateAndProcessBlock({}, coinbase_script, boost::none, &processed);
   BOOST_CHECK(processed);

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         keystore.AddKey(keys[0]);
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
-        BOOST_CHECK(IsStakeableByMe(keystore, scriptPubKey));
+        BOOST_CHECK(!IsStakeableByMe(keystore, scriptPubKey));
     }
 
     // P2PKH uncompressed

--- a/test/functional/proposer_balance.py
+++ b/test/functional/proposer_balance.py
@@ -14,13 +14,13 @@ from random import (
 
 from decimal import Decimal
 
-from test_framework.authproxy import JSONRPCException
 from test_framework.regtest_mnemonics import regtest_mnemonics
 from test_framework.test_framework import UnitETestFramework
 from test_framework.util import (
     assert_equal,
     sync_blocks,
-    sync_mempools
+    sync_mempools,
+    generate_block
 )
 
 
@@ -54,7 +54,8 @@ class ProposerBalanceTest(UnitETestFramework):
         for i in range(15):
             node_idx = i % 3
 
-            self.generate_block(nodes, node_idx)
+            generate_block(nodes[node_idx])
+            sync_blocks(nodes)
             block_info = self.get_last_block_info(node_idx, nodes)
 
             coinstake_tx_id = block_info['tx'][0]
@@ -87,7 +88,8 @@ class ProposerBalanceTest(UnitETestFramework):
                 node0_address, node1_address, node2_address, nodes
             )
 
-            self.generate_block(nodes, node_idx)
+            generate_block(nodes[node_idx])
+            sync_blocks(nodes)
             block_info = self.get_last_block_info(node_idx, nodes)
 
             transactions = [
@@ -152,15 +154,6 @@ class ProposerBalanceTest(UnitETestFramework):
     def load_wallets(self, nodes):
         for i in range(self.num_nodes):
             nodes[i].importmasterkey(regtest_mnemonics[i]['mnemonics'])
-
-    @staticmethod
-    def generate_block(nodes, node_idx):
-        try:
-            nodes[node_idx].generatetoaddress(nblocks=1, address=nodes[node_idx].getnewaddress())
-            sync_blocks(nodes)
-        except JSONRPCException as exp:
-            print("error generating block:", exp.error)
-            raise AssertionError("Node %s cannot generate block" % node_idx)
 
 
 if __name__ == '__main__':

--- a/test/functional/proposer_stakeable_balance.py
+++ b/test/functional/proposer_stakeable_balance.py
@@ -4,7 +4,14 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from decimal import Decimal
 
-from test_framework.util import assert_equal, connect_nodes_bi, wait_until
+from test_framework.util import (
+    assert_equal,
+    connect_nodes_bi,
+    wait_until,
+    disconnect_all_nodes,
+    connect_nodes,
+    sync_mempools
+)
 from test_framework.test_framework import UnitETestFramework
 
 

--- a/test/functional/rpc_filtertransactions.py
+++ b/test/functional/rpc_filtertransactions.py
@@ -17,10 +17,11 @@ from test_framework.util import (
     sync_mempools,
 )
 
+
 class FilterTransactionsTest(UnitETestFramework):
     def set_test_params(self):
         self.num_nodes = 3
-        self.extra_args = [['-deprecatedrpc=validateaddress']]*3
+        self.extra_args = [['-deprecatedrpc=validateaddress']] * 3
         self.enable_mocktime()
 
     def run_test(self):
@@ -108,7 +109,7 @@ class FilterTransactionsTest(UnitETestFramework):
 
         # coinbase
         sync_mempools(self.nodes)
-        self.nodes[0].generatetoaddress(1, self.nodes[0].getnewaddress())  # Clear node1's mempool
+        generate_block(self.nodes[0])  # Clear node1's mempool
         sync_blocks(self.nodes)
 
         address = self.nodes[1].getnewaddress()

--- a/test/functional/rpc_filtertransactions.py
+++ b/test/functional/rpc_filtertransactions.py
@@ -15,8 +15,8 @@ from test_framework.util import (
     assert_raises_rpc_error,
     sync_blocks,
     sync_mempools,
+    generate_block
 )
-
 
 class FilterTransactionsTest(UnitETestFramework):
     def set_test_params(self):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -102,15 +102,14 @@ class TestNode():
         """Return a deterministic priv key in base58, that only depends on the node's index"""
         PRIV_KEYS = [
             # adress , privkey
-            ('mjTkW3DjgyZck4KbiRusZsqTgaYTxdSz6z', 'cVpF924EspNh8KjYsfhgY96mmxvT6DgdWiTYMtMjuM74hJaU5psW'),
-            ('msX6jQXvxiNhx3Q62PKeLPrhrqZQdSimTg', 'cUxsWyKyZ9MAQTaAhUQWJmBbSvHMwSmuv59KgxQV7oZQU3PXN3KE'),
-            ('mnonCMyH9TmAsSj3M59DsbH8H63U3RKoFP', 'cTrh7dkEAeJd6b3MRX9bZK8eRmNqVCMH3LSUkE3dSFDyzjU38QxK'),
-            ('mqJupas8Dt2uestQDvV2NH3RU8uZh2dqQR', 'cVuKKa7gbehEQvVq717hYcbE9Dqmq7KEBKqWgWrYBa2CKKrhtRim'),
-            ('msYac7Rvd5ywm6pEmkjyxhbCDKqWsVeYws', 'cQDCBuKcjanpXDpCqacNSjYfxeQj8G6CAtH1Dsk3cXyqLNC4RPuh'),
-            ('n2rnuUnwLgXqf9kk2kjvVm8R5BZK1yxQBi', 'cQakmfPSLSqKHyMFGwAqKHgWUiofJCagVGhiB4KCainaeCSxeyYq'),
-            ('myzuPxRwsf3vvGzEuzPfK9Nf2RfwauwYe6', 'cQMpDLJwA8DBe9NcQbdoSb1BhmFxVjWD5gRyrLZCtpuF9Zi3a9RK'),
-            ('mumwTaMtbxEPUswmLBBN3vM9oGRtGBrys8', 'cSXmRKXVcoouhNNVpcNKFfxsTsToY5pvB9DVsFksF1ENunTzRKsy'),
-            ('mpV7aGShMkJCZgbW7F6iZgrvuPHjZjH9qg', 'cSoXt6tm3pqy43UMabY6eUTmR3eSUYFtB2iNQDGgb3VUnRsQys2k'),
+            ('uert1qkvnq92mfmjr3q9ce9w2ulc2twks55ycdaj96ls', 'cRHuuVTtbHf3draCUhsfcNLSGT8PEcXBeJr4zc9w2q56VLM35apA'),
+            ('uert1q4gcrhtu6fpk49g9skga2k5z5rgmw4pfx6qmvdf', 'cQUB99dyTgoBLYutKmH3HyJxVM6BRgWN3Kq3dUcqLYiJqFoefH2b'),
+            ('uert1qn0sqfq36twzdvttuz0xrdm0qlj3ctw64hf0ut6', 'cNrajBUomDrtkcBEjx8tGo9pjYGCoGyVQVdGr4My13EdtuDDjyKm'),
+            ('uert1qn46zepgau0nkscrnn482gg62n73lluprtdkd8j', 'cUGpGRbjDkfM7XQNZVb7g8ncjwL9j3k1ySpsUEW8N53bN5buBf8D'),
+            ('uert1qytmnspevw50qy9my74qfjjep5aqxltjym0jvyk', 'cQRyLfPkvc9VmAmwuWp7RNpuuTJ9k7Ro2E9bNh7SGQDVYHAR4vKB'),
+            ('uert1qepcyrgzdht898982jelv3gagfvaktd0a3ry8gx', 'cR3ewc4KNdCZwuT3cj7bK35HPZ1UqNGvx3wk8MYqCHm6q9fBNfpv'),
+            ('uert1qrhcxwaq37j4sk3e9uajwlypxu2sep8c962k36e', 'cTmLQaj61stLCGE1HYkiNHP9FCq7rfgyMo2vwW6oThSX4zx73wfe'),
+            ('uert1qnt6480k4qpjv56rk8vp7mgfss5qwh4g9nzd5ew', 'cVxyXUprK6vsfWdvmZF8Una9ZDqE8XFhhr6vCS1CtjZ6xs9BdQzt'),
         ]
         return PRIV_KEYS[self.index]
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -522,6 +522,15 @@ def connect_nodes_bi(nodes, a, b):
     connect_nodes(nodes[a], b)
     connect_nodes(nodes[b], a)
 
+def disconnect_nodes_bi(nodes, a, b):
+    disconnect_nodes(nodes[a], b)
+    disconnect_nodes(nodes[b], a)
+
+def disconnect_all_nodes(nodes):
+    for i in range(0, len(nodes)):
+        if i+1 < len(nodes):
+            disconnect_nodes_bi(nodes, i, i + 1)
+
 def sync_blocks(rpc_connections, *, wait=1, timeout=60, height=None):
     """
     Wait until everybody has the same tip.

--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -20,7 +20,14 @@ happened previously.
 """
 
 from test_framework.test_framework import (UnitETestFramework, DISABLE_FINALIZATION)
-from test_framework.util import (assert_raises_rpc_error, connect_nodes, sync_blocks, assert_equal, set_node_times)
+from test_framework.util import (
+    assert_raises_rpc_error,
+    connect_nodes,
+    sync_blocks,
+    assert_equal,
+    set_node_times,
+    generate_block
+)
 
 import collections
 import enum
@@ -150,7 +157,7 @@ class ImportRescanTest(UnitETestFramework):
     def run_test(self):
 
         self.setup_stake_coins(self.nodes[0])
-        self.nodes[0].generatetoaddress(200, self.nodes[0].getnewaddress())
+        generate_block(self.nodes[0], 200)
         sync_blocks(self.nodes)
 
         # Create one transaction on node 0 with a unique amount for


### PR DESCRIPTION
This PR removes P2PKH the list of scripts usable for staking since all our coinbase txs are witness transactions.