### PR TITLE
Remove check_proof_of_work flag

### DIFF
--- a/src/staking/legacy_validation_interface.cpp
+++ b/src/staking/legacy_validation_interface.cpp
@@ -30,8 +30,7 @@ class LegacyValidationImpl : public LegacyValidationInterface {
   bool CheckBlockHeader(
       const CBlockHeader &block,
       CValidationState &validation_state,
-      const Consensus::Params &consensus_params,
-      bool check_proof_of_work) override {
+      const Consensus::Params &consensus_params) override {
     // This function used to check proof of work only. It will check timestamps in PoS,
     // so it's not superfluous, but with PoW removed it is currently simply returning true.
     return true;
@@ -41,7 +40,6 @@ class LegacyValidationImpl : public LegacyValidationInterface {
       const CBlock &block,
       CValidationState &state,
       const Consensus::Params &consensus_params,
-      bool check_proof_of_work,
       bool check_merkle_root) override {
 
     // These are checks that are independent of context.
@@ -52,7 +50,7 @@ class LegacyValidationImpl : public LegacyValidationInterface {
 
     // Check that the header is valid (particularly PoW).  This is mostly
     // redundant with the call in AcceptBlockHeader.
-    if (!CheckBlockHeader(block, state, consensus_params, check_proof_of_work)) {
+    if (!CheckBlockHeader(block, state, consensus_params)) {
       return false;
     }
 
@@ -136,7 +134,7 @@ class LegacyValidationImpl : public LegacyValidationInterface {
                          strprintf("%s: witness merkle commitment mismatch", __func__));
       }
     }
-    if (check_proof_of_work && check_merkle_root) {
+    if (check_merkle_root) {
       block.fChecked = true;
     }
     return true;

--- a/src/staking/legacy_validation_interface.h
+++ b/src/staking/legacy_validation_interface.h
@@ -50,34 +50,13 @@ class LegacyValidationInterface {
   virtual bool CheckBlockHeader(
       const CBlockHeader &block,
       CValidationState &validation_state,
-      const Consensus::Params &consensus_params,
-      bool check_proof_of_work) = 0;
-
-  //! Short hand (virtual functions do not go well with default parameters)
-  //! for CheckBlockHeader(block, validation_state, consensus_params, true);
-  bool CheckBlockHeader(
-      const CBlockHeader &block,
-      CValidationState &validation_state,
-      const Consensus::Params &consensus_params) {
-    return CheckBlockHeader(block, validation_state, consensus_params, true);
-  }
+      const Consensus::Params &consensus_params) = 0;
 
   virtual bool CheckBlock(
       const CBlock &block,
       CValidationState &validation_state,
       const Consensus::Params &consensus_params,
-      bool check_proof_of_work,
       bool check_merkle_root) = 0;
-
-  //! Short hand (virtual functions do not go well with default parameters)
-  //! for CheckBlock(block, validation_state, consensus_params, check_proof_of_work, true);
-  bool CheckBlock(
-      const CBlock &block,
-      CValidationState &validation_state,
-      const Consensus::Params &consensus_params,
-      bool check_proof_of_work) {
-    return CheckBlock(block, validation_state, consensus_params, check_proof_of_work, true);
-  }
 
   //! Short hand (virtual functions do not go well with default parameters)
   //! CheckBlock(block, validation_state, consensus_params, true, true);
@@ -85,7 +64,7 @@ class LegacyValidationInterface {
       const CBlock &block,
       CValidationState &validation_state,
       const Consensus::Params &consensus_params) {
-    return CheckBlock(block, validation_state, consensus_params, true, true);
+    return CheckBlock(block, validation_state, consensus_params, true);
   }
 
   virtual bool ContextualCheckBlock(

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checkblock_empty, F, TestFixtures) {
   assert(block.vtx.empty());
 
   CValidationState state;
-  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false, false);
+  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false);
 
   BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-blk-length");
 }
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checkblock_too_many_transactions, F, TestFixtures)
   }
 
   CValidationState state;
