### PR TITLE
Remove fCheckDuplicateInputs flag from CheckTransaction

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -159,7 +159,7 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
     return nSigOps;
 }
 
-bool CheckTransaction(const CTransaction &tx, CValidationState &errState, bool fCheckDuplicateInputs)
+bool CheckTransaction(const CTransaction &tx, CValidationState &errState)
 {
     // Basic checks that don't depend on any context
     if (tx.vin.empty())
@@ -182,14 +182,11 @@ bool CheckTransaction(const CTransaction &tx, CValidationState &errState, bool f
         if (!MoneyRange(nValueOut))
             return errState.DoS(100, false, REJECT_INVALID, "bad-txns-txouttotal-toolarge");
     }
-
-    // Check for duplicate inputs - note that this check is slow so we skip it in CheckBlock
-    if (fCheckDuplicateInputs) {
-        std::set<COutPoint> vInOutPoints;
-        for (const auto& txin : tx.vin)
-        {
-            if (!vInOutPoints.insert(txin.prevout).second)
-                return errState.DoS(100, false, REJECT_INVALID, "bad-txns-inputs-duplicate");
+    std::set<COutPoint> vInOutPoints;
+    for (const auto& txin : tx.vin)
+    {
+        if (!vInOutPoints.insert(txin.prevout).second) {
+            return errState.DoS(100, false, REJECT_INVALID, "bad-txns-inputs-duplicate");
         }
     }
 

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -19,7 +19,7 @@ class CValidationState;
 /** Transaction validation functions */
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransaction &tx, CValidationState &errState, bool fCheckDuplicateInputs=true);
+bool CheckTransaction(const CTransaction &tx, CValidationState &errState);
 
 namespace Consensus {
 /**

--- a/src/staking/legacy_validation_interface.cpp
+++ b/src/staking/legacy_validation_interface.cpp
@@ -98,7 +98,7 @@ class LegacyValidationImpl : public LegacyValidationInterface {
     // Check transactions
     CTransactionRef prevTx;
     for (const auto &tx : block.vtx) {
-      if (!CheckTransaction(*tx, state, true)) {
+      if (!CheckTransaction(*tx, state)) {
         return state.Invalid(
             false, state.GetRejectCode(), state.GetRejectReason(),
             strprintf(


### PR DESCRIPTION
This removes the `fCheckDuplicateInputs` flag from `CheckTransaction` in `consensus/tx_verify.cpp`.

This flag was subject to a CVE in bitcoin (See the full disclosure posting in their blog: https://bitcoincore.org/en/2018/09/20/notice/).

Ever since the CVE was fixed this flag is never passed as `false` and you must not not check it. Also the behavior is not checked with the parameter `false` in any test, as can be seen from this pull request as no test had to be touched yet everything passes.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
