### PR TITLE
Cleanup old checkpoints from finalization state

### DIFF
--- a/src/esperanza/finalizationstate.cpp
+++ b/src/esperanza/finalizationstate.cpp
@@ -163,17 +163,27 @@ void FinalizationState::IncrementDynasty() {
 
   // skip dynasty increment for the hardcoded finalized epoch=0
   // as it's already "considered" incremented from -1 to 0.
-  if (m_current_epoch > 2 && GetCheckpoint(m_current_epoch - 2).m_is_finalized) {
-
-    m_current_dynasty += 1;
-    m_prev_dyn_deposits = m_cur_dyn_deposits;
-    m_cur_dyn_deposits += GetDynastyDelta(m_current_dynasty);
-    m_dynasty_start_epoch[m_current_dynasty] = m_current_epoch + 1;
-
-    LogPrint(BCLog::FINALIZATION, "%s: New current dynasty=%d\n", __func__,
-             m_current_dynasty);
-    // UNIT-E: we can clear old checkpoints (up to m_last_finalized_epoch - 1)
+  if (m_current_epoch < 3) {
+    return;
   }
+  if (!GetCheckpoint(m_current_epoch - 2).m_is_finalized) {
+    return;
+  }
+  m_current_dynasty += 1;
+  m_prev_dyn_deposits = m_cur_dyn_deposits;
+  m_cur_dyn_deposits += GetDynastyDelta(m_current_dynasty);
+  m_dynasty_start_epoch[m_current_dynasty] = m_current_epoch + 1;
+
+  for (auto it = m_checkpoints.begin(); it != m_checkpoints.end();) {
+    if (it->first < m_last_finalized_epoch) {
+      it = m_checkpoints.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  LogPrint(BCLog::FINALIZATION, "%s: New current dynasty=%d\n", __func__,
+           m_current_dynasty);
 }
 
 ufp64::ufp64_t FinalizationState::GetCollectiveRewardFactor() {
@@ -1075,8 +1085,7 @@ bool FinalizationState::IsFinalizedCheckpoint(blockchain::Height blockHeight) co
   if (!m_settings.IsCheckpoint(blockHeight)) {
     return false;
   }
-  auto const it = m_checkpoints.find(GetEpoch(blockHeight));
-  return it != m_checkpoints.end() && it->second.m_is_finalized;
+  return GetEpoch(blockHeight) <= m_last_finalized_epoch;
 }
 
 FinalizationState::InitStatus FinalizationState::GetInitStatus() const {

--- a/src/esperanza/finalizationstate.cpp
+++ b/src/esperanza/finalizationstate.cpp
@@ -327,8 +327,8 @@ Result FinalizationState::IsVotable(const Validator &validator,
   if (it == m_checkpoints.end()) {
     return fail(Result::VOTE_MALFORMED,
                 log_errors,
-                "%s: target_epoch=%d is in the future.\n", __func__,
-                targetEpoch);
+                "%s: target_epoch=%d not found. current_epoch=%d.\n", __func__,
+                targetEpoch, m_current_epoch);
   }
 
   auto &targetCheckpoint = it->second;
@@ -363,7 +363,7 @@ Result FinalizationState::IsVotable(const Validator &validator,
   if (it == m_checkpoints.end()) {
     return fail(Result::VOTE_MALFORMED,
                 log_errors,
-                "%s: source_epoch=%d is in the future. current_epoch=%d\n", __func__,
+                "%s: source_epoch=%d not found. current_epoch=%d\n", __func__,
                 sourceEpoch, m_current_epoch);
   }
 

--- a/src/test/esperanza/checks_tests.cpp
+++ b/src/test/esperanza/checks_tests.cpp
@@ -742,7 +742,7 @@ BOOST_AUTO_TEST_CASE(ContextualCheckVoteTx_test) {
   CPubKey pub_key = key.GetPubKey();
   uint160 validator_address = pub_key.GetID();
 
-  Vote vote_out{pub_key.GetID(), target_hash, 0, 5};
+  Vote vote_out{pub_key.GetID(), target_hash, 4, 5};
 
   std::vector<unsigned char> vote_sig_out;
   BOOST_REQUIRE(CreateVoteSignature(&keystore, vote_out, vote_sig_out));

--- a/src/test/esperanza/finalizationstate_vote_tests.cpp
+++ b/src/test/esperanza/finalizationstate_vote_tests.cpp
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE(process_vote_tx_success) {
 
   spy.CreateAndActivateDeposit(validatorAddress, depositSize);
 
-  Vote vote{validatorAddress, targetHash, 1, 5};
+  Vote vote{validatorAddress, targetHash, 4, 5};
   BOOST_CHECK_EQUAL(spy.ValidateVote(vote), +Result::SUCCESS);
 }
 

--- a/test/functional/finalization_vote.py
+++ b/test/functional/finalization_vote.py
@@ -161,7 +161,7 @@ class VoteTest(UnitETestFramework):
         assert_raises_rpc_error(-26, 'bad-vote-invalid', node0.sendrawtransaction, tx)
         tx = make_vote_tx(finalizer1, address1, node0.getblockhash(40), 7, 6, prev_tx)
         assert_raises_rpc_error(-26, 'bad-vote-invalid', node0.sendrawtransaction, tx)
-        self.log.info('Bad configured votes cannot screw up things')
+        self.log.info('Tested outdated and invalid vote votes')
 
         # check that make_vote_tx works as expected (we really rely on this guy on tests above)
         tx = make_vote_tx(finalizer1, address1, node0.getblockhash(40), 7, 8, prev_tx)

--- a/test/functional/finalization_vote.py
+++ b/test/functional/finalization_vote.py
@@ -10,9 +10,11 @@ VoteTest checks:
 from test_framework.util import (
     assert_equal,
     assert_finalizationstate,
+    assert_raises_rpc_error,
     connect_nodes,
     disconnect_nodes,
     generate_block,
+    make_vote_tx,
     sync_blocks,
 )
 from test_framework.test_framework import UnitETestFramework
@@ -135,7 +137,7 @@ class VoteTest(UnitETestFramework):
         # test that finalizers can vote after configured epoch block number
         generate_block(node0, count=4)
         assert_equal(node0.getblockcount(), 39)
-        self.wait_for_vote_and_disconnect(finalizer=finalizer1, node=node0)
+        prev_tx = self.wait_for_vote_and_disconnect(finalizer=finalizer1, node=node0)
         self.wait_for_vote_and_disconnect(finalizer=finalizer2, node=node0)
         self.wait_for_vote_and_disconnect(finalizer=finalizer3, node=node0)
         generate_block(node0)
@@ -146,6 +148,34 @@ class VoteTest(UnitETestFramework):
                                          'lastFinalizedEpoch': 6,
                                          'validators': 3})
         self.log.info('Finalizers voted after configured block number')
+
+        generate_block(node0, count=4)
+        prev_tx = finalizer1.decoderawtransaction(prev_tx)['txid']
+
+        # test that node recognizes old and invalid votes.
+        tx = make_vote_tx(finalizer1, address1, node0.getblockhash(40), 5, 8, prev_tx)
+        assert_raises_rpc_error(-26, 'bad-vote-invalid', node0.sendrawtransaction, tx)
+        tx = make_vote_tx(finalizer1, address1, node0.getblockhash(40), 7, 9, prev_tx)
+        assert_raises_rpc_error(-26, 'bad-vote-invalid', node0.sendrawtransaction, tx)
+        tx = make_vote_tx(finalizer1, address1, node0.getblockhash(40), 5, 6, prev_tx)
+        assert_raises_rpc_error(-26, 'bad-vote-invalid', node0.sendrawtransaction, tx)
+        tx = make_vote_tx(finalizer1, address1, node0.getblockhash(40), 7, 6, prev_tx)
+        assert_raises_rpc_error(-26, 'bad-vote-invalid', node0.sendrawtransaction, tx)
+        self.log.info('Bad configured votes cannot screw up things')
+
+        # check that make_vote_tx works as expected (we really rely on this guy on tests above)
+        tx = make_vote_tx(finalizer1, address1, node0.getblockhash(40), 7, 8, prev_tx)
+        node0.sendrawtransaction(tx)
+        self.wait_for_vote_and_disconnect(finalizer=finalizer2, node=node0)
+        self.wait_for_vote_and_disconnect(finalizer=finalizer3, node=node0)
+        generate_block(node0)
+        assert_equal(node0.getblockcount(), 45)
+        assert_finalizationstate(node0, {'currentDynasty': 6,
+                                         'currentEpoch': 9,
+                                         'lastJustifiedEpoch': 8,
+                                         'lastFinalizedEpoch': 7,
+                                         'validators': 3})
+        self.log.info('make_vote_tx works together with real finalizers')
 
         # UNIT-E TODO: there is a know issue https://github.com/dtr-org/unit-e/issues/643
         # that finalizer doesn't vote after processing the checkpoint.


### PR DESCRIPTION
This fix significantly reduces individual finalization state size.

In a test, I run 1 proposer with 4 finalizers with configuration epoch_length=2.
After processing ~9k blocks and ~4.5k epochs, finalization state size was 767599.
After applying this PR, it has been reduced to 196002. More finalizers we have,
more memory we save, because checkpoints map holds votes from every finalizer.

Relates to #1073.