### PR TITLE
scripted-diff: Update year in copyright headers

### DIFF
--- a/contrib/devtools/lint-clang-format.py
+++ b/contrib/devtools/lint-clang-format.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The Unit-e developers
+# Copyright (c) 2018-2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/better-enums/enum_set.h
+++ b/src/better-enums/enum_set.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/blockchain/blockchain_genesis.h
+++ b/src/blockchain/blockchain_genesis.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/blockchain/blockchain_interfaces.h
+++ b/src/blockchain/blockchain_interfaces.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/dependency_injector.h
+++ b/src/dependency_injector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/esperanza/admincommand.cpp
+++ b/src/esperanza/admincommand.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/esperanza/admincommand.h
+++ b/src/esperanza/admincommand.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/esperanza/adminparams.h
+++ b/src/esperanza/adminparams.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/esperanza/checkpoint.cpp
+++ b/src/esperanza/checkpoint.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/esperanza/checkpoint.h
+++ b/src/esperanza/checkpoint.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/esperanza/checks.h
+++ b/src/esperanza/checks.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Copyright (c) 2017 The Particl Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/src/esperanza/init.cpp
+++ b/src/esperanza/init.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/esperanza/validator.cpp
+++ b/src/esperanza/validator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/esperanza/validator.h
+++ b/src/esperanza/validator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/esperanza/validatorstate.h
+++ b/src/esperanza/validatorstate.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/esperanza/vote.cpp
+++ b/src/esperanza/vote.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/esperanza/vote.h
+++ b/src/esperanza/vote.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/finalization/vote_recorder.cpp
+++ b/src/finalization/vote_recorder.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/finalization/vote_recorder.h
+++ b/src/finalization/vote_recorder.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/proposer/proposer_state.h
+++ b/src/proposer/proposer_state.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/proposer/waiter.cpp
+++ b/src/proposer/waiter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/proposer/waiter.h
+++ b/src/proposer/waiter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpc/finalization.cpp
+++ b/src/rpc/finalization.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpc/proposing.h
+++ b/src/rpc/proposing.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/snapshot/chainstate_iterator.cpp
+++ b/src/snapshot/chainstate_iterator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/snapshot/chainstate_iterator.h
+++ b/src/snapshot/chainstate_iterator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/snapshot/creator.h
+++ b/src/snapshot/creator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/snapshot/snapshot_index.cpp
+++ b/src/snapshot/snapshot_index.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/better_enum_set_tests.cpp
+++ b/src/test/better_enum_set_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/dependency_injector_tests.cpp
+++ b/src/test/dependency_injector_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/esperanza/adminstate_tests.cpp
+++ b/src/test/esperanza/adminstate_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/esperanza/finalization_utils.cpp
+++ b/src/test/esperanza/finalization_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/esperanza/finalization_utils.h
+++ b/src/test/esperanza/finalization_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/esperanza/finalizationstate_utils.cpp
+++ b/src/test/esperanza/finalizationstate_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/esperanza/finalizationstate_utils.h
+++ b/src/test/esperanza/finalizationstate_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/finalization/vote_recorder_tests.cpp
+++ b/src/test/finalization/vote_recorder_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/interpreter_tests.cpp
+++ b/src/test/interpreter_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/sign_tests.cpp
+++ b/src/test/sign_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/snapshot/chainstate_iterator_tests.cpp
+++ b/src/test/snapshot/chainstate_iterator_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/snapshot/creator_tests.cpp
+++ b/src/test/snapshot/creator_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <snapshot/creator.h>

--- a/src/test/staking/stake_validator_tests.cpp
+++ b/src/test/staking/stake_validator_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/test/ufp64_tests.cpp
+++ b/src/test/ufp64_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/wallet/rpcaddressbook.cpp
+++ b/src/wallet/rpcaddressbook.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/wallet/rpcadmin.cpp
+++ b/src/wallet/rpcadmin.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/wallet/test/rpcvalidator_tests.cpp
+++ b/src/wallet/test/rpcvalidator_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Unit-e developers
+// Copyright (c) 2018-2019 The Unit-e developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/test/functional/feature_graphene_passive.py
+++ b/test/functional/feature_graphene_passive.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The Unit-e developers
+# Copyright (c) 2018-2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/test/functional/feature_spend_genesis.py
+++ b/test/functional/feature_spend_genesis.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The Unit-e developers
+# Copyright (c) 2018-2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/test/functional/finalization_finalizationstate.py
+++ b/test/functional/finalization_finalizationstate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The Unit-e developers
+# Copyright (c) 2018-2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/test/functional/p2p_embargoman_star.py
+++ b/test/functional/p2p_embargoman_star.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The Unit-e developers
+# Copyright (c) 2018-2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http: // www.opensource.org/licenses/mit-license.php.
 """

--- a/test/functional/proposer_balance.py
+++ b/test/functional/proposer_balance.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2018 The Unit-e developers
+# Copyright (c) 2018-2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test Blockchain's rewards & UTXOs balance consistency"""

--- a/test/functional/proposer_multiwallet.py
+++ b/test/functional/proposer_multiwallet.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The Unit-e developers
+# Copyright (c) 2018-2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from test_framework.util import assert_equal, wait_until

--- a/test/functional/proposer_settings.py
+++ b/test/functional/proposer_settings.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The Unit-e developers
+# Copyright (c) 2018-2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from test_framework.util import *

--- a/test/functional/proposer_stakeable_balance.py
+++ b/test/functional/proposer_stakeable_balance.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The Unit-e developers
+# Copyright (c) 2018-2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from test_framework.util import *

--- a/test/functional/rpc_runstringcommand.py
+++ b/test/functional/rpc_runstringcommand.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The Unit-e developers
+# Copyright (c) 2018-2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the RPC call related to the runstringcommand command.

--- a/test/functional/rpc_sendtypeto.py
+++ b/test/functional/rpc_sendtypeto.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The Unit-e developers
+# Copyright (c) 2018-2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/test/functional/test_framework/regtest_mnemonics.py
+++ b/test/functional/test_framework/regtest_mnemonics.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2018 The Unit-e developers
+# Copyright (c) 2018-2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/test/functional/wallet_importmasterkey.py
+++ b/test/functional/wallet_importmasterkey.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The Unit-e developers
+# Copyright (c) 2018-2019 The Unit-e developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test importing a HD masterkey from a seed value (BIP39)."""


### PR DESCRIPTION
Scripted diff to update copyright years. Extracted from #1069. Needs to be rebased and merged after that pull request.