-  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false, false);
+  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false);
 
   BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-blk-length");
 }
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checkblock_coinbase_missing, F, TestFixtures) {
   block.vtx.push_back(MakeTransactionRef(CTransaction(CreateTx())));
 
   CValidationState state;
-  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false, false);
+  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false);
 
   BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-cb-missing");
 }
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checkblock_duplicate_coinbase, F, TestFixtures) {
   block.vtx.push_back(MakeTransactionRef(CreateCoinbase()));
 
   CValidationState state;
-  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false, false);
+  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false);
 
   BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-cb-multiple");
 }
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checkblock_too_many_sigs, F, TestFixtures) {
   block.vtx.push_back(MakeTransactionRef(CTransaction(tx)));
 
   CValidationState state;
-  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false, false);
+  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false);
 
   BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-blk-sigops");
 }
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checkblock_merkle_root, F, TestFixtures) {
   block.hashMerkleRoot = GetRandHash();
 
   CValidationState state;
-  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false, true);
+  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), true);
 
   BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-txnmrklroot");
 }
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checkblock_merkle_root_mutated, F, TestFixtures) {
   block.hashMerkleRoot = BlockMerkleRoot(block, &ignored);
 
   CValidationState state;
-  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false, true);
+  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), true);
 
   BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-txns-duplicate");
 }
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checkblock_duplicates_tx, F, TestFixtures) {
   block.vtx.push_back(MakeTransactionRef(tx));
 
   CValidationState state;
-  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false, false);
+  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false);
 
   BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-txns-duplicate");
 }
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checkblock_tx_order, F, TestFixtures) {
   SortTxs(block, true);
 
   CValidationState state;
-  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false, false);
+  fixture.validation->CheckBlock(block, state, Params().GetConsensus(), false);
 
   BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-tx-ordering");
 }
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(checkblock_witness, F, TestFixtures) {
   block.hash_witness_merkle_root = GetRandHash();
 
   CValidationState state;
-  fixture.validation->CheckBlock(block, state, consensus_params, false, true);
+  fixture.validation->CheckBlock(block, state, consensus_params, true);
 
   BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-witness-merkle-match");
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1977,7 +1977,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     // is enforced in ContextualCheckBlockHeader(); we wouldn't want to
     // re-enforce that rule here (at least until we make it impossible for
     // GetAdjustedTime() to go backward).
-    if (!GetComponent<staking::LegacyValidationInterface>()->CheckBlock(block, state, chainparams.GetConsensus(), !fJustCheck, !fJustCheck)) {
+    if (!GetComponent<staking::LegacyValidationInterface>()->CheckBlock(block, state, chainparams.GetConsensus(), !fJustCheck)) {
         if (state.CorruptionPossible()) {
             // We don't write down blocks to disk if they may have been
             // corrupted, so this should be impossible unless we're having hardware
@@ -3548,7 +3548,7 @@ bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams,
     // NOTE: CheckBlockHeader is called by CheckBlock
     if (!validation->ContextualCheckBlockHeader(block, state, chainparams, pindexPrev, GetAdjustedTime()))
         return error("%s: Consensus::ContextualCheckBlockHeader: %s", __func__, FormatStateMessage(state));
-    if (!validation->CheckBlock(block, state, chainparams.GetConsensus(), false, !skip_merkle_tree_check))
+    if (!validation->CheckBlock(block, state, chainparams.GetConsensus(), !skip_merkle_tree_check))
         return error("%s: Consensus::CheckBlock: %s", __func__, FormatStateMessage(state));
     if (!validation->ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindexPrev))
         return error("%s: Consensus::ContextualCheckBlock: %s", __func__, FormatStateMessage(state));


### PR DESCRIPTION
Ever since `pow.h` has been removed Proof-of-Work is no longer checked and Proof-of-Stake is our consensus algorithm of choice.

This removes the remaining flags which conditionally check PoW. Already these flags have not been used and/or passed as `false` only.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
