### PR TITLE
Move GetEpoch, IsEpochStart, and IsCheckpoint to finalization::Params

### DIFF
--- a/src/esperanza/finalizationstate.h
+++ b/src/esperanza/finalizationstate.h
@@ -168,12 +168,6 @@ class FinalizationState : public FinalizationStateData {
   //! \brief Retrives the hash of the last finalization transaction performed by the validator.
   uint256 GetLastTxHash(const uint160 &validatorAddress) const;
 
-  //! \brief Returns whether block on block_height is the first block of the epoch
-  bool IsEpochStart(blockchain::Height block_height) const;
-
-  //! \brief Returns whether block on blockHeight is the last block of the epoch
-  bool IsCheckpoint(blockchain::Height blockHeight) const;
-
   //! \brief Returns whether block on height blockHeight is justified checkpoint
   bool IsJustifiedCheckpoint(blockchain::Height blockHeight) const;
 

--- a/src/finalization/params.h
+++ b/src/finalization/params.h
@@ -31,6 +31,16 @@ struct Params {
 
   esperanza::AdminParams admin_params;
 
+  //! \brief Returns the epoch which includes block_height.
+  inline uint32_t GetEpoch(const blockchain::Height block_height) const {
+    uint32_t epoch = block_height / epoch_length;
+    if (block_height % epoch_length != 0) {
+      ++epoch;
+    }
+    return epoch;
+  }
+
+  //! \brief Returns the height of the first block of the epoch.
   inline blockchain::Height GetEpochStartHeight(const uint32_t epoch) const {
     // epoch=0 contains only genesis
     if (epoch == 0) {
@@ -39,8 +49,19 @@ struct Params {
     return GetEpochCheckpointHeight(epoch - 1) + 1;
   }
 
+  //! \brief Returns the height of the last block of the epoch.
   inline blockchain::Height GetEpochCheckpointHeight(const uint32_t epoch) const {
     return epoch * epoch_length;
+  }
+
+  //! \brief Returns whether block at block_height is the first block of the epoch.
+  inline bool IsEpochStart(blockchain::Height block_height) const {
+    return block_height % epoch_length == 1;
+  }
+
+  //! \brief Returns whether block at block_height is the last block of the epoch.
+  inline bool IsCheckpoint(blockchain::Height block_height) const {
+    return block_height % epoch_length == 0;
   }
 
   static Params RegTest(bool gen_admin_keys = false);

--- a/src/test/esperanza/finalizationstate_tests.cpp
+++ b/src/test/esperanza/finalizationstate_tests.cpp
@@ -27,33 +27,6 @@ BOOST_AUTO_TEST_CASE(constructor) {
   BOOST_CHECK_EQUAL(0, state.GetLastJustifiedEpoch());
 }
 
-BOOST_AUTO_TEST_CASE(get_epoch) {
-  std::map<uint32_t, uint32_t> height_to_epoch{
-      {0, 0},
-      {1, 1},
-      {2, 1},
-      {3, 1},
-      {4, 1},
-      {5, 1},
-      {6, 2},
-      {9, 2},
-      {10, 2},
-      {11, 3},
-      {15, 3},
-      {16, 4},
-      {20, 4},
-      {25, 5},
-  };
-
-  finalization::Params params;
-  FinalizationState state(params);
-  BOOST_REQUIRE_EQUAL(state.GetEpochLength(), 5);
-
-  for (const auto &it : height_to_epoch) {
-    BOOST_CHECK_EQUAL(state.GetEpoch(it.first), it.second);
-  }
-}
-
 // InitializeEpoch tests
 
 BOOST_AUTO_TEST_CASE(initialize_epoch_wrong_height_passed) {

--- a/src/test/finalization/params_tests.cpp
+++ b/src/test/finalization/params_tests.cpp
@@ -9,6 +9,32 @@
 
 BOOST_AUTO_TEST_SUITE(finalization_params_tests)
 
+BOOST_AUTO_TEST_CASE(get_epoch) {
+  std::map<uint32_t, uint32_t> height_to_epoch{
+      {0, 0},
+      {1, 1},
+      {2, 1},
+      {3, 1},
+      {4, 1},
+      {5, 1},
+      {6, 2},
+      {9, 2},
+      {10, 2},
+      {11, 3},
+      {15, 3},
+      {16, 4},
+      {20, 4},
+      {25, 5},
+  };
+
+  finalization::Params params;
+  params.epoch_length = 5;
+
+  for (const auto &it : height_to_epoch) {
+    BOOST_CHECK_EQUAL(params.GetEpoch(it.first), it.second);
+  }
+}
+
 BOOST_AUTO_TEST_CASE(get_epoch_start_height) {
   finalization::Params params;
   params.epoch_length = 5;
@@ -39,6 +65,50 @@ BOOST_AUTO_TEST_CASE(get_epoch_checkpoint_height) {
   BOOST_CHECK_EQUAL(params.GetEpochCheckpointHeight(1), 50);
   BOOST_CHECK_EQUAL(params.GetEpochCheckpointHeight(2), 100);
   BOOST_CHECK_EQUAL(params.GetEpochCheckpointHeight(3), 150);
+}
+
+BOOST_AUTO_TEST_CASE(is_epoch_start) {
+  finalization::Params params;
+  params.epoch_length = 5;
+
+  BOOST_CHECK(!params.IsEpochStart(0));
+  BOOST_CHECK(params.IsEpochStart(1));
+  BOOST_CHECK(!params.IsEpochStart(2));
+  BOOST_CHECK(!params.IsEpochStart(3));
+  BOOST_CHECK(!params.IsEpochStart(4));
+  BOOST_CHECK(!params.IsEpochStart(5));
+  BOOST_CHECK(params.IsEpochStart(6));
+  BOOST_CHECK(params.IsEpochStart(11));
+
+  params.epoch_length = 42;
+  BOOST_CHECK(!params.IsEpochStart(0));
+  BOOST_CHECK(params.IsEpochStart(1));
+  BOOST_CHECK(!params.IsEpochStart(2));
+  BOOST_CHECK(!params.IsEpochStart(6));
+  BOOST_CHECK(params.IsEpochStart(43));
+  BOOST_CHECK(params.IsEpochStart(85));
+}
+
+BOOST_AUTO_TEST_CASE(is_checkpoint) {
+  finalization::Params params;
+  params.epoch_length = 5;
+
+  BOOST_CHECK(params.IsCheckpoint(0));
+  BOOST_CHECK(!params.IsCheckpoint(1));
+  BOOST_CHECK(!params.IsCheckpoint(2));
+  BOOST_CHECK(!params.IsCheckpoint(3));
+  BOOST_CHECK(!params.IsCheckpoint(4));
+  BOOST_CHECK(params.IsCheckpoint(5));
+  BOOST_CHECK(!params.IsCheckpoint(6));
+  BOOST_CHECK(params.IsCheckpoint(10));
+
+  params.epoch_length = 11;
+  BOOST_CHECK(params.IsCheckpoint(0));
+  BOOST_CHECK(!params.IsCheckpoint(1));
+  BOOST_CHECK(!params.IsCheckpoint(2));
+  BOOST_CHECK(!params.IsCheckpoint(5));
+  BOOST_CHECK(params.IsCheckpoint(11));
+  BOOST_CHECK(params.IsCheckpoint(22));
 }
 
 BOOST_AUTO_TEST_CASE(parse_params_invalid_json) {


### PR DESCRIPTION
`GetEpoch`, `IsEpochStart`, and `IsCheckpoint` do not depend on the finalization state and hence should be moved to `finalization::Params`.

Extracted from #1081.