### PR TITLE
Uniform Mocks + Blocktool for faking block index

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -35,7 +35,11 @@ UNITE_TEST_SUITE = \
   test/test_unite_block_fixture.h \
   test/test_unite_block_fixture.cpp \
   test/test_unite_main.cpp \
-  test/test_unite_mocks.h
+  test/test_unite_mocks.h \
+  test/util/blocktools.h \
+  test/util/blocktools.cpp \
+  test/util/mocks.h \
+  test/util/mocks.cpp
 
 # test_unite binary #
 UNITE_TESTS =\
@@ -139,6 +143,7 @@ UNITE_TESTS =\
   test/ufp64_tests.cpp \
   test/uint256_tests.cpp \
   test/util_tests.cpp \
+  test/util/blocktools_tests.cpp \
   test/validation_tests.cpp \
   test/versionbits_tests.cpp
 

--- a/src/test/finalization/state_db_tests.cpp
+++ b/src/test/finalization/state_db_tests.cpp
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
       state.shuffle();
       original.emplace(block_index, std::move(state));
     }
-    block_index_fake.SetActiveChain(tip99, active_chain);
+    block_index_fake.SetupActiveChain(tip99, active_chain);
     BOOST_REQUIRE_EQUAL(original.size(), 100);
     BOOST_REQUIRE_EQUAL(active_chain.GetTip()->nHeight, 99);
   }
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
   // accoring to the main chain. Simply move active chain forward but keep db as is.
   {
     const CBlockIndex *tip104 = block_index_fake.Generate(5, active_chain.GetTip()->GetBlockHash());
-    block_index_fake.SetActiveChain(tip104, active_chain);
+    block_index_fake.SetupActiveChain(tip104, active_chain);
     BOOST_REQUIRE(active_chain.GetTip()->nHeight == 104);
   }
 

--- a/src/test/finalization/state_db_tests.cpp
+++ b/src/test/finalization/state_db_tests.cpp
@@ -2,9 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <finalization/state_db.h>
+
+#include <finalization/params.h>
+
 #include <test/esperanza/finalizationstate_utils.h>
 #include <test/test_unite.h>
 #include <test/test_unite_mocks.h>
