### PR TITLE
Use proposetoaddress instead of generatetoaddress

### DIFF
--- a/test/functional/feature_staking.py
+++ b/test/functional/feature_staking.py
@@ -65,7 +65,7 @@ class FeatureStakingTest(UnitETestFramework):
             else:
                 assert not all_zeroes(previous_block_info['stake_modifier'])
 
-            result = node.generatetoaddress(1, address)
+            result = node.proposetoaddress(1, address)
             assert_equal(len(result), 1)
             current_block_hash = result[0]
             result = node.tracestake(start=height + 1, length=height + 2, reverse=True)
@@ -84,7 +84,7 @@ class FeatureStakingTest(UnitETestFramework):
         assert_equal(1, len(coins))
 
         self.log.info("Mine another block, this should make the first block reward mature")
-        node.generatetoaddress(1, address)
+        node.proposetoaddress(1, address)
         result = node.liststakeablecoins()
         coins = result['stakeable_coins']
         assert_equal(2, len(coins))

--- a/test/functional/finalization_deposit.py
+++ b/test/functional/finalization_deposit.py
@@ -95,6 +95,7 @@ class DepositTest(UnitETestFramework):
 
         # mine a block to allow the deposit to get included
         self.generate_sync(proposer, nblocks=2)
+        sync_blocks([finalizer, proposer], timeout=10)
         disconnect_nodes(finalizer, proposer.index)
 
         wait_until(lambda: finalizer.getvalidatorinfo()['validator_status'] == 'WAITING_DEPOSIT_FINALIZATION',

--- a/test/functional/finalization_expired_vote_conflict.py
+++ b/test/functional/finalization_expired_vote_conflict.py
@@ -4,7 +4,13 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from test_framework.mininode import P2PInterface
 from test_framework.test_framework import UnitETestFramework
-from test_framework.util import json, sync_blocks, assert_equal, wait_until
+from test_framework.util import (
+    assert_equal,
+    generate_block,
+    json,
+    sync_blocks,
+    wait_until
+)
 import os.path
 import re
 
@@ -110,7 +116,7 @@ class ExpiredVoteConflict(UnitETestFramework):
 
     def generate_epochs_without_mempool_sync(self, n_epochs):
         for _ in range(EPOCH_LENGTH * n_epochs):
-            self.proposer.generate(1)
+            generate_block(self.proposer)
             sync_blocks(self.nodes)
             self.validator.syncwithvalidationinterfacequeue()
 

--- a/test/functional/finalization_slash_itself.py
+++ b/test/functional/finalization_slash_itself.py
@@ -143,11 +143,11 @@ class FinalizationSlashSelfTest(UnitETestFramework):
         vote = fork2.decoderawtransaction(fork2.getrawtransaction(fork2.getrawmempool()[0]))
         assert_equal(vote['txtype'], TxType.VOTE.value)
 
-        fork2.generatetoaddress(1, fork1.getnewaddress('', 'bech32'))
+        fork2.proposetoaddress(1, fork1.getnewaddress('', 'bech32'))
         assert_equal(len(fork2.getrawmempool()), 0)
 
         # check if there is slashing after voting
-        fork2.generatetoaddress(3, fork1.getnewaddress('', 'bech32'))
+        fork2.proposetoaddress(3, fork1.getnewaddress('', 'bech32'))
         assert_equal(fork2.getblockcount(), 26)
         assert_finalizationstate(fork2, {'currentEpoch': 6,
                                          'lastJustifiedEpoch': 4,

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -31,7 +31,7 @@ class MempoolCoinbaseTest(UnitETestFramework):
         self.setup_stake_coins(*self.nodes)
 
         # Start with a 200 block chain
-        self.nodes[0].generatetoaddress(200, self.nodes[0].getnewaddress("", "bech32"))
+        self.nodes[0].proposetoaddress(200, self.nodes[0].getnewaddress("", "bech32"))
         assert_equal(self.nodes[0].getblockcount(), 200)
         self.sync_all()
 

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -65,7 +65,7 @@ class BlockchainTest(UnitETestFramework):
         fund_proof = self.nodes[0].gettxoutproof([funding_txid])
         self.nodes[0].importprunedfunds(genesis_tx_hex, fund_proof)
 
-        self.nodes[0].generatetoaddress(200, self.nodes[0].getnewaddress('', 'bech32'))
+        self.nodes[0].proposetoaddress(200, self.nodes[0].getnewaddress('', 'bech32'))
 
         self._test_getblockchaininfo()
         self._test_getchaintxstats()

--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -52,10 +52,10 @@ class DeprecatedRpcTest(UnitETestFramework):
         # - setlabel
         #
         address0 = self.nodes[0].getnewaddress('', 'bech32')
-        self.nodes[0].generatetoaddress(101, address0)
+        self.nodes[0].proposetoaddress(101, address0)
         self.sync_all()
         address1 = self.nodes[1].getnewaddress('', 'bech32')
-        self.nodes[1].generatetoaddress(101, address1)
+        self.nodes[1].proposetoaddress(101, address1)
 
         self.log.info("- getaccount")
         assert_raises_rpc_error(-32, "getaccount is deprecated", self.nodes[0].getaccount, address0)

--- a/test/functional/rpc_getchaintips.py
+++ b/test/functional/rpc_getchaintips.py
@@ -26,7 +26,7 @@ class GetChainTipsTest (UnitETestFramework):
         self.setup_stake_coins(self.nodes[0], self.nodes[2])
 
         # start with 200 blocks
-        self.nodes[0].generatetoaddress(200, self.nodes[0].getnewaddress('', 'bech32'))
+        self.nodes[0].proposetoaddress(200, self.nodes[0].getnewaddress('', 'bech32'))
         self.sync_all()
 
         tips = self.nodes[0].getchaintips ()

--- a/test/functional/rpc_tracechain.py
+++ b/test/functional/rpc_tracechain.py
@@ -23,7 +23,7 @@ class RpcTraceChainTest(UnitETestFramework):
         node = self.nodes[0]
         self.setup_stake_coins(node)
         address = node.getnewaddress('', 'bech32')
-        node.generatetoaddress(1, address)
+        node.proposetoaddress(1, address)
         result = node.tracechain(start=1, length=2)
         script_pub_key_pattern = {
             'asm': str,

--- a/test/functional/rpc_tracestake.py
+++ b/test/functional/rpc_tracestake.py
@@ -23,7 +23,7 @@ class RpcTraceStakeTest(UnitETestFramework):
         node = self.nodes[0]
         self.setup_stake_coins(node)
         address = node.getnewaddress('', 'bech32')
-        node.generatetoaddress(1, address)
+        node.proposetoaddress(1, address)
         result = node.tracestake(start=1, length=2)
         assert_matches(result, [
             {

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -787,4 +787,4 @@ def make_vote_tx(finalizer, finalizer_address, target_hash, source_epoch, target
     return vtx['hex']
 
 def generate_block(node, count=1):
-    return node.generatetoaddress(count, node.getnewaddress('', 'bech32'))
+    return node.proposetoaddress(count, node.getnewaddress('', 'bech32'))

--- a/test/functional/wallet_disable.py
+++ b/test/functional/wallet_disable.py
@@ -21,10 +21,10 @@ class DisableWalletTest (UnitETestFramework):
         # Make sure wallet is really disabled
         assert_raises_rpc_error(-32601, 'Method not found', self.nodes[0].getwalletinfo)
 
-        # In Unit-e we cannot call generate or generatetoaddress without wallet enabled
+        # In Unit-e we cannot call generate or proposetoaddress without wallet enabled
         assert_raises_rpc_error(-32601, 'Method not found', self.nodes[0].generate, 1)
-        assert_raises_rpc_error(-32601, 'Method not found', self.nodes[0].generatetoaddress, 1)
-        assert_raises_rpc_error(-32601, 'Method not found', self.nodes[0].generatetoaddress, 1, 'mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
+        assert_raises_rpc_error(-32601, 'Method not found', self.nodes[0].proposetoaddress, 1)
+        assert_raises_rpc_error(-32601, 'Method not found', self.nodes[0].proposetoaddress, 1, 'mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
 
         x = self.nodes[0].validateaddress('3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
         assert x['isvalid'] == False


### PR DESCRIPTION
Uses `proposetoaddress` instead of `generatetoaddress` where possible

Signed-off-by: Julian Fleischer <julian@thirdhash.com>