### PR TITLE
TestChain100Setup: Replace BlockAssembler with BlockBuilder

### DIFF
--- a/src/test/esperanza/walletextension_tests.cpp
+++ b/src/test/esperanza/walletextension_tests.cpp
@@ -289,7 +289,9 @@ BOOST_FIXTURE_TEST_CASE(get_stakeable_coins, TestChain100Setup) {
 
   // Make the first coinbase mature
   CScript coinbase_script = GetScriptForDestination(coinbaseKey.GetPubKey().GetID());
-  CreateAndProcessBlock({}, coinbase_script);
+  bool processed;
+  CreateAndProcessBlock({}, coinbase_script, &processed);
+  BOOST_CHECK(processed);
 
   CTransaction &stakeable = m_coinbase_txns.front();
 

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -89,7 +89,7 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
   staking::CoinSet coins;
   {
     LOCK2(m_active_chain->GetLock(), wallet_ext.GetLock());
-     coins = wallet_ext.GetStakeableCoins();
+    coins = wallet_ext.GetStakeableCoins();
   }
 
   const CAmount fees = 0;

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -45,11 +45,11 @@ WalletTestingSetup::~WalletTestingSetup()
 }
 
 TestChain100Setup::TestChain100Setup(UnitEInjectorConfiguration config)
-    : WalletTestingSetup(CBaseChainParams::REGTEST, config)
+    : WalletTestingSetup(CBaseChainParams::REGTEST, config),
+      m_block_builder(proposer::BlockBuilder::New(&settings)),
+      m_active_chain(staking::ActiveChain::New()),
+      m_behavior(blockchain::Behavior::NewForNetwork(blockchain::Network::regtest))
 {
-  m_block_builder = proposer::BlockBuilder::New(&settings);
-  m_active_chain = staking::ActiveChain::New();
-  m_behavior = blockchain::Behavior::NewForNetwork(blockchain::Network::regtest);
 
   coinbaseKey = DecodeSecret("cQTjnbHifWGuMhm9cRgQ23ip5KntTMfj3zwo6iQyxMVxSfJyptqL");
   assert(coinbaseKey.IsValid());

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -13,7 +13,6 @@
 #include <wallet/rpcwalletext.h>
 #include <consensus/merkle.h>
 #include <test/test_unite_mocks.h>
-#include <numeric>
 
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName, UnitEInjectorConfiguration config)
     : WalletTestingSetup([](Settings& s){}, chainName, config) {}

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -13,6 +13,7 @@
 #include <wallet/rpcwalletext.h>
 #include <consensus/merkle.h>
 #include <test/test_unite_mocks.h>
+#include <numeric>
 
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName, UnitEInjectorConfiguration config)
     : WalletTestingSetup([](Settings& s){}, chainName, config) {}