+#include <test/util/blocktools.h>
 #include <boost/test/unit_test.hpp>
 
 namespace esperanza {
@@ -27,8 +32,8 @@ std::string stringify(const CBlockIndex *const &index) {
 BOOST_AUTO_TEST_SUITE(state_db_tests)
 
 BOOST_AUTO_TEST_CASE(leveldb_rand) {
-  mocks::ActiveChainMock active_chain;
-  mocks::BlockIndexMapMock block_index_map;
+  mocks::ActiveChainFake active_chain;
+  mocks::BlockIndexMapFake block_index_map;
   Settings settings;
   finalization::StateDBParams params;
   params.inmemory = true;
@@ -46,7 +51,7 @@ BOOST_AUTO_TEST_CASE(leveldb_rand) {
     state.shuffle();
     original.emplace(block_index, std::move(state));
   }
-  BOOST_REQUIRE(original.size() == 100);
+  BOOST_REQUIRE_EQUAL(original.size(), 100);
 
   db->Save(original);
 
@@ -57,31 +62,29 @@ BOOST_AUTO_TEST_CASE(leveldb_rand) {
   BOOST_CHECK_EQUAL(restored, original);
 }
 
-class ActiveChainTest : public mocks::ActiveChainMock {
- public:
-  ActiveChainTest() {
-    this->stub_AtHeight = [this](blockchain::Height const h) -> CBlockIndex * {
-      const auto it = m_block_heights.find(h);
-      return it != m_block_heights.end() ? it->second : nullptr;
-    };
-  }
-
-  void Add(CBlockIndex &index) {
-    this->result_GetTip = &index;
-    m_block_heights[index.nHeight] = &index;
-  }
-
- private:
-  std::map<blockchain::Height, CBlockIndex *> m_block_heights;
-};
-
 BOOST_AUTO_TEST_CASE(load_best_states) {
-  ActiveChainTest active_chain;
-  mocks::BlockIndexMapMock block_index_map;
   Settings settings;
   finalization::StateDBParams params;
   params.inmemory = true;
   finalization::Params finalization_params;
+
+  mocks::ActiveChainMock active_chain;
+  blocktools::BlockIndexFake block_index_fake;
+  mocks::BlockIndexMapMock block_index_map;
+
+  block_index_map.mock_ForEach.SetStub([&](std::function<bool(const uint256 &, const CBlockIndex &)> &&f) {
+    for (auto &entry : block_index_fake.block_indexes) {
+      const CBlockIndex &block_index = entry.second;
+      f(block_index.GetBlockHash(), block_index);
+    }
+  });
+  block_index_map.mock_Lookup.SetStub([&](const uint256 &block_hash) -> CBlockIndex * {
+    auto result = block_index_fake.block_indexes.find(block_hash);
+    if (result == block_index_fake.block_indexes.end()) {
+      return nullptr;
+    }
+    return &result->second;
+  });
 
   std::unique_ptr<finalization::StateDB> db = finalization::StateDB::NewFromParams(
       params, &settings, &finalization_params, &block_index_map, &active_chain);
@@ -89,53 +92,49 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
   LOCK(block_index_map.GetLock());
   LOCK(active_chain.GetLock());
 
-  auto generate = [&](CBlockIndex *prev, bool add_to_chain) {
-    const blockchain::Height h = prev != nullptr ? prev->nHeight + 1 : 0;
-    CBlockIndex *index = block_index_map.Insert(GetRandHash());
-    index->pprev = prev;
-    index->nHeight = h;
-    if (add_to_chain) {
-      active_chain.Add(*index);
-    }
-    return index;
-  };
-
-  // Generate active chain
   std::map<const CBlockIndex *, esperanza::FinalizationState> original;
-  for (size_t i = 0; i < 100; ++i) {
-    CBlockIndex *block_index = generate(active_chain.result_GetTip, true);
-    FinalizationStateSpy state(finalization_params);
-    state.shuffle();
-    original.emplace(block_index, std::move(state));
-  }
-  BOOST_REQUIRE(original.size() == 100);
-  BOOST_REQUIRE(active_chain.GetTip()->nHeight == 99);
 
-  // Generate fork 1 higher 50
+  // Generate an active chain with 100 blocks
   {
-    CBlockIndex *index = active_chain.stub_AtHeight(50);
-    for (size_t i = 0; i < 100; ++i) {
-      index = generate(index, false);
+    const CBlockIndex *tip99 = block_index_fake.Generate(100);
+    auto chain = block_index_fake.GetChain(tip99->GetBlockHash());
+    for (CBlockIndex *block_index : *chain) {
       FinalizationStateSpy state(finalization_params);
       state.shuffle();
-      original.emplace(index, std::move(state));
+      original.emplace(block_index, std::move(state));
     }
+    block_index_fake.SetActiveChain(tip99, active_chain);
+    BOOST_REQUIRE_EQUAL(original.size(), 100);
+    BOOST_REQUIRE_EQUAL(active_chain.GetTip()->nHeight, 99);
   }
-  BOOST_REQUIRE(original.size() == 200);
-  BOOST_REQUIRE(active_chain.GetTip()->nHeight == 99);
 
-  // Generate fork 2 higher 80
+  // Generate fork 1 branching off at height=50
   {
-    CBlockIndex *index = active_chain.stub_AtHeight(80);
-    for (size_t i = 0; i < 100; ++i) {
-      index = generate(index, false);
+    const CBlockIndex *tip50 = active_chain.AtHeight(50);
+    const CBlockIndex *tip_fork1 = block_index_fake.Generate(100, tip50->GetBlockHash());
+    auto chain = block_index_fake.GetChain(tip_fork1->GetBlockHash());
+    for (CBlockIndex *block_index : *chain) {
       FinalizationStateSpy state(finalization_params);
       state.shuffle();
-      original.emplace(index, std::move(state));
+      original.emplace(block_index, std::move(state));
     }
+    BOOST_REQUIRE_EQUAL(original.size(), 200);
+    BOOST_REQUIRE_EQUAL(active_chain.GetTip()->nHeight, 99);
   }
-  BOOST_REQUIRE(original.size() == 300);
-  BOOST_REQUIRE(active_chain.GetTip()->nHeight == 99);
+
+  // Generate fork 2 branching off at height=80
+  {
+    const CBlockIndex *tip80 = active_chain.AtHeight(80);
+    const CBlockIndex *tip_fork2 = block_index_fake.Generate(100, tip80->GetBlockHash());
+    auto chain = block_index_fake.GetChain(tip_fork2->GetBlockHash());
+    for (CBlockIndex *block_index : *chain) {
+      FinalizationStateSpy state(finalization_params);
+      state.shuffle();
+      original.emplace(block_index, std::move(state));
+    }
+    BOOST_REQUIRE_EQUAL(original.size(), 300);
+    BOOST_REQUIRE_EQUAL(active_chain.GetTip()->nHeight, 99);
+  }
 
   db->Save(original);
 
@@ -152,11 +151,11 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
 
   // Simulate that node cannot load state for tip, then it must load most recent state
   // accoring to the main chain. Simply move active chain forward but keep db as is.
-
-  for (size_t i = 0; i < 5; ++i) {
-    generate(active_chain.result_GetTip, true);
+  {
+    const CBlockIndex *tip104 = block_index_fake.Generate(5, active_chain.GetTip()->GetBlockHash());
+    block_index_fake.SetActiveChain(tip104, active_chain);
+    BOOST_REQUIRE(active_chain.GetTip()->nHeight == 104);
   }
-  BOOST_REQUIRE(active_chain.GetTip()->nHeight == 104);
 
   // Check that db can find last finalized epoch
   {

--- a/src/test/finalization/state_db_tests.cpp
+++ b/src/test/finalization/state_db_tests.cpp
@@ -173,9 +173,9 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
     db->LoadStatesHigherThan(59, &restored);
     BOOST_CHECK_EQUAL(restored.size(), 140);
 
-    for (auto it = restored.begin(); it != restored.end(); ++it) {
-      const CBlockIndex *index = it->first;
-      const esperanza::FinalizationState &state = it->second;
+    for (auto &it : restored) {
+      const CBlockIndex *index = it.first;
+      const esperanza::FinalizationState &state = it.second;
       BOOST_CHECK(index->nHeight >= 60);
 
       const auto oit = original.find(index);

--- a/src/test/finalization/state_db_tests.cpp
+++ b/src/test/finalization/state_db_tests.cpp
@@ -173,9 +173,9 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
     db->LoadStatesHigherThan(59, &restored);
     BOOST_CHECK_EQUAL(restored.size(), 140);
 
-    for (auto &it : restored) {
-      const CBlockIndex *index = it.first;
-      const esperanza::FinalizationState &state = it.second;
+    for (auto &kv : restored) {
+      const CBlockIndex *index = kv.first;
+      const esperanza::FinalizationState &state = kv.second;
       BOOST_CHECK(index->nHeight >= 60);
 
       const auto oit = original.find(index);

--- a/src/test/finalization/state_db_tests.cpp
+++ b/src/test/finalization/state_db_tests.cpp
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
   // Generate an active chain with 100 blocks
   {
     const CBlockIndex *tip99 = block_index_fake.Generate(100);
-    const std::vector<CBlockIndex *> chain = block_index_fake.GetChain(tip99->GetBlockHash());
+    const std::vector<CBlockIndex *> chain = block_index_fake.GetChain(tip99);
     for (CBlockIndex *block_index : chain) {
       FinalizationStateSpy state(finalization_params);
       state.shuffle();
@@ -111,8 +111,8 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
   // Generate fork 1 branching off at height=50
   {
     const CBlockIndex *tip50 = active_chain.AtHeight(50);
-    const CBlockIndex *tip_fork1 = block_index_fake.Generate(100, tip50->GetBlockHash());
-    const std::vector<CBlockIndex *> chain = block_index_fake.GetChain(tip_fork1->GetBlockHash());
+    const CBlockIndex *tip_fork1 = block_index_fake.Generate(100, tip50);
+    const std::vector<CBlockIndex *> chain = block_index_fake.GetChain(tip_fork1);
     for (CBlockIndex *block_index : chain) {
       FinalizationStateSpy state(finalization_params);
       state.shuffle();
@@ -125,8 +125,8 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
   // Generate fork 2 branching off at height=80
   {
     const CBlockIndex *tip80 = active_chain.AtHeight(80);
-    const CBlockIndex *tip_fork2 = block_index_fake.Generate(100, tip80->GetBlockHash());
-    const std::vector<CBlockIndex *> chain = block_index_fake.GetChain(tip_fork2->GetBlockHash());
+    const CBlockIndex *tip_fork2 = block_index_fake.Generate(100, tip80);
+    const std::vector<CBlockIndex *> chain = block_index_fake.GetChain(tip_fork2);
     for (CBlockIndex *block_index : chain) {
       FinalizationStateSpy state(finalization_params);
       state.shuffle();
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
   // Simulate that node cannot load state for tip, then it must load most recent state
   // accoring to the main chain. Simply move active chain forward but keep db as is.
   {
-    const CBlockIndex *tip104 = block_index_fake.Generate(5, active_chain.GetTip()->GetBlockHash());
+    const CBlockIndex *tip104 = block_index_fake.Generate(5, active_chain.GetTip());
     block_index_fake.SetupActiveChain(tip104, active_chain);
     BOOST_REQUIRE(active_chain.GetTip()->nHeight == 104);
   }

--- a/src/test/finalization/state_db_tests.cpp
+++ b/src/test/finalization/state_db_tests.cpp
@@ -97,8 +97,8 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
   // Generate an active chain with 100 blocks
   {
     const CBlockIndex *tip99 = block_index_fake.Generate(100);
-    auto chain = block_index_fake.GetChain(tip99->GetBlockHash());
-    for (CBlockIndex *block_index : *chain) {
+    const std::vector<CBlockIndex *> chain = block_index_fake.GetChain(tip99->GetBlockHash());
+    for (CBlockIndex *block_index : chain) {
       FinalizationStateSpy state(finalization_params);
       state.shuffle();
       original.emplace(block_index, std::move(state));
@@ -112,8 +112,8 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
   {
     const CBlockIndex *tip50 = active_chain.AtHeight(50);
     const CBlockIndex *tip_fork1 = block_index_fake.Generate(100, tip50->GetBlockHash());
-    auto chain = block_index_fake.GetChain(tip_fork1->GetBlockHash());
-    for (CBlockIndex *block_index : *chain) {
+    const std::vector<CBlockIndex *> chain = block_index_fake.GetChain(tip_fork1->GetBlockHash());
+    for (CBlockIndex *block_index : chain) {
       FinalizationStateSpy state(finalization_params);
       state.shuffle();
       original.emplace(block_index, std::move(state));
@@ -126,8 +126,8 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
   {
     const CBlockIndex *tip80 = active_chain.AtHeight(80);
     const CBlockIndex *tip_fork2 = block_index_fake.Generate(100, tip80->GetBlockHash());
-    auto chain = block_index_fake.GetChain(tip_fork2->GetBlockHash());
-    for (CBlockIndex *block_index : *chain) {
+    const std::vector<CBlockIndex *> chain = block_index_fake.GetChain(tip_fork2->GetBlockHash());
+    for (CBlockIndex *block_index : chain) {
       FinalizationStateSpy state(finalization_params);
       state.shuffle();
       original.emplace(block_index, std::move(state));

--- a/src/test/finalization/state_db_tests.cpp
+++ b/src/test/finalization/state_db_tests.cpp
@@ -96,22 +96,22 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
 
   // Generate an active chain with 100 blocks
   {
-    const CBlockIndex *tip99 = block_index_fake.Generate(100);
-    const std::vector<CBlockIndex *> chain = block_index_fake.GetChain(tip99);
+    const CBlockIndex *b99 = block_index_fake.Generate(100);
+    const std::vector<CBlockIndex *> chain = block_index_fake.GetChain(b99);
     for (CBlockIndex *block_index : chain) {
       FinalizationStateSpy state(finalization_params);
       state.shuffle();
       original.emplace(block_index, std::move(state));
     }
-    block_index_fake.SetupActiveChain(tip99, active_chain);
+    block_index_fake.SetupActiveChain(b99, active_chain);
     BOOST_REQUIRE_EQUAL(original.size(), 100);
     BOOST_REQUIRE_EQUAL(active_chain.GetTip()->nHeight, 99);
   }
 
   // Generate fork 1 branching off at height=50
   {
-    const CBlockIndex *tip50 = active_chain.AtHeight(50);
-    const CBlockIndex *tip_fork1 = block_index_fake.Generate(100, tip50);
+    const CBlockIndex *b50 = active_chain.AtHeight(50);
+    const CBlockIndex *tip_fork1 = block_index_fake.Generate(100, b50);
     const std::vector<CBlockIndex *> chain = block_index_fake.GetChain(tip_fork1);
     for (CBlockIndex *block_index : chain) {
       FinalizationStateSpy state(finalization_params);
@@ -124,8 +124,8 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
 
   // Generate fork 2 branching off at height=80
   {
-    const CBlockIndex *tip80 = active_chain.AtHeight(80);
-    const CBlockIndex *tip_fork2 = block_index_fake.Generate(100, tip80);
+    const CBlockIndex *b80 = active_chain.AtHeight(80);
+    const CBlockIndex *tip_fork2 = block_index_fake.Generate(100, b80);
     const std::vector<CBlockIndex *> chain = block_index_fake.GetChain(tip_fork2);
     for (CBlockIndex *block_index : chain) {
       FinalizationStateSpy state(finalization_params);
@@ -152,8 +152,8 @@ BOOST_AUTO_TEST_CASE(load_best_states) {
   // Simulate that node cannot load state for tip, then it must load most recent state
   // accoring to the main chain. Simply move active chain forward but keep db as is.
   {
-    const CBlockIndex *tip104 = block_index_fake.Generate(5, active_chain.GetTip());
-    block_index_fake.SetupActiveChain(tip104, active_chain);
+    const CBlockIndex *b104 = block_index_fake.Generate(5, active_chain.GetTip());
+    block_index_fake.SetupActiveChain(b104, active_chain);
     BOOST_REQUIRE(active_chain.GetTip()->nHeight == 104);
   }
 

--- a/src/test/proposer/proposer_tests.cpp
+++ b/src/test/proposer/proposer_tests.cpp
@@ -114,25 +114,25 @@ BOOST_AUTO_TEST_CASE(not_proposing_stub_vs_actual_impl) {
 
 BOOST_AUTO_TEST_CASE(start_stop_and_status) {
   Fixture f{"-proposing=1"};
-  f.network_mock.result_GetNodeCount = 0;
+  f.network_mock.mock_GetNodeCount.SetResult(0);
   BOOST_CHECK_NO_THROW({
     auto p = f.MakeProposer();
     p->Start();
   });
   // destroying the proposer stops it
-  BOOST_CHECK(f.network_mock.invocations_GetNodeCount > 0);
+  BOOST_CHECK(f.network_mock.mock_GetNodeCount.CountInvocations() > 0);
   BOOST_CHECK_EQUAL(f.wallet->GetWalletExtension().GetProposerState().m_status, +proposer::Status::NOT_PROPOSING_NO_PEERS);
 }
 
 BOOST_AUTO_TEST_CASE(advance_to_blockchain_sync) {
   Fixture f{"-proposing=1"};
-  f.network_mock.result_GetNodeCount = 1;
-  f.chain_mock.result_GetInitialBlockDownloadStatus = SyncStatus::IMPORTING;
+  f.network_mock.mock_GetNodeCount.SetResult(1);
+  f.chain_mock.mock_GetInitialBlockDownloadStatus.SetResult(SyncStatus::IMPORTING);
   BOOST_CHECK_NO_THROW({
     auto p = f.MakeProposer();
     p->Start();
   });
-  BOOST_CHECK(f.chain_mock.invocations_GetInitialBlockDownloadStatus > 0);
+  BOOST_CHECK(f.chain_mock.mock_GetInitialBlockDownloadStatus.CountInvocations() > 0);
   BOOST_CHECK_EQUAL(f.wallet->GetWalletExtension().GetProposerState().m_status, +proposer::Status::NOT_PROPOSING_SYNCING_BLOCKCHAIN);
 }
 

--- a/src/test/tx_verify_tests.cpp
+++ b/src/test/tx_verify_tests.cpp
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_SUITE(tx_verify_tests)
 BOOST_AUTO_TEST_CASE(check_tx_inputs_no_haz_coins) {
 
   mocks::CoinsViewMock utxos;
-  utxos.default_have_inputs = false;
+  utxos.mock_HaveInputs.SetResult(false);
 
   CTransaction tx;
   CValidationState validation_state;
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(check_tx_inputs_no_reward) {
   }();
 
   mocks::CoinsViewMock utxos;
-  utxos.default_coin = Coin(CTxOut(21, CScript()), 1, TxType::REGULAR);
+  utxos.mock_AccessCoin.SetResult(Coin(CTxOut(21, CScript()), 1, TxType::REGULAR));
 
   CValidationState validation_state;
   CAmount fees;
@@ -75,11 +75,11 @@ BOOST_AUTO_TEST_CASE(check_tx_inputs_does_not_access_coinbase_meta_input) {
 
   std::vector<COutPoint> coins_accessed;
   mocks::CoinsViewMock utxos;
-  utxos.default_coin = Coin(CTxOut(21, CScript()), 1, TxType::REGULAR);
-  utxos.access_coin = [&](const COutPoint &coin) -> const Coin & {
+  Coin somecoin(CTxOut(21, CScript()), 1, TxType::REGULAR);
+  utxos.mock_AccessCoin.SetStub([&](const COutPoint &coin) -> const Coin & {
     coins_accessed.emplace_back(coin);
-    return utxos.default_coin;
-  };
+    return somecoin;
+  });
 
   CValidationState validation_state;
   CAmount fees;
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(check_tx_inputs_rejects_coinbase_that_spends_too_little) {
   }();
 
   mocks::CoinsViewMock utxos;
-  utxos.default_coin = Coin(CTxOut(stake_in, CScript()), 1, TxType::REGULAR);
+  utxos.mock_AccessCoin.SetResult(Coin(CTxOut(stake_in, CScript()), 1, TxType::REGULAR));
 
   CValidationState validation_state;
   CAmount fees;
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(check_tx_inputs_rejects_coinbase_that_spends_too_much) {
   }();
 
   mocks::CoinsViewMock utxos;
-  utxos.default_coin = Coin(CTxOut(stake_in, CScript()), 1, TxType::REGULAR);
+  utxos.mock_AccessCoin.SetResult(Coin(CTxOut(stake_in, CScript()), 1, TxType::REGULAR));
 
   CValidationState validation_state;
   CAmount fees;

--- a/src/test/util/blocktools.cpp
+++ b/src/test/util/blocktools.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/blocktools.h>
+
+namespace blocktools {
+
+CBlockIndex *BlockIndexFake::MakeBlockIndex(const uint256 &hash, CBlockIndex *const prev) {
+  auto result = block_indexes.emplace(hash, CBlockIndex());
+  CBlockIndex *const index = &result.first->second;
+  index->phashBlock = &result.first->first;
+  index->nHeight = prev ? prev->nHeight + 1 : 0;
+  index->pprev = prev;
+  return index;
+}
+
+CBlockIndex *BlockIndexFake::Generate(const std::size_t count, const uint256 &starting_point) {
+  auto starting_block = block_indexes.find(starting_point);
+  std::size_t height = 0;
+  CBlockIndex *const starting_index = [&]() {
+    if (starting_block == block_indexes.end()) {
+      ++height;
+      return MakeBlockIndex(starting_point, nullptr);
+    } else {
+      return &starting_block->second;
+    }
+  }();
+  assert(starting_index);
+  assert(starting_index->phashBlock);
+
+  CBlockIndex *current_index = starting_index;
+  for (; height < count; ++height) {
+    const uint256 hash = GetRandHash();
+    current_index = MakeBlockIndex(hash, current_index);
+    assert(current_index);
+    assert(current_index->phashBlock);
+    assert(current_index->pprev);
+  }
+
+  return current_index;
+}
+
+std::shared_ptr<std::vector<CBlockIndex *>> BlockIndexFake::GetChain(const uint256 &tip_hash) {
+  auto tip = block_indexes.find(tip_hash);
+  auto result = std::make_shared<std::vector<CBlockIndex *>>();
+  if (tip == block_indexes.end()) {
+    return result;
+  }
+  CBlockIndex *current = &tip->second;
+  result->resize(current->nHeight + 1, nullptr);
+  std::size_t ix = current->nHeight;
+  do {
+    (*result)[ix] = current;
+    current = current->pprev;
+  } while (ix-- != 0);
+  assert(current == nullptr);
+  return result;
+}
+
+void BlockIndexFake::SetActiveChain(const CBlockIndex *tip, mocks::ActiveChainMock &active_chain_mock) {
+  assert(tip != nullptr);
+  std::shared_ptr<std::vector<CBlockIndex *>> active_chain = GetChain(tip->GetBlockHash());
+  active_chain_mock.mock_GetSize.SetStub([active_chain]() { return active_chain->size(); });
+  active_chain_mock.mock_GetHeight.SetStub([active_chain]() { return active_chain->size() - 1; });
+  active_chain_mock.mock_GetDepth.SetStub([active_chain](const blockchain::Height height) {
+    return active_chain->size() - height;
+  });
+  active_chain_mock.mock_AtHeight.SetStub([active_chain](const blockchain::Height height) -> const CBlockIndex * {
+    if (height >= active_chain->size()) {
+      return nullptr;
+    }
+    return active_chain->at(height);
+  });
+  active_chain_mock.mock_GetTip.SetStub([active_chain]() {
+    return active_chain->back();
+  });
+  active_chain_mock.mock_GetGenesis.SetStub([active_chain]() {
+    return active_chain->at(0);
+  });
+  active_chain_mock.mock_Contains.SetStub([active_chain](const CBlockIndex &block_index) {
+    if (block_index.nHeight >= active_chain->size()) {
+      return false;
+    }
+    const CBlockIndex *at_height = active_chain->at(block_index.nHeight);
+    return at_height->GetBlockHash() == block_index.GetBlockHash();
+  });
+  active_chain_mock.mock_FindForkOrigin.SetStub([&active_chain_mock](const CBlockIndex &block_index) {
+    const CBlockIndex *walk = &block_index;
+    while (walk != nullptr && active_chain_mock.AtHeight(walk->nHeight) != walk) {
+      walk = walk->pprev;
+    }
+    return walk;
+  });
+  active_chain_mock.mock_GetNext.SetStub([&active_chain_mock](const CBlockIndex &block_index) -> const CBlockIndex * {
+    if (active_chain_mock.AtHeight(block_index.nHeight) == &block_index) {
+      return active_chain_mock.AtHeight(block_index.nHeight + 1);
+    }
+    return nullptr;
+  });
+}
+
+}  // namespace blocktools

--- a/src/test/util/blocktools.cpp
+++ b/src/test/util/blocktools.cpp
@@ -17,16 +17,20 @@ CBlockIndex *BlockIndexFake::MakeBlockIndex(const uint256 &hash, CBlockIndex *co
   return index;
 }
 
-CBlockIndex *BlockIndexFake::Generate(const std::size_t count, const uint256 &starting_point) {
-  auto it = block_indexes.find(starting_point);
+CBlockIndex *BlockIndexFake::Generate(const std::size_t count, const CBlockIndex *starting_point) {
+
   std::size_t height = 0;
   CBlockIndex *const starting_index = [&]() {
-    if (it == block_indexes.end()) {
+    if (starting_point == nullptr) {
       ++height;
-      return MakeBlockIndex(starting_point, nullptr);
-    } else {
-      return &it->second;
+      const uint256 hash = GetRandHash();
+      return MakeBlockIndex(hash, nullptr);
     }
+    auto it = block_indexes.find(starting_point->GetBlockHash());
+    BOOST_REQUIRE_MESSAGE(
+        it != block_indexes.end(),
+        "starting_point not known by this instance of BlockIndexFake.");
+    return &it->second;
   }();
   BOOST_REQUIRE(starting_index);
   BOOST_REQUIRE(starting_index->phashBlock);
@@ -43,15 +47,16 @@ CBlockIndex *BlockIndexFake::Generate(const std::size_t count, const uint256 &st
   return current_index;
 }
 
-std::vector<CBlockIndex *> BlockIndexFake::GetChain(const uint256 &tip_hash) {
-  auto it = block_indexes.find(tip_hash);
+std::vector<CBlockIndex *> BlockIndexFake::GetChain(const CBlockIndex *tip) {
+  BOOST_REQUIRE(tip != nullptr);
+  auto it = block_indexes.find(tip->GetBlockHash());
+  BOOST_REQUIRE_MESSAGE(
+      it != block_indexes.end(),
+      "tip not known by this instance of BlockIndexFake.");
   std::vector<CBlockIndex *> result;
-  if (it == block_indexes.end()) {
-    return result;
-  }
-  CBlockIndex *tip = &it->second;
+  CBlockIndex *found_tip = &it->second;
   result.resize(tip->nHeight + 1, nullptr);
-  for (CBlockIndex *walk = tip; walk != nullptr; walk = walk->pprev) {
+  for (CBlockIndex *walk = found_tip; walk != nullptr; walk = walk->pprev) {
     result[walk->nHeight] = walk;
   }
   return result;
@@ -59,8 +64,8 @@ std::vector<CBlockIndex *> BlockIndexFake::GetChain(const uint256 &tip_hash) {
 
 void BlockIndexFake::SetupActiveChain(const CBlockIndex *tip,
                                       mocks::ActiveChainMock &active_chain_mock) {
-  assert(tip != nullptr);
-  auto active_chain = std::make_shared<std::vector<CBlockIndex *>>(GetChain(tip->GetBlockHash()));
+  BOOST_REQUIRE(tip != nullptr);
+  auto active_chain = std::make_shared<std::vector<CBlockIndex *>>(GetChain(tip));
   active_chain_mock.mock_GetSize.SetStub([active_chain]() { return active_chain->size(); });
   active_chain_mock.mock_GetHeight.SetStub([active_chain]() { return active_chain->size() - 1; });
   active_chain_mock.mock_GetDepth.SetStub([active_chain](const blockchain::Height height) {

--- a/src/test/util/blocktools.cpp
+++ b/src/test/util/blocktools.cpp
@@ -73,9 +73,17 @@ void BlockIndexFake::SetupActiveChain(const CBlockIndex *tip,
     return active_chain->at(height);
   });
   active_chain_mock.mock_GetTip.SetStub([active_chain]() {
+    BOOST_REQUIRE_MESSAGE(
+        active_chain->size() > 0,
+        "GetTip() called on an empty chain (this is probably an error in mocking, "
+        "an active chain should at least always contain a genesis block).");
     return active_chain->back();
   });
   active_chain_mock.mock_GetGenesis.SetStub([active_chain]() {
+    BOOST_REQUIRE_MESSAGE(
+        active_chain->size() > 0,
+        "GetGenesis() called on an empty chain (this is probably an error in mocking, "
+        "an active chain should at least always contain a genesis block).");
     return active_chain->at(0);
   });
   active_chain_mock.mock_Contains.SetStub([active_chain](const CBlockIndex &block_index) {

--- a/src/test/util/blocktools.cpp
+++ b/src/test/util/blocktools.cpp
@@ -74,14 +74,14 @@ void BlockIndexFake::SetupActiveChain(const CBlockIndex *tip,
   });
   active_chain_mock.mock_GetTip.SetStub([active_chain]() {
     BOOST_REQUIRE_MESSAGE(
-        active_chain->size() > 0,
+        !active_chain->empty(),
         "GetTip() called on an empty chain (this is probably an error in mocking, "
         "an active chain should at least always contain a genesis block).");
     return active_chain->back();
   });
   active_chain_mock.mock_GetGenesis.SetStub([active_chain]() {
     BOOST_REQUIRE_MESSAGE(
-        active_chain->size() > 0,
+        !active_chain->empty(),
         "GetGenesis() called on an empty chain (this is probably an error in mocking, "
         "an active chain should at least always contain a genesis block).");
     return active_chain->at(0);

--- a/src/test/util/blocktools.cpp
+++ b/src/test/util/blocktools.cpp
@@ -4,6 +4,8 @@
 
 #include <test/util/blocktools.h>
 
+#include <boost/test/unit_test.hpp>
+
 namespace blocktools {
 
 CBlockIndex *BlockIndexFake::MakeBlockIndex(const uint256 &hash, CBlockIndex *const prev) {
@@ -26,16 +28,16 @@ CBlockIndex *BlockIndexFake::Generate(const std::size_t count, const uint256 &st
       return &starting_block->second;
     }
   }();
-  assert(starting_index);
-  assert(starting_index->phashBlock);
+  BOOST_REQUIRE(starting_index);
+  BOOST_REQUIRE(starting_index->phashBlock);
 
   CBlockIndex *current_index = starting_index;
   for (; height < count; ++height) {
     const uint256 hash = GetRandHash();
     current_index = MakeBlockIndex(hash, current_index);
-    assert(current_index);
-    assert(current_index->phashBlock);
-    assert(current_index->pprev);
+    BOOST_REQUIRE(current_index);
+    BOOST_REQUIRE(current_index->phashBlock);
+    BOOST_REQUIRE(current_index->pprev);
   }
 
   return current_index;
@@ -54,11 +56,12 @@ std::shared_ptr<std::vector<CBlockIndex *>> BlockIndexFake::GetChain(const uint2
     (*result)[ix] = current;
     current = current->pprev;
   } while (ix-- != 0);
-  assert(current == nullptr);
+  BOOST_REQUIRE(current == nullptr);
   return result;
 }
 
-void BlockIndexFake::SetActiveChain(const CBlockIndex *tip, mocks::ActiveChainMock &active_chain_mock) {
+void BlockIndexFake::SetupActiveChain(const CBlockIndex *tip,
+                                      mocks::ActiveChainMock &active_chain_mock) {
   assert(tip != nullptr);
   std::shared_ptr<std::vector<CBlockIndex *>> active_chain = GetChain(tip->GetBlockHash());
   active_chain_mock.mock_GetSize.SetStub([active_chain]() { return active_chain->size(); });

--- a/src/test/util/blocktools.cpp
+++ b/src/test/util/blocktools.cpp
@@ -44,19 +44,16 @@ CBlockIndex *BlockIndexFake::Generate(const std::size_t count, const uint256 &st
 }
 
 std::shared_ptr<std::vector<CBlockIndex *>> BlockIndexFake::GetChain(const uint256 &tip_hash) {
-  auto tip = block_indexes.find(tip_hash);
+  auto it = block_indexes.find(tip_hash);
   auto result = std::make_shared<std::vector<CBlockIndex *>>();
-  if (tip == block_indexes.end()) {
+  if (it == block_indexes.end()) {
     return result;
   }
-  CBlockIndex *current = &tip->second;
-  result->resize(current->nHeight + 1, nullptr);
-  std::size_t ix = current->nHeight;
-  do {
-    (*result)[ix] = current;
-    current = current->pprev;
-  } while (ix-- != 0);
-  BOOST_REQUIRE(current == nullptr);
+  CBlockIndex *tip = &it->second;
+  result->resize(tip->nHeight + 1, nullptr);
+  for (CBlockIndex *walk = tip; walk != nullptr; walk = walk->pprev) {
+    (*result)[walk->nHeight] = walk;
+  }
   return result;
 }
 

--- a/src/test/util/blocktools.h
+++ b/src/test/util/blocktools.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef UNIT_E_TEST_UTIL_BLOCKTOOLS_H
+#define UNIT_E_TEST_UTIL_BLOCKTOOLS_H
+
+#include <test/test_unite_mocks.h>
+
+#include <chain.h>
+#include <random.h>
+#include <uint256.h>
+
+#include <map>
+
+namespace blocktools {
+
+struct BlockIndexFake {
+
+  std::map<uint256, CBlockIndex> block_indexes;
+
+  //! Creates a new CBlockIndex in block_indexes and returns a pointer to it.
+  //!
+  //! The height and pointer to previous block are deduced from the previous
+  //! block index. If none is given (nullptr) a block at height 0 without a
+  //! predecessor is created.
+  //!
+  //! \param hash The block hash for the new block index
+  //! \param prev The previous block (maybe nullptr)
+  //!
+  //! \return A pointer to the newly created block index.
+  CBlockIndex *MakeBlockIndex(const uint256 &hash, CBlockIndex *prev);
+
+  //! Generates a bunch of CBlockIndexes that form a chain.
+  //!
+  //! The chain maybe a fork, when a starting_point is given.
+  //!
+  //! \param count The number of blocks to be created.
+  //! \param starting_point optional, the starting point to fork from.
+  //!
+  //! \return A pointer to the tip of the newly created chain.
+  CBlockIndex *Generate(std::size_t count, const uint256 &starting_point = uint256::zero);
+
+  //! Retrieves a chain that ends in the specified tip.
+  std::shared_ptr<std::vector<CBlockIndex *>> GetChain(const uint256 &tip_hash);
+
+  void SetActiveChain(const CBlockIndex *tip, mocks::ActiveChainMock &active_chain_mock);
+};
+
+}  // namespace blocktools
+
+#endif  //UNIT_E_TEST_UTIL_BLOCKTOOLS_H

--- a/src/test/util/blocktools.h
+++ b/src/test/util/blocktools.h
@@ -39,10 +39,10 @@ struct BlockIndexFake {
   //! \param starting_point optional, the starting point to fork from.
   //!
   //! \return A pointer to the tip of the newly created chain.
-  CBlockIndex *Generate(std::size_t count, const uint256 &starting_point = uint256::zero);
+  CBlockIndex *Generate(std::size_t count, const CBlockIndex* starting_point = nullptr);
 
   //! Retrieves a chain that ends in the specified tip.
-  std::vector<CBlockIndex *> GetChain(const uint256 &tip_hash);
+  std::vector<CBlockIndex *> GetChain(const CBlockIndex* tip);
 
   //! Stubs an active chain mock with stubs that use the block index from this
   //! instance and activates the chain which has the given tip.

--- a/src/test/util/blocktools.h
+++ b/src/test/util/blocktools.h
@@ -8,9 +8,9 @@
 #include <test/test_unite_mocks.h>
 
 #include <chain.h>
-#include <random.h>
 #include <uint256.h>
 
+#include <cstdint>
 #include <map>
 
 namespace blocktools {
@@ -41,6 +41,17 @@ struct BlockIndexFake {
   //! \return A pointer to the tip of the newly created chain.
   CBlockIndex *Generate(std::size_t count, const CBlockIndex *starting_point = nullptr);
 
+  //! Generates a random hash and encodes height and fork_number in it.
+  //!
+  //! Example hashes:
+  //! - 2046b80afe8458145d02244c8958b5e000000000000000000000000000000000
+  //!                                   ^ fork=0        ^ height=0
+  //! - 37cde99f37f4ee323ab10afc8c6e5fa300000000000000020000000000000007
+  //!                                   ^ fork=2        ^ height=7
+  //! - ef101be55d91aa5adfe8df797432fbb5ffffffffffffffff00000000008da8a1
+  //!                                   fork=uint64_max ^ height=9283745
+  uint256 GenerateHash(std::uint64_t height, std::uint64_t fork_number) const;
+
   //! Retrieves a chain that ends in the specified tip.
   std::vector<CBlockIndex *> GetChain(const CBlockIndex *tip);
 
@@ -52,6 +63,9 @@ struct BlockIndexFake {
   //! instance and activates the chain which has the given tip.
   void SetupActiveChain(const CBlockIndex *tip,
                         mocks::ActiveChainMock &active_chain_mock);
+
+ private:
+  std::size_t number_of_forks = 0;
 };
 
 }  // namespace blocktools

--- a/src/test/util/blocktools.h
+++ b/src/test/util/blocktools.h
@@ -44,6 +44,8 @@ struct BlockIndexFake {
   //! Retrieves a chain that ends in the specified tip.
   std::shared_ptr<std::vector<CBlockIndex *>> GetChain(const uint256 &tip_hash);
 
+  //! Stubs an active chain mock with stubs that use the block index from this
+  //! instance and activates the chain which has the given tip.
   void SetActiveChain(const CBlockIndex *tip, mocks::ActiveChainMock &active_chain_mock);
 };
 

--- a/src/test/util/blocktools.h
+++ b/src/test/util/blocktools.h
@@ -21,7 +21,7 @@ struct BlockIndexFake {
 
   //! Creates a new CBlockIndex in block_indexes and returns a pointer to it.
   //!
-  //! The height and pointer to previous block are deduced from the previous
+  //! The height and pointer to the previous block are deduced from the previous
   //! block index. If none is given (nullptr) a block at height 0 without a
   //! predecessor is created.
   //!

--- a/src/test/util/blocktools.h
+++ b/src/test/util/blocktools.h
@@ -39,10 +39,14 @@ struct BlockIndexFake {
   //! \param starting_point optional, the starting point to fork from.
   //!
   //! \return A pointer to the tip of the newly created chain.
-  CBlockIndex *Generate(std::size_t count, const CBlockIndex* starting_point = nullptr);
+  CBlockIndex *Generate(std::size_t count, const CBlockIndex *starting_point = nullptr);
 
   //! Retrieves a chain that ends in the specified tip.
-  std::vector<CBlockIndex *> GetChain(const CBlockIndex* tip);
+  std::vector<CBlockIndex *> GetChain(const CBlockIndex *tip);
+
+  //! Looks up a node by id which is known to exist in this block index.
+  //! Fails with BOOST_REQUIRE_MESSAGE if it does not exist.
+  CBlockIndex *Lookup(const uint256 &hash);
 
   //! Stubs an active chain mock with stubs that use the block index from this
   //! instance and activates the chain which has the given tip.

--- a/src/test/util/blocktools.h
+++ b/src/test/util/blocktools.h
@@ -46,7 +46,8 @@ struct BlockIndexFake {
 
   //! Stubs an active chain mock with stubs that use the block index from this
   //! instance and activates the chain which has the given tip.
-  void SetActiveChain(const CBlockIndex *tip, mocks::ActiveChainMock &active_chain_mock);
+  void SetupActiveChain(const CBlockIndex *tip,
+                        mocks::ActiveChainMock &active_chain_mock);
 };
 
 }  // namespace blocktools

--- a/src/test/util/blocktools.h
+++ b/src/test/util/blocktools.h
@@ -42,7 +42,7 @@ struct BlockIndexFake {
   CBlockIndex *Generate(std::size_t count, const uint256 &starting_point = uint256::zero);
 
   //! Retrieves a chain that ends in the specified tip.
-  std::shared_ptr<std::vector<CBlockIndex *>> GetChain(const uint256 &tip_hash);
+  std::vector<CBlockIndex *> GetChain(const uint256 &tip_hash);
 
   //! Stubs an active chain mock with stubs that use the block index from this
   //! instance and activates the chain which has the given tip.

--- a/src/test/util/blocktools_tests.cpp
+++ b/src/test/util/blocktools_tests.cpp
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(BlockIndexFake_GetChain) {
 
   const CBlockIndex *tip = fake.Generate(10);
   BOOST_REQUIRE(tip);
-  const std::vector<CBlockIndex *> chain = fake.GetChain(tip->GetBlockHash());
+  const std::vector<CBlockIndex *> chain = fake.GetChain(tip);
 
   BOOST_REQUIRE_EQUAL(chain.size(), 10);
 
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(BlockIndexFake_Feature_Forks) {
   const CBlockIndex *tip1 = fake.Generate(10);
   BOOST_CHECK_EQUAL(fake.block_indexes.size(), 10);
 
-  std::vector<CBlockIndex *> chain1 = fake.GetChain(tip1->GetBlockHash());
+  std::vector<CBlockIndex *> chain1 = fake.GetChain(tip1);
   BOOST_CHECK_EQUAL(chain1.size(), 10);
 
   {
@@ -115,11 +115,11 @@ BOOST_AUTO_TEST_CASE(BlockIndexFake_Feature_Forks) {
     BOOST_CHECK_EQUAL(previous, tip1);
   }
 
-  const CBlockIndex *tip2 = fake.Generate(3, chain1.at(5)->GetBlockHash());
+  const CBlockIndex *tip2 = fake.Generate(3, chain1.at(5));
   // 10 blocks previously, plus an additional 3
   BOOST_CHECK_EQUAL(fake.block_indexes.size(), 13);
 
-  std::vector<CBlockIndex *> chain2 = fake.GetChain(tip2->GetBlockHash());
+  std::vector<CBlockIndex *> chain2 = fake.GetChain(tip2);
   // at height=5 there is the 6th block, plus 3 on top
   BOOST_CHECK_EQUAL(chain2.size(), 9);
 

--- a/src/test/util/blocktools_tests.cpp
+++ b/src/test/util/blocktools_tests.cpp
@@ -71,13 +71,13 @@ BOOST_AUTO_TEST_CASE(BlockIndexFake_GetChain) {
 
   const CBlockIndex *tip = fake.Generate(10);
   BOOST_REQUIRE(tip);
-  const std::shared_ptr<std::vector<CBlockIndex *>> chain = fake.GetChain(tip->GetBlockHash());
+  const std::vector<CBlockIndex *> chain = fake.GetChain(tip->GetBlockHash());
 
-  BOOST_REQUIRE_EQUAL(chain->size(), 10);
+  BOOST_REQUIRE_EQUAL(chain.size(), 10);
 
   const CBlockIndex *previous = nullptr;
   for (std::size_t height = 0; height < 10; ++height) {
-    const CBlockIndex *const block_index = chain->at(height);
+    const CBlockIndex *const block_index = chain.at(height);
 
     BOOST_REQUIRE(block_index);
     BOOST_CHECK(block_index->phashBlock);
@@ -97,13 +97,13 @@ BOOST_AUTO_TEST_CASE(BlockIndexFake_Feature_Forks) {
   const CBlockIndex *tip1 = fake.Generate(10);
   BOOST_CHECK_EQUAL(fake.block_indexes.size(), 10);
 
-  std::shared_ptr<std::vector<CBlockIndex *>> chain1 = fake.GetChain(tip1->GetBlockHash());
-  BOOST_CHECK_EQUAL(chain1->size(), 10);
+  std::vector<CBlockIndex *> chain1 = fake.GetChain(tip1->GetBlockHash());
+  BOOST_CHECK_EQUAL(chain1.size(), 10);
 
   {
     const CBlockIndex *previous = nullptr;
-    for (std::size_t height = 0; height < chain1->size(); ++height) {
-      const CBlockIndex *const block_index = chain1->at(height);
+    for (std::size_t height = 0; height < chain1.size(); ++height) {
+      const CBlockIndex *const block_index = chain1.at(height);
 
       BOOST_REQUIRE(block_index);
       BOOST_CHECK(block_index->phashBlock);
@@ -115,18 +115,18 @@ BOOST_AUTO_TEST_CASE(BlockIndexFake_Feature_Forks) {
     BOOST_CHECK_EQUAL(previous, tip1);
   }
 
-  const CBlockIndex *tip2 = fake.Generate(3, chain1->at(5)->GetBlockHash());
+  const CBlockIndex *tip2 = fake.Generate(3, chain1.at(5)->GetBlockHash());
   // 10 blocks previously, plus an additional 3
   BOOST_CHECK_EQUAL(fake.block_indexes.size(), 13);
 
-  std::shared_ptr<std::vector<CBlockIndex *>> chain2 = fake.GetChain(tip2->GetBlockHash());
+  std::vector<CBlockIndex *> chain2 = fake.GetChain(tip2->GetBlockHash());
   // at height=5 there is the 6th block, plus 3 on top
-  BOOST_CHECK_EQUAL(chain2->size(), 9);
+  BOOST_CHECK_EQUAL(chain2.size(), 9);
 
   {
     const CBlockIndex *previous = nullptr;
-    for (std::size_t height = 0; height < chain2->size(); ++height) {
-      const CBlockIndex *const block_index = chain2->at(height);
+    for (std::size_t height = 0; height < chain2.size(); ++height) {
+      const CBlockIndex *const block_index = chain2.at(height);
 
       BOOST_REQUIRE(block_index);
       BOOST_CHECK(block_index->phashBlock);

--- a/src/test/util/blocktools_tests.cpp
+++ b/src/test/util/blocktools_tests.cpp
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(BlockIndexFake_GenerateHash) {
 
   auto check = [&](const std::uint64_t height, const std::uint64_t fork_number) {
     const uint256 hash = fake.GenerateHash(height, fork_number);
-    // nota bene: GetUint64 takes the index of a byte
+    // nota bene: GetUint64 takes the index of a uint64 (good ol' pointer arithmetic)
     BOOST_CHECK_EQUAL(hash.GetUint64(0), height);
     BOOST_CHECK_EQUAL(hash.GetUint64(1), fork_number);
   };

--- a/src/test/util/blocktools_tests.cpp
+++ b/src/test/util/blocktools_tests.cpp
@@ -1,0 +1,142 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/blocktools.h>
+
+#include <random.h>
+#include <uint256.h>
+
+#include <test/test_unite.h>
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(blocktools_tests)
+
+BOOST_AUTO_TEST_CASE(BLockIndexFake_MakeBlockIndex) {
+
+  blocktools::BlockIndexFake fake;
+
+  BOOST_CHECK_EQUAL(fake.block_indexes.size(), 0);
+
+  {
+    // create a block at height=0
+    const uint256 hash = GetRandHash();
+    CBlockIndex *block_index = fake.MakeBlockIndex(hash, nullptr);
+
+    BOOST_CHECK_EQUAL(fake.block_indexes.size(), 1);
+    BOOST_CHECK_EQUAL(&fake.block_indexes.begin()->second, block_index);
+    BOOST_CHECK_EQUAL(block_index->nHeight, 0);
+    BOOST_CHECK(block_index->pprev == nullptr);
+    BOOST_REQUIRE(block_index->phashBlock);
+    BOOST_CHECK_EQUAL(*block_index->phashBlock, hash);
+  }
+
+  {
+    // create a successor to the previously generated block
+    const uint256 hash = GetRandHash();
+    CBlockIndex *block_index = fake.MakeBlockIndex(hash, &fake.block_indexes.begin()->second);
+
+    BOOST_CHECK_EQUAL(fake.block_indexes.size(), 2);
+    BOOST_CHECK_EQUAL(block_index->nHeight, 1);
+    BOOST_CHECK(block_index->pprev);
+    BOOST_REQUIRE(block_index->phashBlock);
+    BOOST_CHECK_EQUAL(*block_index->phashBlock, hash);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(BlockIndexFake_Generate) {
+
+  blocktools::BlockIndexFake fake;
+
+  BOOST_CHECK_EQUAL(fake.block_indexes.size(), 0);
+  CBlockIndex *tip = fake.Generate(5);
+  BOOST_CHECK_EQUAL(fake.block_indexes.size(), 5);
+
+  // the blocks are at height=0 till height=4 which makes for 5 blocks
+  std::size_t count = 0;
+  std::size_t height = 4;
+  while (tip) {
+    BOOST_CHECK(tip->phashBlock);
+    BOOST_CHECK_EQUAL(tip->nHeight, height);
+    tip = tip->pprev;
+    --height;
+    ++count;
+  }
+  BOOST_CHECK_EQUAL(count, 5);
+}
+
+BOOST_AUTO_TEST_CASE(BlockIndexFake_GetChain) {
+
+  blocktools::BlockIndexFake fake;
+
+  const CBlockIndex *tip = fake.Generate(10);
+  BOOST_REQUIRE(tip);
+  const std::shared_ptr<std::vector<CBlockIndex *>> chain = fake.GetChain(tip->GetBlockHash());
+
+  BOOST_REQUIRE_EQUAL(chain->size(), 10);
+
+  const CBlockIndex *previous = nullptr;
+  for (std::size_t height = 0; height < 10; ++height) {
+    const CBlockIndex *const block_index = chain->at(height);
+
+    BOOST_REQUIRE(block_index);
+    BOOST_CHECK(block_index->phashBlock);
+    BOOST_CHECK_EQUAL(block_index->nHeight, height);
+    BOOST_CHECK_EQUAL(block_index->pprev, previous);
+
+    previous = block_index;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(BlockIndexFake_Feature_Forks) {
+
+  blocktools::BlockIndexFake fake;
+
+  BOOST_CHECK_EQUAL(fake.block_indexes.size(), 0);
+
+  const CBlockIndex *tip1 = fake.Generate(10);
+  BOOST_CHECK_EQUAL(fake.block_indexes.size(), 10);
+
+  std::shared_ptr<std::vector<CBlockIndex *>> chain1 = fake.GetChain(tip1->GetBlockHash());
+  BOOST_CHECK_EQUAL(chain1->size(), 10);
+
+  {
+    const CBlockIndex *previous = nullptr;
+    for (std::size_t height = 0; height < chain1->size(); ++height) {
+      const CBlockIndex *const block_index = chain1->at(height);
+
+      BOOST_REQUIRE(block_index);
+      BOOST_CHECK(block_index->phashBlock);
+      BOOST_CHECK_EQUAL(block_index->nHeight, height);
+      BOOST_CHECK_EQUAL(block_index->pprev, previous);
+
+      previous = block_index;
+    }
+    BOOST_CHECK_EQUAL(previous, tip1);
+  }
+
+  const CBlockIndex *tip2 = fake.Generate(3, chain1->at(5)->GetBlockHash());
+  // 10 blocks previously, plus an additional 3
+  BOOST_CHECK_EQUAL(fake.block_indexes.size(), 13);
+
+  std::shared_ptr<std::vector<CBlockIndex *>> chain2 = fake.GetChain(tip2->GetBlockHash());
+  // at height=5 there is the 6th block, plus 3 on top
+  BOOST_CHECK_EQUAL(chain2->size(), 9);
+
+  {
+    const CBlockIndex *previous = nullptr;
+    for (std::size_t height = 0; height < chain2->size(); ++height) {
+      const CBlockIndex *const block_index = chain2->at(height);
+
+      BOOST_REQUIRE(block_index);
+      BOOST_CHECK(block_index->phashBlock);
+      BOOST_CHECK_EQUAL(block_index->nHeight, height);
+      BOOST_CHECK_EQUAL(block_index->pprev, previous);
+
+      previous = block_index;
+    }
+    BOOST_CHECK_EQUAL(previous, tip2);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/mocks.cpp
+++ b/src/test/util/mocks.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/mocks.h>
+
+namespace mocks {
+
+MethodMockBase::MethodMockBase(Mock *const parent) : m_parent(parent) {
+  parent->MockRegister(this);
+}
+
+std::uint32_t MethodMockBase::CountInvocations() const {
+  return m_invocations;
+}
+
+void MethodMockBase::ResetInvocationCounts() {
+  m_invocations = 0;
+}
+
+void MethodMockBase::CountInteraction() const {
+  ++m_invocations;
+  m_parent->MockCountInteraction(this);
+}
+
+void Mock::MockRegister(MethodMockBase *const method_mock) {
+  m_method_mocks.emplace_back(method_mock);
+}
+
+void Mock::MockCountInteraction(const MethodMockBase *const method_mock) {
+  ++m_interaction_count;
+}
+
+std::uint32_t Mock::MockCountInteractions() {
+  return m_interaction_count;
+}
+
+void Mock::MockReset() {
+  for (MethodMockBase *const method_mock : m_method_mocks) {
+    method_mock->Reset();
+  }
+  m_interaction_count = 0;
+}
+
+void Mock::MockResetInvocationCounts() {
+  for (MethodMockBase *const method_mock : m_method_mocks) {
+    method_mock->ResetInvocationCounts();
+  }
+  m_interaction_count = 0;
+}
+
+}  // namespace mocks

--- a/src/test/util/mocks.h
+++ b/src/test/util/mocks.h
@@ -1,0 +1,196 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef UNIT_E_TEST_UTIL_MOCKS_H
+#define UNIT_E_TEST_UTIL_MOCKS_H
+
+#include <sync.h>
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace mocks {
+
+class MethodMockBase;
+
+class Mock {
+  friend MethodMockBase;
+
+ public:
+  void MockReset();
+  void MockResetInvocationCounts();
+  std::uint32_t MockCountInteractions();
+
+ private:
+  void MockRegister(MethodMockBase *method_mock);
+  void MockCountInteraction(const MethodMockBase *method_mock);
+
+  std::vector<MethodMockBase *> m_method_mocks;
+  mutable std::atomic<std::uint32_t> m_interaction_count{0};
+};
+
+class MethodMockBase {
+ public:
+  std::uint32_t CountInvocations() const;
+  virtual void Reset() = 0;
+  void ResetInvocationCounts();
+
+ protected:
+  explicit MethodMockBase(Mock *parent);
+  void CountInteraction() const;
+  mutable std::atomic<std::uint32_t> m_invocations{0};
+  Mock *const m_parent;
+};
+
+template <typename... Args>
+class VoidMethodMockImpl : public MethodMockBase {
+  using Stub = std::function<void(Args...)>;
+
+ public:
+  void SetStub(const Stub &stub) {
+    m_stub = stub;
+  }
+  Stub GetDefaultStub() const {
+    return [&](Args...) -> void {};
+  }
+  void Reset() override {
+    SetStub(GetDefaultStub());
+    ResetInvocationCounts();
+  }
+  void operator()(Args... args) const {
+    CountInteraction();
+    m_stub(args...);
+  }
+  void forward(Args&&... args) const {
+    CountInteraction();
+    m_stub(std::forward<Args...>(args)...);
+  }
+
+ protected:
+  explicit VoidMethodMockImpl(Mock *const parent)
+      : MethodMockBase(parent), m_stub(GetDefaultStub()) {}
+
+ private:
+  Stub m_stub;
+};
+
+template <typename R, typename... Args>
+class MethodMockImpl : public MethodMockBase {
+  using Stub = std::function<R(Args...)>;
+
+ public:
+  using Result = typename std::remove_const<typename std::remove_reference<R>::type>::type;
+
+  void SetResult(Result result) {
+    m_result = result;
+  }
+  void SetStub(const Stub &stub) {
+    m_stub = stub;
+  }
+  Result GetResult() {
+    return m_result;
+  }
+  Stub GetDefaultStub() const {
+    return [&](Args...) -> R {
+      return m_result;
+    };
+  }
+  void Reset() override {
+    SetStub(GetDefaultStub());
+    ResetInvocationCounts();
+  }
+  R operator()(Args... args) const {
+    CountInteraction();
+    return m_stub(args...);
+  }
+  R forward(Args&&... args) const {
+    CountInteraction();
+    return m_stub(std::forward<Args...>(args)...);
+  }
+
+ protected:
+  explicit MethodMockImpl(Mock *const parent)
+      : MethodMockBase(parent), m_stub(GetDefaultStub()) {}
+  MethodMockImpl(Mock *const parent, Result default_return_value)
+      : MethodMockBase(parent), m_stub(GetDefaultStub()), m_result(default_return_value) {}
+
+ private:
+  Stub m_stub;
+  Result m_result;
+};
+
+class LockMethodMockImpl : public MethodMockBase {
+  using Stub = std::function<CCriticalSection &()>;
+
+ public:
+  void Reset() override {
+    ResetInvocationCounts();
+  }
+  CCriticalSection &operator()() const {
+    CountInteraction();
+    return m_cs;
+  }
+
+ protected:
+  explicit LockMethodMockImpl(Mock *const parent)
+      : MethodMockBase(parent) {}
+
+ private:
+  mutable CCriticalSection m_cs;
+};
+
+template <typename T>
+class MethodMock;
+
+//! Mocks typical GetLock() methods
+template <typename C>
+class MethodMock<CCriticalSection &(C::*)()> : public LockMethodMockImpl {
+ public:
+  explicit MethodMock(Mock *const parent) : LockMethodMockImpl(parent) {}
+};
+
+//! Mocks typical GetLock() const methods
+template <typename C>
+class MethodMock<CCriticalSection &(C::*)() const> : public LockMethodMockImpl {
+ public:
+  explicit MethodMock(Mock *const parent) : LockMethodMockImpl(parent) {}
+};
+
+//! Mocks const void methods
+template <typename C, typename... Args>
+class MethodMock<void (C::*)(Args...) const> : public VoidMethodMockImpl<Args...> {
+ public:
+  explicit MethodMock(Mock *const parent) : VoidMethodMockImpl<Args...>(parent) {}
+};
+
+//! Mocks non-const void methods
+template <typename C, typename... Args>
+class MethodMock<void (C::*)(Args...)> : public VoidMethodMockImpl<Args...> {
+ public:
+  explicit MethodMock(Mock *const parent) : VoidMethodMockImpl<Args...>(parent) {}
+};
+
+//! Mocks const member functions (methods that return something)
+template <typename R, typename C, typename... Args>
+class MethodMock<R (C::*)(Args...) const> : public MethodMockImpl<R, Args...> {
+ public:
+  explicit MethodMock(Mock *const parent) : MethodMockImpl<R, Args...>(parent) {}
+  MethodMock(Mock *const parent, R result) : MethodMockImpl<R, Args...>(parent, result) {}
+};
+
+//! Mocks non-const member functions (methods that return something)
+template <typename R, typename C, typename... Args>
+class MethodMock<R (C::*)(Args...)> : public MethodMockImpl<R, Args...> {
+ public:
+  explicit MethodMock(Mock *const parent) : MethodMockImpl<R, Args...>(parent) {}
+  MethodMock(Mock *const parent, R result) : MethodMockImpl<R, Args...>(parent, result) {}
+};
+
+};  // namespace mocks
+
+#endif  //UNIT_E_TEST_UTIL_MOCKS_H

--- a/src/test/util/mocks.h
+++ b/src/test/util/mocks.h
@@ -22,8 +22,16 @@ class Mock {
   friend MethodMockBase;
 
  public:
+  //! Resets this mock and all of its mocked methods, i.e. invokes
+  //! Reset() on every MockMethod and resets interactions counts of this mock.
   void MockReset();
+
+  //! Resets the invocation counts of every mock method of this mock to zero.
+  //! Also the interaction count with this mock is set to zero.
   void MockResetInvocationCounts();
+
+  //! Returns how often this mock was interacted with. This is the sum of
+  //! all invocations of every mocked method of this Mock.
   std::uint32_t MockCountInteractions();
 
  private:
@@ -36,8 +44,13 @@ class Mock {
 
 class MethodMockBase {
  public:
+  //! Returns how often this method was invoked.
   std::uint32_t CountInvocations() const;
+
+  //! Resets this method mocks (invocation counts and stub).
   virtual void Reset() = 0;
+
+  //! Resets just the invocation counts to zero.
   void ResetInvocationCounts();
 
  protected:
@@ -66,7 +79,7 @@ class VoidMethodMockImpl : public MethodMockBase {
     CountInteraction();
     m_stub(args...);
   }
-  void forward(Args&&... args) const {
+  void forward(Args &&... args) const {
     CountInteraction();
     m_stub(std::forward<Args...>(args)...);
   }
@@ -108,7 +121,7 @@ class MethodMockImpl : public MethodMockBase {
     CountInteraction();
     return m_stub(args...);
   }
-  R forward(Args&&... args) const {
+  R forward(Args &&... args) const {
     CountInteraction();
     return m_stub(std::forward<Args...>(args)...);
   }

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -25,6 +25,8 @@ WalletTestingSetup::WalletTestingSetup(
 {
     bool fFirstRun;
 
+    stake_validator_mock.mock_IsStakeMature.SetResult(true);
+
     f(settings);
     esperanza::WalletExtensionDeps deps(&settings, &stake_validator_mock);
 


### PR DESCRIPTION
This introduces a unified interface to the mocks in `test_unite_mocks.h`. So far the mocks were growing uncontrolled and some were more like fakes, stubs, and whatever you want to call these things. Most important however: Some of them were different in spirit from other ones.

Now every Mock (every class ending in `*Mock`) has a member field for every overloaded function called `mock_NameOfThatFunction`. That function can be stubbed (using `SetStub`), the result to be returned can be set (using `SetResult`), the invocations of a particular method can be checked (`CountInnovations`) and the number of times a Mock was interacted with (`CountInteractions`).

In order to streamline the mocks I needed to touch a few tests, most heavily I touched `state_db_tests`. In order to wrap my head around it I created a blocktool that allows to clearly create chains of block indexes. It is itself unit tested.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
