### PR TITLE
Convert two fields of FinalizationState to local variables

### DIFF
--- a/src/esperanza/finalizationstate.cpp
+++ b/src/esperanza/finalizationstate.cpp
@@ -98,9 +98,9 @@ Result FinalizationState::InitializeEpoch(blockchain::Height blockHeight) {
 
   m_current_epoch = new_epoch;
 
-  ufp64::ufp64_t last_voter_rescale = ufp64::add_uint(GetCollectiveRewardFactor(), 1);
+  const ufp64::ufp64_t last_voter_rescale = ufp64::add_uint(GetCollectiveRewardFactor(), 1);
 
-  ufp64::ufp64_t last_non_voter_rescale = ufp64::div(last_voter_rescale, (ufp64::add_uint(m_reward_factor, 1)));
+  const ufp64::ufp64_t last_non_voter_rescale = ufp64::div(last_voter_rescale, (ufp64::add_uint(m_reward_factor, 1)));
 
   m_deposit_scale_factor[new_epoch] = ufp64::mul(last_non_voter_rescale, GetDepositScaleFactor(new_epoch - 1));
 

--- a/src/esperanza/finalizationstate.cpp
+++ b/src/esperanza/finalizationstate.cpp
@@ -98,11 +98,11 @@ Result FinalizationState::InitializeEpoch(blockchain::Height blockHeight) {
 
   m_current_epoch = new_epoch;
 
-  m_last_voter_rescale = ufp64::add_uint(GetCollectiveRewardFactor(), 1);
+  ufp64::ufp64_t last_voter_rescale = ufp64::add_uint(GetCollectiveRewardFactor(), 1);
 
-  m_last_non_voter_rescale = ufp64::div(m_last_voter_rescale, (ufp64::add_uint(m_reward_factor, 1)));
+  ufp64::ufp64_t last_non_voter_rescale = ufp64::div(last_voter_rescale, (ufp64::add_uint(m_reward_factor, 1)));
 
-  m_deposit_scale_factor[new_epoch] = ufp64::mul(m_last_non_voter_rescale, GetDepositScaleFactor(new_epoch - 1));
+  m_deposit_scale_factor[new_epoch] = ufp64::mul(last_non_voter_rescale, GetDepositScaleFactor(new_epoch - 1));
 
   m_total_slashed[new_epoch] = GetTotalSlashed(new_epoch - 1);
 

--- a/src/esperanza/finalizationstate_data.cpp
+++ b/src/esperanza/finalizationstate_data.cpp
@@ -26,8 +26,6 @@ bool FinalizationStateData::operator==(const FinalizationStateData &other) const
          m_last_justified_epoch == other.m_last_justified_epoch &&
          m_recommended_target_hash == other.m_recommended_target_hash &&
          m_recommended_target_epoch == other.m_recommended_target_epoch &&
-         m_last_voter_rescale == other.m_last_voter_rescale &&
-         m_last_non_voter_rescale == other.m_last_non_voter_rescale &&
          m_reward_factor == other.m_reward_factor &&
          m_admin_state == other.m_admin_state;
 }
@@ -50,8 +48,6 @@ std::string FinalizationStateData::ToString() const {
       "m_last_justified_epoch=%d\n"
       "m_recommended_target_hash=%s\n"
       "m_recommended_target_epoch=%d\n"
-      "m_last_voter_rescale=%d\n"
-      "m_last_non_voter_rescale=%d\n"
       "m_reward_factor=%d\n"
       "m_admin_state=%s}",
       util::to_string(m_checkpoints),
@@ -69,8 +65,6 @@ std::string FinalizationStateData::ToString() const {
       m_last_justified_epoch,
       util::to_string(m_recommended_target_hash),
       m_recommended_target_epoch,
-      m_last_voter_rescale,
-      m_last_non_voter_rescale,
       m_reward_factor,
       util::to_string(m_admin_state));
 }

--- a/src/esperanza/finalizationstate_data.h
+++ b/src/esperanza/finalizationstate_data.h
@@ -85,10 +85,6 @@ class FinalizationStateData {
   uint256 m_recommended_target_hash = uint256();
   uint32_t m_recommended_target_epoch = 0;
 
-  ufp64::ufp64_t m_last_voter_rescale = 0;
-
-  ufp64::ufp64_t m_last_non_voter_rescale = 0;
-
   // Reward for voting as fraction of deposit size
   ufp64::ufp64_t m_reward_factor = 0;
 
@@ -114,8 +110,6 @@ class FinalizationStateData {
     READWRITE(m_last_justified_epoch);
     READWRITE(m_recommended_target_hash);
     READWRITE(m_recommended_target_epoch);
-    READWRITE(m_last_voter_rescale);
-    READWRITE(m_last_non_voter_rescale);
     READWRITE(m_reward_factor);
     READWRITE(m_admin_state);
   };

--- a/src/test/esperanza/finalizationstate_utils.cpp
+++ b/src/test/esperanza/finalizationstate_utils.cpp
@@ -80,8 +80,6 @@ void FinalizationStateSpy::shuffle() {
   m_last_justified_epoch = Rand<uint32_t>();
   m_recommended_target_hash = GetRandHash();
   m_recommended_target_epoch = Rand<uint32_t>();
-  m_last_voter_rescale = Rand<ufp64::ufp64_t>();
-  m_last_non_voter_rescale = Rand<ufp64::ufp64_t>();
   m_reward_factor = Rand<ufp64::ufp64_t>();
 }
 


### PR DESCRIPTION
Make `m_last_voter_rescale` and `m_last_non_voter_rescale` local variables
to reduce the size of FinalizationState and have a better understanding of how and
where these fields are used

Signed-off-by: Kostiantyn Stepaniuk <kostia@thirdhash.com>