### PR TITLE
Fix scripted diffs with CRs in the commit message

### DIFF
--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -23,7 +23,7 @@ PREV_HEAD=`git rev-parse HEAD`
 for i in `git rev-list --reverse $1`; do
     if git rev-list -n 1 --pretty="%s" $i | grep -q "^scripted-diff:"; then
         git checkout --quiet $i^ || exit
-        SCRIPT="`git rev-list --format=%b -n1 $i | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d'`"
+        SCRIPT="`git rev-list --format=%b -n1 $i | sed 's/\r$//;/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d'`"
         if test "x$SCRIPT" = "x"; then
             echo "Error: missing script for: $i"
             echo "Failed"


### PR DESCRIPTION
GitHub inserts line endings using CRs in some cases when squashing
commits. This causes issues in case of scripted diffs where the
script is extracted from the commit message by `commit-script-check.sh`.

This patch fixes this by removing CRs at the end of the line before
extracting the script for checking the commit.

This issue made the lint check on https://github.com/dtr-org/unit-e/pull/1083 fail. With this patch the lint check should work again on that PR.

You can test the change locally by calling `commit-script-check.sh` manually with a commit range which includes a scripted diff. I tested with `test/lint/commit-script-check.sh 9978e63..a52d88e` which is the commit with the scripted diff we added in #1072.
