### PR TITLE
Update copyright headers

### DIFF
--- a/contrib/devtools/circular-dependencies.py
+++ b/contrib/devtools/circular-dependencies.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 import sys
 import re

--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -316,7 +316,7 @@ def report_cmd(argv):
 # query git for year of last change
 ################################################################################
 
-GIT_LOG_CMD = "git log --pretty=format:%%ai %s"
+GIT_LOG_CMD = "git log --pretty=format:%%ai --no-merges %s"
 
 def call_git_log(filename):
     out = subprocess.check_output((GIT_LOG_CMD % filename).split(' '))

--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -65,7 +65,7 @@ def get_filenames_to_examine():
 ################################################################################
 
 
-COPYRIGHT_WITH_C = 'Copyright\s*\(c\)'
+COPYRIGHT_WITH_C = r'Copyright \(c\)'
 COPYRIGHT_WITHOUT_C = 'Copyright'
 ANY_COPYRIGHT_STYLE = '(%s|%s)' % (COPYRIGHT_WITH_C, COPYRIGHT_WITHOUT_C)
 

--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -115,7 +115,10 @@ EXPECTED_HOLDER_NAMES = [
     "The ShadowCoin developers\n",
     "Institute of Formal and Applied Linguistics, Faculty of", # Multi-line
     "Intel Corporation",
-    "Anton Bachin"
+    "Anton Bachin",
+    "Gavin Andresen",
+    "The Bitcoin Unlimited developers",
+    "The Bitcoin ABC developers",
 ]
 
 DOMINANT_STYLE_COMPILED = {}

--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -65,7 +65,7 @@ def get_filenames_to_examine():
 ################################################################################
 
 
-COPYRIGHT_WITH_C = 'Copyright \(c\)'
+COPYRIGHT_WITH_C = 'Copyright\s*\(c\)'
 COPYRIGHT_WITHOUT_C = 'Copyright'
 ANY_COPYRIGHT_STYLE = '(%s|%s)' % (COPYRIGHT_WITH_C, COPYRIGHT_WITHOUT_C)
 

--- a/contrib/devtools/test_copyright_header.py
+++ b/contrib/devtools/test_copyright_header.py
@@ -46,7 +46,7 @@ def main():
 '''
         expected_result = '''# Copyright (c) 2017-2018 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/licenses/MIT.
 import something
 
 def main():
