### PR TITLE
Block reward validation

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -251,6 +251,7 @@ UNITE_CORE_H = \
   snapshot/state.h \
   staking/active_chain.h \
   staking/block_index_map.h \
+  staking/block_reward_validator.h \
   staking/block_validation_info.h \
   staking/block_validator.h \
   staking/coin.h \
@@ -398,6 +399,7 @@ libunite_server_a_SOURCES = \
   snapshot/state.cpp \
   staking/active_chain.cpp \
   staking/block_index_map.cpp \
+  staking/block_reward_validator.cpp \
   staking/block_validation_info.cpp \
   staking/block_validator.cpp \
   staking/coin.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -133,6 +133,7 @@ UNITE_TESTS =\
   test/snapshot/snapshot_index_tests.cpp \
   test/snapshot/state_tests.cpp \
   test/snapshot/validation_tests.cpp \
+  test/staking/block_reward_validator_tests.cpp \
   test/staking/coin_tests.cpp \
   test/staking/proof_of_stake_tests.cpp \
   test/streams_tests.cpp \

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -259,33 +259,9 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
     }
 
     const CAmount value_out = tx.GetValueOut();
-    if (tx.IsCoinBase()) {
-        // The coinbase transaction should spend exactly its inputs and the reward.
-        // The reward output is by definition in the zeroth output. The reward
-        // consists of newly minted money (the block reward) and the fees accumulated
-        // from the transactions.
-        if (tx.vout.empty()) {
-          return state.DoS(100, false, REJECT_INVALID, "bad-cb-no-reward", false,
-                           strprintf("coinbase without a reward txout"));
-        }
-        const CTxOut &reward_out = tx.vout[0];
-        const CAmount reward = reward_out.nValue;
-        if (nValueIn + reward < value_out) {
-            return state.DoS(100, false, REJECT_INVALID, "bad-cb-spends-too-much", false,
-                             strprintf("value in (%s) + reward(%s) != value out (%s) in coinbase",
-                                       FormatMoney(nValueIn),
-                                       FormatMoney(reward),
-                                       FormatMoney(value_out)));
-        }
-        if (nValueIn + reward > value_out) {
-            return state.DoS(100, false, REJECT_INVALID, "bad-cb-spends-too-little", false,
-                             strprintf("value in (%s) + reward(%s) != value out (%s) in coinbase",
-                                       FormatMoney(nValueIn),
-                                       FormatMoney(reward),
-                                       FormatMoney(value_out)));
-        }
-    } else if (!tx.IsCoinBase()) {
-        // All other transactions have to spend no more then their inputs. If they spend
+    // Coinbase outputs are validated in BlockRewardValidator::CheckBlockRewards
+    if (!tx.IsCoinBase()) {
+        // All non-coinbase transactions have to spend no more than their inputs. If they spend
         // less, the change is counted towards the fees which are included in the reward
         // of the coinbase transaction.
         if (nValueIn < value_out) {

--- a/src/injector.h
+++ b/src/injector.h
@@ -22,6 +22,7 @@
 #include <settings.h>
 #include <staking/active_chain.h>
 #include <staking/block_index_map.h>
+#include <staking/block_reward_validator.h>
 #include <staking/block_validator.h>
 #include <staking/legacy_validation_interface.h>
 #include <staking/network.h>
@@ -71,6 +72,9 @@ class UnitEInjector : public Injector<UnitEInjector> {
             staking::ActiveChain,
             staking::BlockValidator,
             staking::StakeValidator)
+
+  COMPONENT(BlockRewardValidator, staking::BlockRewardValidator, staking::BlockRewardValidator::New,
+            blockchain::Behavior)
 
   COMPONENT(BlockDB, BlockDB, BlockDB::New)
 

--- a/src/staking/block_reward_validator.cpp
+++ b/src/staking/block_reward_validator.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/MIT.
+
+#include <staking/block_reward_validator.h>
+
+#include <chain.h>
+#include <consensus/validation.h>
+#include <primitives/transaction.h>
+
+#include <utilmoneystr.h>
+
+namespace staking {
+
+class BlockRewardValidatorImpl : public BlockRewardValidator {
+ private:
+  Dependency<blockchain::Behavior> m_behavior;
+
+ public:
+  BlockRewardValidatorImpl(
+      Dependency<blockchain::Behavior> behavior)
+      : m_behavior(behavior) {}
+
+  bool CheckBlockRewards(const CTransaction &coinbase_tx, CValidationState &state, const CBlockIndex &index,
+                         CAmount input_amount, CAmount fees) override {
+    assert(MoneyRange(input_amount));
+    assert(MoneyRange(fees));
+
+    const CBlockIndex &prev_block = *index.pprev;
+    CAmount total_reward = fees + m_behavior->CalculateBlockReward(prev_block.nHeight);
+
+    std::size_t num_reward_outputs = 1;
+
+    CAmount output_amount = coinbase_tx.GetValueOut();
+    if (output_amount - input_amount > total_reward) {
+      return state.DoS(100,
+                       error("%s: coinbase pays too much (total output=%d total input=%d expected reward=%d )",
+                             __func__, FormatMoney(output_amount), FormatMoney(input_amount),
+                             FormatMoney(total_reward)),
+                       REJECT_INVALID, "bad-cb-amount");
+    }
+
+    // TODO UNIT-E: make the check stricter: if (coinbase_tx.GetValueOut() - input_amount < block_reward)
+    if (output_amount < input_amount) {
+      return state.DoS(100,
+                       error("%s: coinbase pays too little (total output=%d total input=%d expected reward=%d )",
+                             __func__, FormatMoney(output_amount), FormatMoney(input_amount),
+                             FormatMoney(total_reward)),
+                       REJECT_INVALID, "bad-cb-spends-too-little");
+    }
+
+    CAmount non_reward_out = 0;
+    for (std::size_t i = num_reward_outputs; i < coinbase_tx.vout.size(); ++i) {
+      non_reward_out += coinbase_tx.vout[i].nValue;
+    }
+    if (non_reward_out > input_amount) {
+      return state.DoS(100,
+                       error("%s: coinbase spends too much (non-reward output=%d total input=%d)", __func__,
+                             FormatMoney(non_reward_out), FormatMoney(input_amount)),
+                       REJECT_INVALID, "bad-cb-spends-too-much");
+    }
+
+    return true;
+  }
+};
+
+std::unique_ptr<BlockRewardValidator> BlockRewardValidator::New(
+    Dependency<blockchain::Behavior> behavior) {
+  return MakeUnique<BlockRewardValidatorImpl>(behavior);
+}
+}  // namespace staking

--- a/src/staking/block_reward_validator.cpp
+++ b/src/staking/block_reward_validator.cpp
@@ -29,6 +29,12 @@ class BlockRewardValidatorImpl : public BlockRewardValidator {
     CAmount total_reward = fees + m_behavior->CalculateBlockReward(index.nHeight);
 
     std::size_t num_reward_outputs = 1;
+    if (coinbase_tx.vout.size() < num_reward_outputs) {
+      return state.DoS(100,
+                       error("%s: too few coinbase outputs expected at least %d actual %d", __func__,
+                             num_reward_outputs, coinbase_tx.vout.size()),
+                       REJECT_INVALID, "bad-cb-too-few-outputs");
+    }
 
     CAmount output_amount = coinbase_tx.GetValueOut();
     if (output_amount - input_amount > total_reward) {

--- a/src/staking/block_reward_validator.cpp
+++ b/src/staking/block_reward_validator.cpp
@@ -27,7 +27,7 @@ class BlockRewardValidatorImpl : public BlockRewardValidator {
     assert(MoneyRange(fees));
 
     const CBlockIndex &prev_block = *index.pprev;
-    CAmount total_reward = fees + m_behavior->CalculateBlockReward(prev_block.nHeight);
+    CAmount total_reward = fees + m_behavior->CalculateBlockReward(index.nHeight);
 
     std::size_t num_reward_outputs = 1;
 
@@ -40,8 +40,8 @@ class BlockRewardValidatorImpl : public BlockRewardValidator {
                        REJECT_INVALID, "bad-cb-amount");
     }
 
-    // TODO UNIT-E: make the check stricter: if (coinbase_tx.GetValueOut() - input_amount < block_reward)
-    if (output_amount < input_amount) {
+    // TODO UNIT-E: make the check stricter: if (output_amount - input_amount < total_reward)
+    if (output_amount - input_amount < total_reward - fees) {
       return state.DoS(100,
                        error("%s: coinbase pays too little (total output=%d total input=%d expected reward=%d )",
                              __func__, FormatMoney(output_amount), FormatMoney(input_amount),

--- a/src/staking/block_reward_validator.cpp
+++ b/src/staking/block_reward_validator.cpp
@@ -22,7 +22,7 @@ class BlockRewardValidatorImpl : public BlockRewardValidator {
       : m_behavior(behavior) {}
 
   bool CheckBlockRewards(const CTransaction &coinbase_tx, CValidationState &state, const CBlockIndex &index,
-                         CAmount input_amount, CAmount fees) override {
+                         CAmount input_amount, CAmount fees) const override {
     assert(MoneyRange(input_amount));
     assert(MoneyRange(fees));
 

--- a/src/staking/block_reward_validator.cpp
+++ b/src/staking/block_reward_validator.cpp
@@ -26,7 +26,6 @@ class BlockRewardValidatorImpl : public BlockRewardValidator {
     assert(MoneyRange(input_amount));
     assert(MoneyRange(fees));
 
-    const CBlockIndex &prev_block = *index.pprev;
     CAmount total_reward = fees + m_behavior->CalculateBlockReward(index.nHeight);
 
     std::size_t num_reward_outputs = 1;

--- a/src/staking/block_reward_validator.h
+++ b/src/staking/block_reward_validator.h
@@ -24,7 +24,7 @@ class BlockRewardValidator {
       CValidationState &state,
       const CBlockIndex &index,
       CAmount input_amount,
-      CAmount fees) = 0;
+      CAmount fees) const = 0;
 
   virtual ~BlockRewardValidator() = default;
 

--- a/src/staking/block_reward_validator.h
+++ b/src/staking/block_reward_validator.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/MIT.
+
+#ifndef UNIT_E_STAKING_BLOCK_REWARD_VALIDATOR_H
+#define UNIT_E_STAKING_BLOCK_REWARD_VALIDATOR_H
+
+#include <amount.h>
+#include <blockchain/blockchain_behavior.h>
+#include <dependency.h>
+
+#include <memory>
+
+class CBlockIndex;
+class CTransaction;
+class CValidationState;
+
+namespace staking {
+
+class BlockRewardValidator {
+ public:
+  virtual bool CheckBlockRewards(
+      const CTransaction &coinbase_tx,
+      CValidationState &state,
+      const CBlockIndex &index,
+      CAmount input_amount,
+      CAmount fees) = 0;
+
+  virtual ~BlockRewardValidator() = default;
+
+  static std::unique_ptr<BlockRewardValidator> New(
+      Dependency<blockchain::Behavior>);
+};
+
+}  // namespace staking
+
+#endif  //UNIT_E_STAKING_BLOCK_REWARD_VALIDATOR_H

--- a/src/test/staking/block_reward_validator_tests.cpp
+++ b/src/test/staking/block_reward_validator_tests.cpp
@@ -103,6 +103,22 @@ BOOST_AUTO_TEST_CASE(total_output_is_too_large) {
   test_invalid_outputs({f.immediate_reward + fees, input_amount + 1});
 }
 
+BOOST_AUTO_TEST_CASE(no_outputs) {
+  Fixture f;
+  const auto validator = f.GetBlockRewardValidator();
+
+  const CAmount input_amount = 11 * UNIT;
+  const CAmount fees = UNIT / 2;
+  CTransaction tx = f.MakeCoinbaseTx({});
+  CValidationState validation_state;
+
+  const bool result = validator->CheckBlockRewards(tx, validation_state, f.block, input_amount, fees);
+  BOOST_CHECK(!result);
+  BOOST_CHECK(!validation_state.IsValid());
+  BOOST_CHECK_EQUAL(validation_state.GetRejectCode(), REJECT_INVALID);
+  BOOST_CHECK_EQUAL(validation_state.GetRejectReason(), "bad-cb-too-few-outputs");
+}
+
 BOOST_AUTO_TEST_CASE(total_output_is_too_small) {
   Fixture f;
   const auto validator = f.GetBlockRewardValidator();

--- a/src/test/staking/block_reward_validator_tests.cpp
+++ b/src/test/staking/block_reward_validator_tests.cpp
@@ -1,0 +1,157 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/MIT.
+
+#include <blockchain/blockchain_parameters.h>
+#include <consensus/validation.h>
+#include <staking/block_reward_validator.h>
+
+#include <test/test_unite.h>
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+struct Fixture {
+
+  const CAmount total_reward = 10 * UNIT;
+
+  blockchain::Parameters parameters = [this]() {
+    blockchain::Parameters p = blockchain::Parameters::TestNet();
+    p.reward = total_reward;
+    return p;
+  }();
+
+  std::unique_ptr<blockchain::Behavior> b =
+      blockchain::Behavior::NewFromParameters(parameters);
+
+  CBlockIndex prev_block = [this]() {
+    CBlockIndex b;
+    b.nHeight = 100;
+    return b;
+  }();
+
+  const uint256 block_hash;
+  CBlockIndex block = [this]() {
+    CBlockIndex b;
+    b.pprev = &prev_block;
+    b.nHeight = prev_block.nHeight + 1;
+    b.phashBlock = &block_hash;
+    return b;
+  }();
+
+  CTransaction MakeCoinbaseTx(const std::vector<CAmount> &outputs) {
+    const CTxIn meta_input;
+    const CTxIn staking_input;
+
+    CMutableTransaction tx;
+    tx.SetType(TxType::COINBASE);
+    tx.vin = {meta_input, staking_input};
+    for (const auto out : outputs) {
+      tx.vout.emplace_back(out, CScript());
+    }
+    return tx;
+  }
+
+  CTransaction MakeCoinbaseTx(
+      CAmount block_reward,
+      const std::vector<std::pair<CScript, CAmount>> &finalization_rewards,
+      const std::vector<CAmount> &outputs) {
+    const CTxIn meta_input;
+    const CTxIn staking_input;
+
+    CMutableTransaction tx;
+    tx.SetType(TxType::COINBASE);
+    tx.vin = {meta_input, staking_input};
+    tx.vout.emplace_back(block_reward, CScript());
+    for (const auto &r : finalization_rewards) {
+      tx.vout.emplace_back(r.second, r.first);
+    }
+    for (const auto out : outputs) {
+      tx.vout.emplace_back(out, CScript());
+    }
+    return tx;
+  }
+
+  std::unique_ptr<staking::BlockRewardValidator> GetBlockRewardValidator() {
+    return staking::BlockRewardValidator::New(b.get());
+  }
+};
+
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(block_reward_validator_tests)
+
+BOOST_AUTO_TEST_CASE(valid_reward) {
+  Fixture f;
+  const auto validator = f.GetBlockRewardValidator();
+
+  const CAmount input_amount = 10 * UNIT;
+  const CAmount fees = 1 * UNIT;
+
+  auto test_valid_outputs = [&](const std::vector<CAmount> outputs) {
+    CTransaction tx = f.MakeCoinbaseTx(outputs);
+    CValidationState validation_state;
+
+    const bool result = validator->CheckBlockRewards(tx, validation_state, f.block, input_amount, fees);
+    BOOST_CHECK(result);
+    BOOST_CHECK(validation_state.IsValid());
+  };
+  test_valid_outputs({1 * UNIT + fees, input_amount});
+  test_valid_outputs({1 * UNIT + fees, input_amount / 2, input_amount / 2});
+  test_valid_outputs({1 * UNIT + fees + input_amount});
+  test_valid_outputs({input_amount});
+}
+
+BOOST_AUTO_TEST_CASE(total_output_is_too_large) {
+  Fixture f;
+  const auto validator = f.GetBlockRewardValidator();
+
+  const CAmount input_amount = 11 * UNIT;
+  const CAmount fees = 1 * UNIT;
+  auto test_invalid_outputs = [&](const std::vector<CAmount> outputs) {
+    CTransaction tx = f.MakeCoinbaseTx(outputs);
+    CValidationState validation_state;
+
+    const bool result = validator->CheckBlockRewards(tx, validation_state, f.block, input_amount, fees);
+    BOOST_CHECK(!result);
+    BOOST_CHECK(!validation_state.IsValid());
+    BOOST_CHECK_EQUAL(validation_state.GetRejectCode(), REJECT_INVALID);
+    BOOST_CHECK_EQUAL(validation_state.GetRejectReason(), "bad-cb-amount");
+  };
+  test_invalid_outputs({1 * UNIT + fees + 1, input_amount});
+  test_invalid_outputs({1 * UNIT + fees, input_amount + 1});
+}
+
+BOOST_AUTO_TEST_CASE(total_output_is_too_small) {
+  Fixture f;
+  const auto validator = f.GetBlockRewardValidator();
+
+  const CAmount input_amount = 11 * UNIT;
+  const CAmount fees = 1 * UNIT;
+  CTransaction tx = f.MakeCoinbaseTx({0, input_amount - 1});
+  CValidationState validation_state;
+
+  const bool result = validator->CheckBlockRewards(tx, validation_state, f.block, input_amount, fees);
+  BOOST_CHECK(!result);
+  BOOST_CHECK(!validation_state.IsValid());
+  BOOST_CHECK_EQUAL(validation_state.GetRejectCode(), REJECT_INVALID);
+  BOOST_CHECK_EQUAL(validation_state.GetRejectReason(), "bad-cb-spends-too-little");
+}
+
+BOOST_AUTO_TEST_CASE(non_reward_output_is_too_large) {
+  Fixture f;
+  const auto validator = f.GetBlockRewardValidator();
+
+  const CAmount input_amount = 15 * UNIT;
+  const CAmount fees = 1 * UNIT;
+  CTransaction tx = f.MakeCoinbaseTx({1 * UNIT, input_amount + fees});
+  CValidationState validation_state;
+
+  const bool result = validator->CheckBlockRewards(tx, validation_state, f.block, input_amount, fees);
+  BOOST_CHECK(!result);
+  BOOST_CHECK(!validation_state.IsValid());
+  BOOST_CHECK_EQUAL(validation_state.GetRejectCode(), REJECT_INVALID);
+  BOOST_CHECK_EQUAL(validation_state.GetRejectReason(), "bad-cb-spends-too-much");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/tx_verify_tests.cpp
+++ b/src/test/tx_verify_tests.cpp
@@ -31,33 +31,6 @@ BOOST_AUTO_TEST_CASE(check_tx_inputs_no_haz_coins) {
   BOOST_CHECK_EQUAL(validation_state.GetRejectReason(), "bad-txns-inputs-missingorspent");
 }
 
-BOOST_AUTO_TEST_CASE(check_tx_inputs_no_reward) {
-
-  const CTxIn meta_input;
-  BOOST_REQUIRE(meta_input.prevout.IsNull());
-  const uint256 some_txid = uint256S("4623a9438473459c466ea4fe87b5a614362e08c47454cf59646e49c5759cb60d");
-  const CTxIn staking_input(some_txid, 0);
-
-  CTransaction tx = [&] {
-    CMutableTransaction tx;
-    tx.SetType(TxType::COINBASE);
-    tx.vin = {meta_input, staking_input};
-    return tx;
-  }();
-
-  mocks::CoinsViewMock utxos;
-  utxos.mock_AccessCoin.SetResult(Coin(CTxOut(21, CScript()), 1, TxType::REGULAR));
-
-  CValidationState validation_state;
-  CAmount fees;
-
-  const bool result = Consensus::CheckTxInputs(tx, validation_state, utxos, 2, fees);
-  BOOST_CHECK(!result);
-  BOOST_CHECK(!validation_state.IsValid());
-  BOOST_CHECK_EQUAL(validation_state.GetRejectCode(), REJECT_INVALID);
-  BOOST_CHECK_EQUAL(validation_state.GetRejectReason(), "bad-cb-no-reward");
-}
-
 BOOST_AUTO_TEST_CASE(check_tx_inputs_does_not_access_coinbase_meta_input) {
 
   const CTxIn meta_input;
@@ -89,70 +62,6 @@ BOOST_AUTO_TEST_CASE(check_tx_inputs_does_not_access_coinbase_meta_input) {
   BOOST_CHECK(std::find(coins_accessed.begin(), coins_accessed.end(), meta_input.prevout) == coins_accessed.end());
   // check vin[1] was tried to be retrieved from coins view
   BOOST_CHECK(std::find(coins_accessed.begin(), coins_accessed.end(), staking_input.prevout) != coins_accessed.end());
-}
-
-BOOST_AUTO_TEST_CASE(check_tx_inputs_rejects_coinbase_that_spends_too_little) {
-
-  const CTxIn meta_input;
-  BOOST_REQUIRE(meta_input.prevout.IsNull());
-  const uint256 some_txid = uint256S("4623a9438473459c466ea4fe87b5a614362e08c47454cf59646e49c5759cb60d");
-  const CTxIn staking_input(some_txid, 0);
-
-  const CAmount reward = 21;
-  const CAmount stake_in = 19;
-  const CAmount stake_out = stake_in - 1;
-
-  CTransaction tx = [&] {
-    CMutableTransaction tx;
-    tx.SetType(TxType::COINBASE);
-    tx.vin = {meta_input, staking_input};
-    tx.vout = {CTxOut(reward, CScript()), CTxOut(stake_out, CScript())};
-    return tx;
-  }();
-
-  mocks::CoinsViewMock utxos;
-  utxos.mock_AccessCoin.SetResult(Coin(CTxOut(stake_in, CScript()), 1, TxType::REGULAR));
-
-  CValidationState validation_state;
-  CAmount fees;
-
-  const bool result = Consensus::CheckTxInputs(tx, validation_state, utxos, 2, fees);
-  BOOST_CHECK(!result);
-  BOOST_CHECK(!validation_state.IsValid());
-  BOOST_CHECK_EQUAL(validation_state.GetRejectCode(), REJECT_INVALID);
-  BOOST_CHECK_EQUAL(validation_state.GetRejectReason(), "bad-cb-spends-too-little");
-}
-
-BOOST_AUTO_TEST_CASE(check_tx_inputs_rejects_coinbase_that_spends_too_much) {
-
-  const CTxIn meta_input;
-  BOOST_REQUIRE(meta_input.prevout.IsNull());
-  const uint256 some_txid = uint256S("4623a9438473459c466ea4fe87b5a614362e08c47454cf59646e49c5759cb60d");
-  const CTxIn staking_input(some_txid, 0);
-
-  const CAmount reward = 21;
-  const CAmount stake_in = 19;
-  const CAmount stake_out = stake_in + 1;
-
-  CTransaction tx = [&] {
-    CMutableTransaction tx;
-    tx.SetType(TxType::COINBASE);
-    tx.vin = {meta_input, staking_input};
-    tx.vout = {CTxOut(reward, CScript()), CTxOut(stake_out, CScript())};
-    return tx;
-  }();
-
-  mocks::CoinsViewMock utxos;
-  utxos.mock_AccessCoin.SetResult(Coin(CTxOut(stake_in, CScript()), 1, TxType::REGULAR));
-
-  CValidationState validation_state;
-  CAmount fees;
-
-  const bool result = Consensus::CheckTxInputs(tx, validation_state, utxos, 2, fees);
-  BOOST_CHECK(!result);
-  BOOST_CHECK(!validation_state.IsValid());
-  BOOST_CHECK_EQUAL(validation_state.GetRejectCode(), REJECT_INVALID);
-  BOOST_CHECK_EQUAL(validation_state.GetRejectReason(), "bad-cb-spends-too-much");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes #777.

Extracted from #1081 because it contains important changes to coinbase validation which can be easily overlooked.

This PR implements the following rules for coinbase transactions:
1. The output amount minus the input amount must not be bigger than the block reward plus fees.
2. The output amount minus the input amount must not be smaller than the block reward. It allows proposers to burn fees. I did it this way because many functional tests generate coinbase transactions without taking into account fees.
3. Non-reward output amount (sum of all outputs except the first one) must not be bigger than the input amount.

Note that the first output (which is subject to coinbase maturity) can be bigger than the block reward plus fees, i.e. the reward and the stake can be sent to one output. It might useful for proposers who do not want to increase the number of their coins.