@@ -47,6 +48,9 @@ WalletTestingSetup::~WalletTestingSetup()
 TestChain100Setup::TestChain100Setup(UnitEInjectorConfiguration config)
     : WalletTestingSetup(CBaseChainParams::REGTEST, config)
 {
+  m_block_builder = proposer::BlockBuilder::New(&settings);
+  m_active_chain = staking::ActiveChain::New();
+
   coinbaseKey = DecodeSecret("cQTjnbHifWGuMhm9cRgQ23ip5KntTMfj3zwo6iQyxMVxSfJyptqL");
   assert(coinbaseKey.IsValid());
   {
@@ -76,27 +80,52 @@ TestChain100Setup::TestChain100Setup(UnitEInjectorConfiguration config)
 // scriptPubKey, and try to add it to the current chain.
 //
 CBlock
-TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns, const CScript& scriptPubKey, bool *processed)
+TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns, const CScript& coinbase_script, bool *processed)
 {
   const CChainParams& chainparams = Params();
-  std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
-  CBlock& block = pblocktemplate->block;
 
-  // Replace mempool-selected txns with just coinbase plus passed-in txns:
-  block.vtx.resize(1);
-  for (const CMutableTransaction& tx : txns)
-    block.vtx.push_back(MakeTransactionRef(tx));
-  // IncrementExtraNonce creates a valid coinbase and merkleRoot
-  unsigned int extraNonce = 0;
+  esperanza::WalletExtension &wallet_ext = m_wallet->GetWalletExtension();
+
+  staking::CoinSet coins;
   {
-    LOCK(cs_main);
-    IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
+    LOCK2(m_active_chain->GetLock(), wallet_ext.GetLock());
+     coins = wallet_ext.GetStakeableCoins();
   }
-  // Regenerate the merkle roots cause we possibly changed the txs included
-  block.ComputeMerkleTrees();
 
-  std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
-  const bool was_processed = ProcessNewBlock(chainparams, shared_pblock, true, nullptr);
+//  for (const auto &tx : txns) {
+//    tx.
+//  }
+//  const CAmount fees = std::accumulate(txns, txns.fees.end(), CAmount(0));
+  uint256 snapshot_hash;
+  {
+    LOCK(m_active_chain->GetLock());
+    snapshot_hash = m_active_chain->ComputeSnapshotHash();
+  }
+
+  std::vector<CTransactionRef> tx_refs;
+  for (const CMutableTransaction& tx : txns) {
+    tx_refs.push_back(MakeTransactionRef(tx));
+  }
+
+  proposer::EligibleCoin coin = {
+      *coins.begin(),
+      uint256(),
+      CAmount(),
+      static_cast<blockchain::Height>(m_active_chain->GetTip()->nHeight+1),
+      0,
+      0
+  };
+  std::shared_ptr<const CBlock> block = m_block_builder->BuildBlock(
+      *m_active_chain->GetTip(),
+      snapshot_hash,
+      coin,
+      {},
+      tx_refs,
+      0,
+      coinbase_script,
+      wallet_ext);
+
+  const bool was_processed = ProcessNewBlock(chainparams, block, true, nullptr);
   assert(processed != nullptr || was_processed);
   if (processed != nullptr) {
     *processed = was_processed;
@@ -104,8 +133,7 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
 
   SyncWithValidationInterfaceQueue(); // To prevent Wallet::ConnectBlock from running concurrently
 
-  CBlock result = block;
-  return result;
+  return *block;
 }
 
 TestChain100Setup::~TestChain100Setup()

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -8,6 +8,7 @@
 #include <test/test_unite.h>
 #include <test/test_unite_mocks.h>
 
+#include <proposer/block_builder.h>
 #include <wallet/wallet.h>
 
 #include <memory>
@@ -50,6 +51,8 @@ struct TestChain100Setup : public WalletTestingSetup {
 
   std::vector<CTransaction> m_coinbase_txns; // For convenience, coinbase transactions
   CKey coinbaseKey; // private/public key needed to spend coinbase transactions
+  std::shared_ptr<proposer::BlockBuilder> m_block_builder;
+  std::shared_ptr<staking::ActiveChain> m_active_chain;
 };
 
 #endif // UNITE_WALLET_TEST_WALLET_TEST_FIXTURE_H

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -51,9 +51,9 @@ struct TestChain100Setup : public WalletTestingSetup {
 
   std::vector<CTransaction> m_coinbase_txns; // For convenience, coinbase transactions
   CKey coinbaseKey; // private/public key needed to spend coinbase transactions
-  std::shared_ptr<proposer::BlockBuilder> m_block_builder;
-  std::shared_ptr<staking::ActiveChain> m_active_chain;
-  std::shared_ptr<blockchain::Behavior> m_behavior;
+  std::unique_ptr<proposer::BlockBuilder> m_block_builder;
+  std::unique_ptr<staking::ActiveChain> m_active_chain;
+  std::unique_ptr<blockchain::Behavior> m_behavior;
 };
 
 #endif // UNITE_WALLET_TEST_WALLET_TEST_FIXTURE_H

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -53,6 +53,7 @@ struct TestChain100Setup : public WalletTestingSetup {
   CKey coinbaseKey; // private/public key needed to spend coinbase transactions
   std::shared_ptr<proposer::BlockBuilder> m_block_builder;
   std::shared_ptr<staking::ActiveChain> m_active_chain;
+  std::shared_ptr<blockchain::Behavior> m_behavior;
 };
 
 #endif // UNITE_WALLET_TEST_WALLET_TEST_FIXTURE_H


### PR DESCRIPTION
This PR replaces the `BlockAssembler` with the `BlockBuilder` while building blocks for the `Test100ChainSetup`.