### PR TITLE
Remove function without implementation from LegacyValidationInterface

### DIFF
--- a/src/staking/legacy_validation_interface.h
+++ b/src/staking/legacy_validation_interface.h
@@ -103,11 +103,6 @@ class LegacyValidationInterface {
 
   virtual ~LegacyValidationInterface() = default;
 
-  static std::unique_ptr<LegacyValidationInterface> New(
-      Dependency<ActiveChain> active_chain,
-      Dependency<BlockValidator> block_validator,
-      Dependency<StakeValidator> stake_validator);
-
   //! \brief Instantiates an instance of the old validation functions.
   //!
   //! Although the old functions do not require all these dependencies


### PR DESCRIPTION
Removes the `New` factory function declaration from `LegacyValidationInterface`. The function does not have a definition in the `*.cpp` counterpart.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
