### PR TITLE
Restore unit test keepalives in Travis

### DIFF
--- a/.travis/test_06_script.sh
+++ b/.travis/test_06_script.sh
@@ -51,7 +51,7 @@ END_FOLD
 
 if [ "$RUN_TESTS" = "true" ]; then
   BEGIN_FOLD unit-tests
-  echo Running the unit tests with an increased timeout
+  echo "Running the unit tests (this might take a while...)"
   travis_wait DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1
   END_FOLD
 fi

--- a/.travis/test_06_script.sh
+++ b/.travis/test_06_script.sh
@@ -38,7 +38,7 @@ BEGIN_FOLD distdir
 DOCKER_EXEC make distdir VERSION=$HOST
 END_FOLD
 
-DOCKER_EXEC chmod a+w unit-e-$HOST
+DOCKER_EXEC chmod a+w unit-e-$HOST  # Needed to allow travis_wait to create a log file
 cd unit-e-$HOST
 
 BEGIN_FOLD configure
@@ -51,6 +51,7 @@ END_FOLD
 
 if [ "$RUN_TESTS" = "true" ]; then
   BEGIN_FOLD unit-tests
+  echo Running the unit tests with an increased timeout
   travis_wait DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1
   END_FOLD
 fi

--- a/.travis/test_06_script.sh
+++ b/.travis/test_06_script.sh
@@ -38,6 +38,7 @@ BEGIN_FOLD distdir
 DOCKER_EXEC make distdir VERSION=$HOST
 END_FOLD
 
+DOCKER_EXEC chmod a+w unit-e-$HOST
 cd unit-e-$HOST
 
 BEGIN_FOLD configure
@@ -50,7 +51,7 @@ END_FOLD
 
 if [ "$RUN_TESTS" = "true" ]; then
   BEGIN_FOLD unit-tests
-  DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1
+  travis_wait DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1
   END_FOLD
 fi
 

--- a/.travis/test_06_script.sh
+++ b/.travis/test_06_script.sh
@@ -50,7 +50,6 @@ END_FOLD
 
 if [ "$RUN_TESTS" = "true" ]; then
   BEGIN_FOLD unit-tests
-  echo "Running the unit tests (this might take a while...)"
   while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
   KEEPALIVE_PID=$!
   DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1

--- a/.travis/test_06_script.sh
+++ b/.travis/test_06_script.sh
@@ -52,8 +52,10 @@ if [ "$RUN_TESTS" = "true" ]; then
   BEGIN_FOLD unit-tests
   echo "Running the unit tests (this might take a while...)"
   while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
+  KEEPALIVE_PID=$!
   DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1
-  kill %1
+  disown $KEEPALIVE_PID
+  kill $KEEPALIVE_PID
   END_FOLD
 fi
 

--- a/.travis/test_06_script.sh
+++ b/.travis/test_06_script.sh
@@ -38,7 +38,6 @@ BEGIN_FOLD distdir
 DOCKER_EXEC make distdir VERSION=$HOST
 END_FOLD
 
-DOCKER_EXEC chmod a+w unit-e-$HOST  # Needed to allow travis_wait to create a log file
 cd unit-e-$HOST
 
 BEGIN_FOLD configure
@@ -52,7 +51,9 @@ END_FOLD
 if [ "$RUN_TESTS" = "true" ]; then
   BEGIN_FOLD unit-tests
   echo "Running the unit tests (this might take a while...)"
-  travis_wait DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1
+  while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
+  DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1
+  kill %1
   END_FOLD
 fi
 

--- a/test/util/unite-util-test.py
+++ b/test/util/unite-util-test.py
@@ -80,7 +80,6 @@ def bctest(testDir, testObj, buildenv):
     execprog = os.path.join(buildenv["BUILDDIR"], "src", testObj["exec"] + buildenv["EXEEXT"])
     execargs = testObj['args']
     execrun = [execprog] + execargs
-    print(execrun)
 
     # Read the input data (if there is any)
     stdinCfg = None


### PR DESCRIPTION
By default, Travis kills the build if more than 10 minutes pass without
any output on screen. After the PR #1065 was merged, [this regularly happens](https://travis-ci.com/dtr-org/unit-e/jobs/197972202#L3384)
with our Windows build .

This commit restores the keepalive changes from #115 that were lost with the 0.17 merge.