@@ -68,7 +68,7 @@ def main():
         expected_result = '''#!/usr/bin/env python3
 # Copyright (c) 2017-2018 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/licenses/MIT.
 import something
 
 def main():
@@ -89,7 +89,7 @@ void main() {
 '''
         expected_result = '''// Copyright (c) 2017-2018 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://opensource.org/licenses/MIT.
 
 #include "something.h"
 

--- a/contrib/devtools/test_copyright_header.py
+++ b/contrib/devtools/test_copyright_header.py
@@ -163,8 +163,8 @@ Some text.
 
 class TestCopyrightMatch(unittest.TestCase):
     def test_copyright(self):
-        assert(ANY_COPYRIGHT_COMPILED.search("Copyright (c) 2019 Jane Doe"))
-        assert(ANY_COPYRIGHT_COMPILED.search("Copyright(c) 2019 Jane Doe"))
+        self.assertIsNotNone(ANY_COPYRIGHT_COMPILED.search("Copyright (c) 2019 Jane Doe"))
+        self.assertIsNone(ANY_COPYRIGHT_COMPILED.search("Copyright(c) 2019 Jane Doe"))
 
 
 if __name__ == '__main__':

--- a/contrib/devtools/test_copyright_header.py
+++ b/contrib/devtools/test_copyright_header.py
@@ -11,8 +11,10 @@ from unittest import mock
 
 import tempfile
 import os
-from copyright_header import exec_insert_header
-
+from copyright_header import (
+    exec_insert_header,
+    ANY_COPYRIGHT_COMPILED,
+)
 
 class TestCopyrightHeader(unittest.TestCase):
     def run_and_test_insertion(self, original, expected_result, header_type):
@@ -157,6 +159,12 @@ Some text.
         # Should not insert the header twice
         with self.assertRaises(SystemExit):
             self.run_and_test_insertion(expected_result, expected_result, 'rst')
+
+
+class TestCopyrightMatch(unittest.TestCase):
+    def test_copyright(self):
+        assert(ANY_COPYRIGHT_COMPILED.search("Copyright (c) 2019 Jane Doe"))
+        assert(ANY_COPYRIGHT_COMPILED.search("Copyright(c) 2019 Jane Doe"))
 
 
 if __name__ == '__main__':

--- a/contrib/filter-lcov.py
+++ b/contrib/filter-lcov.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright (c) 2016-2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 import argparse
 

--- a/src/blockchain/regtest_funds.cpp
+++ b/src/blockchain/regtest_funds.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/MIT.
+
 #ifndef UNIT_E_BLOCKCHAIN_REGTEST_FUNDS_H
 #define UNIT_E_BLOCKCHAIN_REGTEST_FUNDS_H
 

--- a/src/blockchain/testnet_funds.cpp
+++ b/src/blockchain/testnet_funds.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/MIT.
+
 #ifndef UNIT_E_BLOCKCHAIN_TESTNET_FUNDS_H
 #define UNIT_E_BLOCKCHAIN_TESTNET_FUNDS_H
 

--- a/src/finalization/state_processor.cpp
+++ b/src/finalization/state_processor.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/MIT.
+
 #include <finalization/state_processor.h>
 
 #include <esperanza/finalizationstate.h>

--- a/src/staking/block_validation_info.cpp
+++ b/src/staking/block_validation_info.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/MIT.
+
 #include <staking/block_validation_info.h>
 
 namespace staking {

--- a/src/staking/block_validation_info.h
+++ b/src/staking/block_validation_info.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/MIT.
+
 #ifndef UNIT_E_STAKING_BLOCK_INFO_H
 #define UNIT_E_STAKING_BLOCK_INFO_H
 

--- a/src/staking/validation_error.cpp
+++ b/src/staking/validation_error.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/MIT.
+
 #include <staking/validation_error.h>
 
 #include <consensus/validation.h>

--- a/src/staking/validation_error.h
+++ b/src/staking/validation_error.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/MIT.
+
 #ifndef UNIT_E_STAKING_VALIDATION_ERROR_H
 #define UNIT_E_STAKING_VALIDATION_ERROR_H
 

--- a/src/staking/validation_result.cpp
+++ b/src/staking/validation_result.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/MIT.
+
 #include <staking/validation_result.h>
 
 namespace staking {

--- a/src/staking/validation_result.h
+++ b/src/staking/validation_result.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/MIT.
+
 #ifndef UNIT_E_STAKING_VALIDATION_RESULT_H
 #define UNIT_E_STAKING_VALIDATION_RESULT_H
 

--- a/src/trit.cpp
+++ b/src/trit.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/MIT.
+
 #include <trit.h>
 
 const Trit Trit::True = Trit(true);

--- a/test/functional/feature_graphene_active.py
+++ b/test/functional/feature_graphene_active.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright (c) 2019 The Unit-e developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/MIT.
 # Copyright(c) 2018 The Unit - e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http: // www.opensource.org/licenses/mit-license.php.

--- a/test/functional/feature_graphene_active.py
+++ b/test/functional/feature_graphene_active.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
-# Copyright (c) 2019 The Unit-e developers
+# Copyright (c) 2018-2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/licenses/MIT.
-# Copyright(c) 2018 The Unit - e developers
-# Distributed under the MIT software license, see the accompanying
-# file COPYING or http: // www.opensource.org/licenses/mit-license.php.
 
 """
 This tests node reactions on different hand-made graphene requests/responses:

--- a/test/functional/feature_remote_staking.py
+++ b/test/functional/feature_remote_staking.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2019 The Unit-e Core developers
+# Copyright (c) 2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from test_framework.blocktools import (

--- a/test/functional/p2p_embargoman_star.py
+++ b/test/functional/p2p_embargoman_star.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The unit - e core developers
+# Copyright (c) 2018 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http: // www.opensource.org/licenses/mit-license.php.
 """

--- a/test/functional/proposer_remote_staking.py
+++ b/test/functional/proposer_remote_staking.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2019 The Unit-e Core developers
+# Copyright (c) 2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from test_framework.mininode import sha256


### PR DESCRIPTION
* Add copyright headers to files which didn't have one yet
* Fix format of Unit-e copyright headers to be consistent
* Adapt `copyright_headers.py` to not take merge commits into
  account when calculating the date of the last change
* Add missing copyright holders to list of known copyright holders
  in `copyright_headers.py`
* Update years in copyright notice for the files which have
  been updated in 2019 without updating the notice by running
  `copyright_headers.py update`
* Remove empty file `test/functional/test_framework/blockstore.py`
