### PR TITLE
Simplify BlockValidationResult

### DIFF
--- a/src/staking/block_validator.cpp
+++ b/src/staking/block_validator.cpp
@@ -44,34 +44,39 @@ class BlockValidatorImpl : public AbstractBlockValidator {
   //! - has at least two inputs
   //! - the first input contains only meta information
   //! - the first input's scriptSig contains the block height and snapshot hash
-  void CheckCoinbaseTransactionInternal(
+  BlockValidationResult CheckCoinbaseTransactionInternal(
+      const CBlock &block,             //!< [in] The block that contains this coinbase transaction
       const CTransaction &tx,          //!< [in] The transaction to check
       blockchain::Height *height_out,  //!< [out] The height extracted from the scriptSig
-      uint256 *snapshot_hash_out,      //!< [out] The snapshot hash extracted from the scriptSig
-      BlockValidationResult &result    //!< [in,out] The validation result
+      uint256 *snapshot_hash_out       //!< [out] The snapshot hash extracted from the scriptSig
       ) const {
     if (tx.vin.empty()) {
-      result.errors += Error::NO_META_INPUT;
+      return BlockValidationResult(Error::NO_META_INPUT);
     } else {
-      CheckCoinbaseMetaInputInternal(tx.vin[0], height_out, snapshot_hash_out, result);
+      const BlockValidationResult result = CheckCoinbaseMetaInputInternal(tx.vin[0], height_out, snapshot_hash_out);
+      if (!result) {
+        return result;
+      }
     }
     if (tx.vin.size() < 2) {
-      result.AddError(Error::NO_STAKING_INPUT);
+      if (!m_blockchain_behavior->IsGenesisBlock(block)) {
+        return BlockValidationResult(Error::NO_STAKING_INPUT);
+      }
     }
     if (tx.vout.empty()) {
-      result.AddError(Error::COINBASE_TRANSACTION_WITHOUT_OUTPUT);
+      return BlockValidationResult(Error::COINBASE_TRANSACTION_WITHOUT_OUTPUT);
     }
+    return BlockValidationResult::success;
   }
 
   //! \brief checks that the first input of a coinbase transaction is well-formed
   //!
   //! A well-formed meta input encodes the block height, followed by the snapshot hash.
   //! It is then either terminated by OP_0 or some data follows (forwards-compatible).
-  void CheckCoinbaseMetaInputInternal(
+  BlockValidationResult CheckCoinbaseMetaInputInternal(
       const CTxIn &in,                 //!< [in] The input to check
       blockchain::Height *height_out,  //!< [out] The height extracted from the scriptSig
-      uint256 *snapshot_hash_out,      //!< [out] The snapshot hash extracted from the scriptSig
-      BlockValidationResult &result    //!< [in,out] The validation result
+      uint256 *snapshot_hash_out       //!< [out] The snapshot hash extracted from the scriptSig
       ) const {
 
     const CScript &script_sig = in.scriptSig;
@@ -84,30 +89,28 @@ class BlockValidatorImpl : public AbstractBlockValidator {
     // read + check height
     check = script_sig.GetOp(it, op, buf);
     if (!check || (buf.empty() && op != OP_0)) {
-      result.AddError(Error::NO_BLOCK_HEIGHT);
-      result.AddError(Error::NO_SNAPSHOT_HASH);
-      return;
+      return BlockValidationResult(Error::NO_BLOCK_HEIGHT);
     }
     try {
       CScriptNum height(buf, true);
       if (height < 0 || height > std::numeric_limits<blockchain::Height>::max()) {
-        result.AddError(Error::INVALID_BLOCK_HEIGHT);
+        return BlockValidationResult(Error::INVALID_BLOCK_HEIGHT);
       } else if (height_out) {
         *height_out = static_cast<blockchain::Height>(height.getint());
       }
     } catch (scriptnum_error &) {
-      result.AddError(Error::INVALID_BLOCK_HEIGHT);
+      return BlockValidationResult(Error::INVALID_BLOCK_HEIGHT);
     }
 
     // read + check snapshot hash
     check = script_sig.GetOp(it, op, buf);
     if (!check || op != 0x20 || buf.size() != 32) {
-      result.AddError(Error::NO_SNAPSHOT_HASH);
-      return;
+      return BlockValidationResult(Error::NO_SNAPSHOT_HASH);
     }
     if (snapshot_hash_out) {
       *snapshot_hash_out = uint256(buf);
     }
+    return BlockValidationResult::success;
   }
 
   //! \brief Checks the blocks signature.
@@ -120,78 +123,76 @@ class BlockValidatorImpl : public AbstractBlockValidator {
   //!
   //! This signature is checked here against the public key which is used to unlock the
   //! stake. The piece of information which is signed is the block hash.
-  void CheckBlockSignatureInternal(const CBlock &block, BlockValidationResult &result) const {
+  BlockValidationResult CheckBlockSignatureInternal(const CBlock &block) const {
     const uint256 block_hash = block.GetHash();
 
     const std::vector<CPubKey> keys = staking::ExtractBlockSigningKeys(block);
     if (keys.empty()) {
-      result.AddError(Error::INVALID_BLOCK_PUBLIC_KEY);
-      return;
+      return BlockValidationResult(Error::INVALID_BLOCK_PUBLIC_KEY);
     }
     for (const CPubKey &pubkey : keys) {
       if (pubkey.Verify(block_hash, block.signature)) {
-        return;
+        return BlockValidationResult();
       }
     }
     // if signature is verified, above loop will return from this function.
     // otherwise we reach here and track the error.
-    result.AddError(Error::BLOCK_SIGNATURE_VERIFICATION_FAILED);
+    return BlockValidationResult(Error::BLOCK_SIGNATURE_VERIFICATION_FAILED);
   }
 
-  void CheckBlockHeaderInternal(
-      const CBlockHeader &block_header,
-      BlockValidationResult &result) const override {
+  BlockValidationResult CheckBlockHeaderInternal(
+      const CBlockHeader &block_header) const override {
 
     if (m_blockchain_behavior->CalculateProposingTimestamp(block_header.nTime) != block_header.nTime) {
-      result.AddError(Error::INVALID_BLOCK_TIME);
+      return BlockValidationResult(Error::INVALID_BLOCK_TIME);
     }
+    return BlockValidationResult::success;
   }
 
-  void ContextualCheckBlockHeaderInternal(
+  BlockValidationResult ContextualCheckBlockHeaderInternal(
       const CBlockHeader &block_header,
       const blockchain::Time adjusted_time,
-      const CBlockIndex &previous_block,
-      BlockValidationResult &result) const override {
+      const CBlockIndex &previous_block) const override {
 
     if (block_header.hashPrevBlock != *previous_block.phashBlock) {
-      result.AddError(Error::PREVIOUS_BLOCK_DOESNT_MATCH);
+      return BlockValidationResult(Error::PREVIOUS_BLOCK_DOESNT_MATCH);
     }
-
     const int64_t block_time = block_header.GetBlockTime();
 
     if (block_time <= previous_block.GetMedianTimePast()) {
-      result.AddError(Error::BLOCKTIME_TOO_EARLY);
+      return BlockValidationResult(Error::BLOCKTIME_TOO_EARLY);
     }
-
     if (block_time > adjusted_time + m_blockchain_behavior->GetParameters().max_future_block_time_seconds) {
-      result.AddError(Error::BLOCKTIME_TOO_FAR_INTO_FUTURE);
+      return BlockValidationResult(Error::BLOCKTIME_TOO_FAR_INTO_FUTURE);
     }
+    return BlockValidationResult::success;
   }
 
-  void CheckBlockInternal(
+  BlockValidationResult CheckBlockInternal(
       const CBlock &block,             //!< [in] The block to check
       blockchain::Height *height_out,  //!< [out] The height extracted from the scriptSig
-      uint256 *snapshot_hash_out,      //!< [out] The snapshot hash extracted from the scriptSig
-      BlockValidationResult &result    //!< [in,out] The validation result
+      uint256 *snapshot_hash_out       //!< [out] The snapshot hash extracted from the scriptSig
       ) const override {
 
     // check that there are transactions
     if (block.vtx.empty()) {
-      result.AddError(Error::NO_TRANSACTIONS);
-      return;
+      return BlockValidationResult(Error::NO_TRANSACTIONS);
     }
 
     // check that coinbase transaction is first transaction
     if (block.vtx[0]->GetType() == +TxType::COINBASE) {
-      CheckCoinbaseTransactionInternal(*block.vtx[0], height_out, snapshot_hash_out, result);
+      const BlockValidationResult result = CheckCoinbaseTransactionInternal(block, *block.vtx[0], height_out, snapshot_hash_out);
+      if (!result) {
+        return result;
+      }
     } else {
-      result.AddError(Error::FIRST_TRANSACTION_NOT_A_COINBASE_TRANSACTION);
+      return BlockValidationResult(Error::FIRST_TRANSACTION_NOT_A_COINBASE_TRANSACTION);
     }
 
     // check that all other transactions are no coinbase transactions
     for (auto tx = block.vtx.cbegin() + 1; tx != block.vtx.cend(); ++tx) {
       if ((*tx)->GetType() == +TxType::COINBASE) {
-        result.AddError(Error::COINBASE_TRANSACTION_AT_POSITION_OTHER_THAN_FIRST);
+        return BlockValidationResult(Error::COINBASE_TRANSACTION_AT_POSITION_OTHER_THAN_FIRST);
       }
     }
 
@@ -201,57 +202,56 @@ class BlockValidatorImpl : public AbstractBlockValidator {
     // check merkle root
     const uint256 expected_merkle_root = BlockMerkleRoot(block, &duplicate_transactions);
     if (block.hashMerkleRoot != expected_merkle_root) {
-      result.AddError(Error::MERKLE_ROOT_MISMATCH);
+      return BlockValidationResult(Error::MERKLE_ROOT_MISMATCH);
     }
     if (duplicate_transactions) {
       // UNIT-E TODO: this check is required to mitigate CVE-2012-2459
       // Apparently an alternative construction of the merkle tree avoids this
       // issue completely _and_ results in faster merkle tree construction, see
       // BIP 98 https://github.com/bitcoin/bips/blob/master/bip-0098.mediawiki
-      result.AddError(Error::MERKLE_ROOT_DUPLICATE_TRANSACTIONS);
+      return BlockValidationResult(Error::MERKLE_ROOT_DUPLICATE_TRANSACTIONS);
     }
 
     // check witness merkle root
     const uint256 expected_witness_merkle_root = BlockWitnessMerkleRoot(block, &duplicate_transactions);
     if (block.hash_witness_merkle_root != expected_witness_merkle_root) {
-      result.AddError(Error::WITNESS_MERKLE_ROOT_MISMATCH);
+      return BlockValidationResult(Error::WITNESS_MERKLE_ROOT_MISMATCH);
     }
     if (duplicate_transactions) {
-      result.AddError(Error::WITNESS_MERKLE_ROOT_DUPLICATE_TRANSACTIONS);
+      return BlockValidationResult(Error::WITNESS_MERKLE_ROOT_DUPLICATE_TRANSACTIONS);
     }
 
     if (block.hash_finalizer_commits_merkle_root != BlockFinalizerCommitsMerkleRoot(block)) {
-      result.AddError(Error::FINALIZER_COMMITS_MERKLE_ROOT_MISMATCH);
+      return BlockValidationResult(Error::FINALIZER_COMMITS_MERKLE_ROOT_MISMATCH);
     }
 
     // check proposer signature
-    CheckBlockSignatureInternal(block, result);
-
-    if (!result && m_blockchain_behavior->IsGenesisBlock(block)) {
+    if (!m_blockchain_behavior->IsGenesisBlock(block)) {
       // genesis block does not have any stake (as there are no previous blocks)
-      result.RemoveError(Error::NO_STAKING_INPUT);
-      // because of this so there's also no public key to sign the block
-      result.RemoveError(Error::INVALID_BLOCK_PUBLIC_KEY);
+      const BlockValidationResult result = CheckBlockSignatureInternal(block);
+      if (!result) {
+        return result;
+      }
     }
+    return BlockValidationResult::success;
   }
 
-  void ContextualCheckBlockInternal(
+  BlockValidationResult ContextualCheckBlockInternal(
       const CBlock &block,
       const CBlockIndex &prev_block,
-      const BlockValidationInfo &validation_info,
-      BlockValidationResult &result) const override {
+      const BlockValidationInfo &validation_info) const override {
 
     if (validation_info.GetHeight() != static_cast<blockchain::Height>(prev_block.nHeight) + 1) {
-      result.AddError(Error::MISMATCHING_HEIGHT);
+      return BlockValidationResult(Error::MISMATCHING_HEIGHT);
     }
+    return BlockValidationResult::success;
   }
 
  public:
   BlockValidationResult CheckCoinbaseTransaction(
+      const CBlock &block,
       const CTransaction &coinbase_tx) const override {
-    BlockValidationResult result;
-    CheckCoinbaseTransactionInternal(coinbase_tx, nullptr, nullptr, result);
-    return result;
+    return CheckCoinbaseTransactionInternal(block, coinbase_tx, nullptr, nullptr);
   }
 
   explicit BlockValidatorImpl(Dependency<blockchain::Behavior> blockchain_behavior)
@@ -267,14 +267,13 @@ BlockValidationResult AbstractBlockValidator::CheckBlock(
     const CBlock &block,
     BlockValidationInfo *const block_validation_info) const {
 
-  BlockValidationResult result;
   if (block_validation_info && block_validation_info->GetCheckBlockStatus()) {
     // short circuit in case the validation already happened
-    return result;
+    return BlockValidationResult::success;
   }
   // Make sure CheckBlockHeader has passed
   if (!block_validation_info || !block_validation_info->GetCheckBlockHeaderStatus()) {
-    result.AddAll(CheckBlockHeader(block, block_validation_info));
+    const BlockValidationResult result = CheckBlockHeader(block, block_validation_info);
     if (!result) {
       return result;
     }
@@ -282,7 +281,7 @@ BlockValidationResult AbstractBlockValidator::CheckBlock(
   // perform the actual checks
   blockchain::Height height;
   uint256 snapshot_hash;
-  CheckBlockInternal(block, &height, &snapshot_hash, result);
+  const BlockValidationResult result = CheckBlockInternal(block, &height, &snapshot_hash);
   // save results in block_validation_info if present
   if (block_validation_info) {
     if (result) {
@@ -300,7 +299,6 @@ BlockValidationResult AbstractBlockValidator::ContextualCheckBlock(
     blockchain::Time adjusted_time,
     BlockValidationInfo *block_validation_info) const {
 
-  BlockValidationResult result;
   // block_validation_info is optional for the caller but carries meta data from
   // the coinbase transaction, hence we make sure to have one available here.
   std::unique_ptr<BlockValidationInfo> ptr = nullptr;
@@ -310,24 +308,24 @@ BlockValidationResult AbstractBlockValidator::ContextualCheckBlock(
   }
   if (block_validation_info->GetContextualCheckBlockStatus()) {
     // short circuit in case the validation already happened
-    return result;
+    return BlockValidationResult::success;
   }
   // Make sure CheckBlock has passed
   if (!block_validation_info->GetCheckBlockStatus()) {
-    result.AddAll(CheckBlock(block, block_validation_info));
+    const BlockValidationResult result = CheckBlock(block, block_validation_info);
     if (!result) {
       return result;
     }
   }
   // Make sure ContextualCheckBlockHeader has passed
   if (!block_validation_info->GetContextualCheckBlockHeaderStatus()) {
-    result.AddAll(ContextualCheckBlockHeader(block, prev_block, adjusted_time, block_validation_info));
+    const BlockValidationResult result = ContextualCheckBlockHeader(block, prev_block, adjusted_time, block_validation_info);
     if (!result) {
       return result;
     }
   }
   // perform the actual checks
-  ContextualCheckBlockInternal(block, prev_block, *block_validation_info, result);
+  const BlockValidationResult result = ContextualCheckBlockInternal(block, prev_block, *block_validation_info);
   // save results in block_validation_info
   if (result) {
     block_validation_info->MarkContextualCheckBlockSuccessfull();
@@ -341,13 +339,12 @@ BlockValidationResult AbstractBlockValidator::CheckBlockHeader(
     const CBlockHeader &block_header,
     BlockValidationInfo *const block_validation_info) const {
 
-  BlockValidationResult result;
   if (block_validation_info && block_validation_info->GetCheckBlockHeaderStatus()) {
     // short circuit in case the validation already happened
-    return result;
+    return BlockValidationResult::success;
   }
   // perform the actual checks
-  CheckBlockHeaderInternal(block_header, result);
+  const BlockValidationResult result = CheckBlockHeaderInternal(block_header);
   // save results in block_validation_info if present
   if (block_validation_info) {
     if (result) {
@@ -365,20 +362,19 @@ BlockValidationResult AbstractBlockValidator::ContextualCheckBlockHeader(
     const blockchain::Time adjusted_time,
     BlockValidationInfo *const block_validation_info) const {
 
-  BlockValidationResult result;
   if (block_validation_info && block_validation_info->GetContextualCheckBlockHeaderStatus()) {
     // short circuit in case the validation already happened
-    return result;
+    return BlockValidationResult::success;
   }
   // Make sure CheckBlockHeader has passed
   if (!block_validation_info || !block_validation_info->GetCheckBlockHeaderStatus()) {
-    result.AddAll(CheckBlockHeader(block_header, block_validation_info));
+    const BlockValidationResult result = CheckBlockHeader(block_header, block_validation_info);
     if (!result) {
       return result;
     }
   }
   // perform the actual checks
-  ContextualCheckBlockHeaderInternal(block_header, adjusted_time, prev_block, result);
+  const BlockValidationResult result = ContextualCheckBlockHeaderInternal(block_header, adjusted_time, prev_block);
   // save results in block_validation_info if present
   if (block_validation_info) {
     if (result) {

--- a/src/staking/block_validator.cpp
+++ b/src/staking/block_validator.cpp
@@ -132,7 +132,7 @@ class BlockValidatorImpl : public AbstractBlockValidator {
     }
     for (const CPubKey &pubkey : keys) {
       if (pubkey.Verify(block_hash, block.signature)) {
-        return BlockValidationResult();
+        return BlockValidationResult::success;
       }
     }
     // if signature is verified, above loop will return from this function.

--- a/src/staking/block_validator.h
+++ b/src/staking/block_validator.h
@@ -111,6 +111,7 @@ class BlockValidator {
   //! - the meta input carrying height and snapshot hash at vin[0]
   //! - the staking input at vin[1]
   virtual BlockValidationResult CheckCoinbaseTransaction(
+      const CBlock &block,             //!< [in] The block that contains this coinbase transaction
       const CTransaction &coinbase_tx  //!< [in] The coinbase transaction to check
       ) const = 0;
 
@@ -126,27 +127,23 @@ class BlockValidator {
 class AbstractBlockValidator : public BlockValidator {
 
  protected:
-  virtual void CheckBlockHeaderInternal(
-      const CBlockHeader &block_header,
-      BlockValidationResult &result) const = 0;
+  virtual BlockValidationResult CheckBlockHeaderInternal(
+      const CBlockHeader &block_header) const = 0;
 
-  virtual void ContextualCheckBlockHeaderInternal(
+  virtual BlockValidationResult ContextualCheckBlockHeaderInternal(
       const CBlockHeader &block_header,
       blockchain::Time adjusted_time,
-      const CBlockIndex &previous_block,
-      BlockValidationResult &result) const = 0;
+      const CBlockIndex &previous_block) const = 0;
 
-  virtual void CheckBlockInternal(
+  virtual BlockValidationResult CheckBlockInternal(
       const CBlock &block,
       blockchain::Height *height_out,
-      uint256 *snapshot_hash_out,
-      BlockValidationResult &result) const = 0;
+      uint256 *snapshot_hash_out) const = 0;
 
-  virtual void ContextualCheckBlockInternal(
+  virtual BlockValidationResult ContextualCheckBlockInternal(
       const CBlock &block,
       const CBlockIndex &prev_block,
-      const BlockValidationInfo &validation_info,
-      BlockValidationResult &result) const = 0;
+      const BlockValidationInfo &validation_info) const = 0;
 
  public:
   BlockValidationResult CheckBlock(

--- a/src/staking/validation_error.cpp
+++ b/src/staking/validation_error.cpp
@@ -161,10 +161,10 @@ const std::string &GetRejectionMessageFor(const BlockValidationError error) {
 
 bool CheckResult(const BlockValidationResult &result, CValidationState &state) {
   if (!result) {
-    const ValidationError &validation_error = GetValidationErrorFor(*result.errors.begin());
+    const ValidationError &validation_error = GetValidationErrorFor(*result);
     state.DoS(
         validation_error.level, false, validation_error.reject_code, validation_error.reject_reason,
-        validation_error.corruption, result.errors.ToString());
+        validation_error.corruption, (*result)._to_string());
     return false;
   }
   return true;

--- a/src/staking/validation_result.cpp
+++ b/src/staking/validation_result.cpp
@@ -6,24 +6,28 @@
 
 namespace staking {
 
-void BlockValidationResult::AddAll(const BlockValidationResult &other) {
-  errors += other.errors;
-}
-
-void BlockValidationResult::AddError(const BlockValidationError error) {
-  errors += error;
-}
-
-void BlockValidationResult::RemoveError(const BlockValidationError error) {
-  errors -= error;
-}
+BlockValidationResult BlockValidationResult::success = BlockValidationResult();
 
 BlockValidationResult::operator bool() const {
-  return errors.IsEmpty();
+  return !m_error;
 }
 
 std::string BlockValidationResult::GetRejectionMessage() const {
-  return errors.ToStringUsing(GetRejectionMessageFor);
+  if (!m_error) {
+    return "";
+  }
+  return GetRejectionMessageFor(*m_error);
+}
+
+bool BlockValidationResult::Is(const BlockValidationError error) const {
+  if (!m_error) {
+    return false;
+  }
+  return *m_error == +error;
+}
+
+BlockValidationError BlockValidationResult::operator*() const {
+  return *m_error;
 }
 
 }  // namespace staking

--- a/src/staking/validation_result.cpp
+++ b/src/staking/validation_result.cpp
@@ -6,7 +6,7 @@
 
 namespace staking {
 
-BlockValidationResult BlockValidationResult::success = BlockValidationResult();
+const BlockValidationResult BlockValidationResult::success = BlockValidationResult();
 
 BlockValidationResult::operator bool() const {
   return !m_error;

--- a/src/staking/validation_result.h
+++ b/src/staking/validation_result.h
@@ -16,22 +16,26 @@ namespace staking {
 
 class BlockValidationResult {
  public:
-  EnumSet<BlockValidationError> errors;
+  static BlockValidationResult success;
 
-  //! \brief Add all errors from the given validation result to this one.
-  void AddAll(const BlockValidationResult &other);
+  //! \brief Construct a positive BlockValidationResult.
+  BlockValidationResult() noexcept : m_error(boost::none) {}
 
-  //! \brief Add another error to this validation result.
-  void AddError(BlockValidationError);
-
-  //! \brief Remove an error from this validation result.
-  void RemoveError(BlockValidationError);
+  //! \brief Constructs a failed BlockValidationResult with an accompanying error code.
+  explicit BlockValidationResult(const BlockValidationError error) : m_error(error) {}
 
   //! \brief Validation succeeded if there are no validation errors
   explicit operator bool() const;
 
   //! \brief Create a message suitable for usage in a REJECT p2p message.
   std::string GetRejectionMessage() const;
+
+  bool Is(BlockValidationError error) const;
+
+  BlockValidationError operator*() const;
+
+ private:
+  boost::optional<BlockValidationError> m_error;
 };
 
 }  // namespace staking

--- a/src/staking/validation_result.h
+++ b/src/staking/validation_result.h
@@ -16,7 +16,7 @@ namespace staking {
 
 class BlockValidationResult {
  public:
-  static BlockValidationResult success;
+  static const BlockValidationResult success;
 
   //! \brief Construct a positive BlockValidationResult.
   BlockValidationResult() noexcept : m_error(boost::none) {}

--- a/src/test/proposer/block_builder_tests.cpp
+++ b/src/test/proposer/block_builder_tests.cpp
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(build_block_and_validate) {
       current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, boost::none, f.wallet);
   BOOST_REQUIRE(static_cast<bool>(block));
   auto is_valid = validator->CheckBlock(*block, nullptr);
-  BOOST_CHECK(is_valid);
+  BOOST_CHECK_MESSAGE(is_valid, is_valid.GetRejectionMessage());
 
   auto &stake_in = block->vtx[0]->vin[1];
   BOOST_CHECK(stake_in.scriptWitness.stack[1] == f.pubkeydata);
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(split_amount) {
     });
     // check that outputs differ no more than one in size (this avoids dust)
     BOOST_CHECK(abs(minmax.first->nValue - minmax.second->nValue) <= 1);
-    BOOST_CHECK(static_cast<bool>(is_valid));
+    BOOST_CHECK_MESSAGE(is_valid, is_valid.GetRejectionMessage());
   };
 
   // eligible_coin.amount=100, threshold=10, reward=50 -> 10x10 (reward is separate)
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE(check_reward_destination) {
       current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, boost::none, f.wallet);
   BOOST_REQUIRE(static_cast<bool>(block));
   const staking::BlockValidationResult is_valid = validator->CheckBlock(*block, nullptr);
-  BOOST_CHECK(static_cast<bool>(is_valid));
+  BOOST_CHECK_MESSAGE(is_valid, is_valid.GetRejectionMessage());
 
   const CTxOut stake_out = block->vtx[0]->vout[1];
   BOOST_CHECK_EQUAL(f.eligible_coin.utxo.GetAmount(), stake_out.nValue);
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(combine_stake) {
       current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, boost::none, f.wallet);
   BOOST_REQUIRE(static_cast<bool>(block));
   const staking::BlockValidationResult is_valid = validator->CheckBlock(*block, nullptr);
-  BOOST_CHECK(static_cast<bool>(is_valid));
+  BOOST_CHECK_MESSAGE(is_valid, is_valid.GetRejectionMessage());
   // must have a coinbase transaction
   BOOST_REQUIRE(!block->vtx.empty());
 
@@ -327,7 +327,7 @@ BOOST_AUTO_TEST_CASE(remote_staking) {
         current_tip, f.snapshot_hash, eligible_coin, coins, transactions, fees, boost::none, f.wallet);
     BOOST_REQUIRE(static_cast<bool>(block));
     const staking::BlockValidationResult is_valid = validator->CheckBlock(*block, nullptr);
-    BOOST_CHECK(static_cast<bool>(is_valid));
+    BOOST_CHECK_MESSAGE(is_valid, is_valid.GetRejectionMessage());
     // must have a coinbase transaction
     BOOST_REQUIRE(!block->vtx.empty());
 
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(remote_staking) {
         current_tip, f.snapshot_hash, f.eligible_coin, coins, transactions, fees, boost::none, f.wallet);
     BOOST_REQUIRE(static_cast<bool>(block));
     const staking::BlockValidationResult is_valid = validator->CheckBlock(*block, nullptr);
-    BOOST_CHECK(static_cast<bool>(is_valid));
+    BOOST_CHECK_MESSAGE(is_valid, is_valid.GetRejectionMessage());
     // must have a coinbase transaction
     BOOST_REQUIRE(!block->vtx.empty());
 

--- a/src/test/staking/block_validator_tests.cpp
+++ b/src/test/staking/block_validator_tests.cpp
@@ -6,6 +6,7 @@
 
 #include <blockchain/blockchain_genesis.h>
 #include <blockchain/blockchain_parameters.h>
+#include <test/util/blocktools.h>
 #include <consensus/merkle.h>
 #include <key/mnemonic/mnemonic.h>
 #include <test/test_unite.h>
@@ -18,8 +19,46 @@ namespace {
 std::unique_ptr<blockchain::Behavior> b =
     blockchain::Behavior::NewFromParameters(blockchain::Parameters::TestNet());
 
+struct KeyFixture {
+  CExtKey ext_key;
+  CPubKey pub_key;
+  std::vector<unsigned char> pub_key_data;
+};
+
+KeyFixture MakeKeyFixture(const std::string& seed_words = "cook note face vicious suggest company unit smart lobster tongue dune diamond faculty solid thought") {
+  // a block is signed by the proposer, thus we need some key setup here
+  const key::mnemonic::Seed seed(seed_words);
+  const CExtKey &ext_key = seed.GetExtKey();
+  // public key for signing block
+  const CPubKey pub_key = ext_key.key.GetPubKey();
+  return {
+      ext_key,
+      pub_key,
+      std::vector<unsigned char>(pub_key.begin(), pub_key.end())
+  };
+}
+
+CTransactionRef MakeCoinbaseTransaction(const KeyFixture& key_fixture = MakeKeyFixture(), const blockchain::Height height = 0) {
+
+  CMutableTransaction tx;
+  tx.SetType(TxType::COINBASE);
+
+  // meta input: block height, snapshot hash, terminator
+  CScript script_sig = CScript() << CScriptNum::serialize(4711)
+                                 << ToByteVector(uint256S("689dae90b6913ff34a64750dd537177afa58b3d012803a10793d74f1ebb88da9"));
+  tx.vin.emplace_back(uint256(), 0, script_sig);
+  // stake
+  tx.vin.emplace_back(uint256(), 1);
+  tx.vin[1].scriptWitness.stack.emplace_back();  // signature, not checked
+  tx.vin[1].scriptWitness.stack.emplace_back(key_fixture.pub_key_data);
+  // can be spent by anyone, simply yields "true"
+  CScript script_pub_key = CScript() << OP_TRUE;
+  tx.vout.emplace_back(50, script_pub_key);
+  return MakeTransactionRef(CTransaction(tx));
+}
+
 //! \brief creates a minimal block that passes validation without looking at the chain
-CBlock MinimalBlock() {
+CBlock MinimalBlock(const KeyFixture& key_fixture = MakeKeyFixture()) {
   // a block is signed by the proposer, thus we need some key setup here
   const key::mnemonic::Seed seed("cook note face vicious suggest company unit smart lobster tongue dune diamond faculty solid thought");
   const CExtKey &ext_key = seed.GetExtKey();
@@ -29,31 +68,15 @@ CBlock MinimalBlock() {
 
   CBlock block;
   block.nTime = b->CalculateProposingTimestamp(std::time(nullptr));
-  {
-    CMutableTransaction tx;
-    tx.SetType(TxType::COINBASE);
-    // meta input: block height, snapshot hash, terminator
-    CScript script_sig = CScript() << CScriptNum::serialize(4711)
-                                   << ToByteVector(uint256S("689dae90b6913ff34a64750dd537177afa58b3d012803a10793d74f1ebb88da9"));
-    tx.vin.emplace_back(uint256(), 0, script_sig);
-    // stake
-    tx.vin.emplace_back(uint256(), 1);
-    tx.vin[1].scriptWitness.stack.emplace_back();  // signature, not checked
-    tx.vin[1].scriptWitness.stack.emplace_back(pub_key_data);
-    // can be spent by anyone, simply yields "true"
-    CScript script_pub_key = CScript() << OP_TRUE;
-    tx.vout.emplace_back(50, script_pub_key);
-    block.vtx.push_back(MakeTransactionRef(CTransaction(tx)));
-  }
+  block.vtx.emplace_back(MakeCoinbaseTransaction(key_fixture));
   {
     CMutableTransaction tx;
     tx.SetType(TxType::REGULAR);
     block.vtx.push_back(MakeTransactionRef(CTransaction(tx)));
   }
-
-  bool duplicate_transactions;
-  block.hashMerkleRoot = BlockMerkleRoot(block, &duplicate_transactions);
-  block.hash_witness_merkle_root = BlockWitnessMerkleRoot(block, &duplicate_transactions);
+  block.hashMerkleRoot = BlockMerkleRoot(block);
+  block.hash_witness_merkle_root = BlockWitnessMerkleRoot(block);
+  block.hash_finalizer_commits_merkle_root = BlockFinalizerCommitsMerkleRoot(block);
   const uint256 blockHash = block.GetHash();
 
   ext_key.key.Sign(blockHash, block.signature);
@@ -69,7 +92,7 @@ void CheckGenesisBlock(const blockchain::Parameters &parameters) {
   const auto block_validator = staking::BlockValidator::New(chain_behaviour.get());
   const auto validation_result = block_validator->CheckBlock(parameters.genesis_block.block, nullptr);
 
-  BOOST_CHECK(static_cast<bool>(validation_result));
+  BOOST_CHECK_MESSAGE(static_cast<bool>(validation_result), validation_result.GetRejectionMessage());
 }
 
 using Error = staking::BlockValidationError;
@@ -83,13 +106,14 @@ BOOST_AUTO_TEST_CASE(check_empty_block) {
 
   CBlock block;
 
-  const auto validation_result = block_validator->CheckBlock(block, nullptr);
+  const staking::BlockValidationResult validation_result = block_validator->CheckBlock(block, nullptr);
 
   BOOST_CHECK(!validation_result);
-  BOOST_CHECK(validation_result.errors.Contains(Error::NO_TRANSACTIONS));
+  BOOST_CHECK(validation_result.Is(Error::NO_TRANSACTIONS));
 }
 
 BOOST_AUTO_TEST_CASE(check_first_transaction_not_a_coinbase_transaction) {
+  // checks a block that lacks a coinbase transaction
   const auto block_validator = staking::BlockValidator::New(b.get());
 
   CMutableTransaction tx;
@@ -98,14 +122,14 @@ BOOST_AUTO_TEST_CASE(check_first_transaction_not_a_coinbase_transaction) {
   CBlock block;
   block.vtx.push_back(MakeTransactionRef(CTransaction(tx)));
 
-  const auto validation_result = block_validator->CheckBlock(block, nullptr);
+  const staking::BlockValidationResult validation_result = block_validator->CheckBlock(block, nullptr);
 
   BOOST_CHECK(!validation_result);
-  BOOST_CHECK(validation_result.errors.Contains(Error::FIRST_TRANSACTION_NOT_A_COINBASE_TRANSACTION));
-  BOOST_CHECK(!validation_result.errors.Contains(Error::COINBASE_TRANSACTION_AT_POSITION_OTHER_THAN_FIRST));
+  BOOST_CHECK(validation_result.Is(Error::FIRST_TRANSACTION_NOT_A_COINBASE_TRANSACTION));
 }
 
 BOOST_AUTO_TEST_CASE(check_coinbase_other_than_first) {
+  // checks a block that _has_ a coinbase transaction but not at the right position
   const auto block_validator = staking::BlockValidator::New(b.get());
 
   CBlock block;
@@ -114,39 +138,26 @@ BOOST_AUTO_TEST_CASE(check_coinbase_other_than_first) {
     tx.SetType(TxType::REGULAR);
     block.vtx.push_back(MakeTransactionRef(CTransaction(tx)));
   }
-  {
-    CMutableTransaction tx;
-    tx.SetType(TxType::COINBASE);
-    block.vtx.push_back(MakeTransactionRef(CTransaction(tx)));
-  }
+  block.vtx.emplace_back(MakeCoinbaseTransaction());
 
-  const auto validation_result = block_validator->CheckBlock(block, nullptr);
+  const staking::BlockValidationResult validation_result = block_validator->CheckBlock(block, nullptr);
 
   BOOST_CHECK(!validation_result);
-  BOOST_CHECK(validation_result.errors.Contains(Error::COINBASE_TRANSACTION_AT_POSITION_OTHER_THAN_FIRST));
-  BOOST_CHECK(validation_result.errors.Contains(Error::FIRST_TRANSACTION_NOT_A_COINBASE_TRANSACTION));
+  BOOST_CHECK_MESSAGE(validation_result.Is(Error::FIRST_TRANSACTION_NOT_A_COINBASE_TRANSACTION), validation_result.GetRejectionMessage());
 }
 
 BOOST_AUTO_TEST_CASE(check_two_coinbase_transactions) {
   const auto block_validator = staking::BlockValidator::New(b.get());
 
   CBlock block;
-  {
-    CMutableTransaction tx;
-    tx.SetType(TxType::COINBASE);
-    block.vtx.push_back(MakeTransactionRef(CTransaction(tx)));
-  }
-  {
-    CMutableTransaction tx;
-    tx.SetType(TxType::COINBASE);
-    block.vtx.push_back(MakeTransactionRef(CTransaction(tx)));
-  }
+  const KeyFixture key_fixture = MakeKeyFixture();
+  block.vtx.emplace_back(MakeCoinbaseTransaction(key_fixture));
+  block.vtx.emplace_back(MakeCoinbaseTransaction(key_fixture));
 
-  const auto validation_result = block_validator->CheckBlock(block, nullptr);
+  const staking::BlockValidationResult validation_result = block_validator->CheckBlock(block, nullptr);
 
-  BOOST_CHECK(validation_result.errors.Contains(Error::COINBASE_TRANSACTION_AT_POSITION_OTHER_THAN_FIRST));
-  BOOST_CHECK(!validation_result.errors.Contains(Error::FIRST_TRANSACTION_NOT_A_COINBASE_TRANSACTION));
   BOOST_CHECK(!validation_result);
+  BOOST_CHECK_MESSAGE(validation_result.Is(Error::COINBASE_TRANSACTION_AT_POSITION_OTHER_THAN_FIRST), validation_result.GetRejectionMessage());
 }
 
 BOOST_AUTO_TEST_CASE(check_NO_block_height) {
@@ -156,10 +167,10 @@ BOOST_AUTO_TEST_CASE(check_NO_block_height) {
   coinbase.vin[0].scriptSig = CScript();
   block.vtx[0] = MakeTransactionRef(coinbase);
 
-  const auto validation_result = block_validator->CheckBlock(block, nullptr);
+  const staking::BlockValidationResult validation_result = block_validator->CheckBlock(block, nullptr);
 
-  BOOST_CHECK(validation_result.errors.Contains(Error::NO_BLOCK_HEIGHT));
   BOOST_CHECK(!validation_result);
+  BOOST_CHECK_MESSAGE(validation_result.Is(Error::NO_BLOCK_HEIGHT), validation_result.GetRejectionMessage());
 }
 
 BOOST_AUTO_TEST_CASE(check_premature_end_of_scriptsig) {
@@ -170,11 +181,10 @@ BOOST_AUTO_TEST_CASE(check_premature_end_of_scriptsig) {
                                         << OP_0;
   block.vtx[0] = MakeTransactionRef(coinbase);
 
-  const auto validation_result = block_validator->CheckBlock(block, nullptr);
+  const staking::BlockValidationResult validation_result = block_validator->CheckBlock(block, nullptr);
 
-  BOOST_CHECK(!validation_result.errors.Contains(Error::NO_BLOCK_HEIGHT));
-  BOOST_CHECK(validation_result.errors.Contains(Error::NO_SNAPSHOT_HASH));
   BOOST_CHECK(!validation_result);
+  BOOST_CHECK_MESSAGE(validation_result.Is(Error::NO_SNAPSHOT_HASH), validation_result.GetRejectionMessage());
 }
 
 BOOST_AUTO_TEST_CASE(check_scriptsig_with_additional_data) {
@@ -186,10 +196,10 @@ BOOST_AUTO_TEST_CASE(check_scriptsig_with_additional_data) {
                                         << ToByteVector(uint256());
   block.vtx[0] = MakeTransactionRef(coinbase);
 
-  const auto validation_result = block_validator->CheckBlock(block, nullptr);
+  const staking::BlockValidationResult validation_result = block_validator->CheckBlock(block, nullptr);
 
-  BOOST_CHECK(!validation_result.errors.Contains(Error::NO_BLOCK_HEIGHT));
-  BOOST_CHECK(!validation_result.errors.Contains(Error::NO_SNAPSHOT_HASH));
+  BOOST_CHECK(!validation_result.Is(Error::NO_BLOCK_HEIGHT));
+  BOOST_CHECK(!validation_result.Is(Error::NO_SNAPSHOT_HASH));
 }
 
 BOOST_AUTO_TEST_CASE(check_NO_snapshot_hash) {
@@ -199,11 +209,11 @@ BOOST_AUTO_TEST_CASE(check_NO_snapshot_hash) {
   coinbase.vin[0].scriptSig = CScript() << CScriptNum::serialize(7) << OP_0;
   block.vtx[0] = MakeTransactionRef(coinbase);
 
-  const auto validation_result = block_validator->CheckBlock(block, nullptr);
+  const staking::BlockValidationResult validation_result = block_validator->CheckBlock(block, nullptr);
 
-  BOOST_CHECK(!validation_result.errors.Contains(Error::NO_BLOCK_HEIGHT));
-  BOOST_CHECK(validation_result.errors.Contains(Error::NO_SNAPSHOT_HASH));
   BOOST_CHECK(!validation_result);
+  BOOST_CHECK_MESSAGE(validation_result.Is(Error::NO_SNAPSHOT_HASH), validation_result.GetRejectionMessage());
+
 }
 
 BOOST_AUTO_TEST_CASE(check_empty_coinbase_transaction) {
@@ -214,12 +224,10 @@ BOOST_AUTO_TEST_CASE(check_empty_coinbase_transaction) {
   coinbase.SetType(TxType::COINBASE);
   block.vtx[0] = MakeTransactionRef(coinbase);
 
-  const auto validation_result = block_validator->CheckBlock(block, nullptr);
+  const staking::BlockValidationResult validation_result = block_validator->CheckBlock(block, nullptr);
 
-  BOOST_CHECK(validation_result.errors.Contains(Error::NO_META_INPUT));
-  BOOST_CHECK(validation_result.errors.Contains(Error::COINBASE_TRANSACTION_WITHOUT_OUTPUT));
-  BOOST_CHECK(validation_result.errors.Contains(Error::NO_STAKING_INPUT));
   BOOST_CHECK(!validation_result);
+  BOOST_CHECK_MESSAGE(validation_result.Is(Error::NO_META_INPUT), validation_result.GetRejectionMessage());
 }
 
 BOOST_AUTO_TEST_CASE(check_coinbase_transaction_without_stake) {
@@ -230,10 +238,10 @@ BOOST_AUTO_TEST_CASE(check_coinbase_transaction_without_stake) {
   coinbase.vin.erase(coinbase.vin.begin() + 1);
   block.vtx[0] = MakeTransactionRef(coinbase);
 
-  const auto validation_result = block_validator->CheckBlock(block, nullptr);
+  const staking::BlockValidationResult validation_result = block_validator->CheckBlock(block, nullptr);
 
-  BOOST_CHECK(validation_result.errors.Contains(Error::NO_STAKING_INPUT));
   BOOST_CHECK(!validation_result);
+  BOOST_CHECK_MESSAGE(validation_result.Is(Error::NO_STAKING_INPUT), validation_result.GetRejectionMessage());
 }
 
 BOOST_AUTO_TEST_CASE(no_public_key) {
@@ -243,10 +251,11 @@ BOOST_AUTO_TEST_CASE(no_public_key) {
   // remove public key from staking input's witness stack
   coinbase.vin[1].scriptWitness.stack.clear();
   block.vtx[0] = MakeTransactionRef(coinbase);
-  const auto validation_result = block_validator->CheckBlock(block, nullptr);
+  block.hash_witness_merkle_root = BlockWitnessMerkleRoot(block);
+  const staking::BlockValidationResult validation_result = block_validator->CheckBlock(block, nullptr);
 
-  BOOST_CHECK(validation_result.errors.Contains(Error::INVALID_BLOCK_PUBLIC_KEY));
   BOOST_CHECK(!validation_result);
+  BOOST_CHECK_MESSAGE(validation_result.Is(Error::INVALID_BLOCK_PUBLIC_KEY), validation_result.GetRejectionMessage());
 }
 
 BOOST_AUTO_TEST_CASE(invalid_block_signature) {
@@ -254,10 +263,10 @@ BOOST_AUTO_TEST_CASE(invalid_block_signature) {
   CBlock block = MinimalBlock();
   // corrupt signature by flipping some byte
   block.signature[7] = ~block.signature[7];
-  const auto validation_result = block_validator->CheckBlock(block, nullptr);
+  const staking::BlockValidationResult validation_result = block_validator->CheckBlock(block, nullptr);
 
   BOOST_CHECK(!validation_result);
-  BOOST_CHECK(validation_result.errors.Contains(Error::BLOCK_SIGNATURE_VERIFICATION_FAILED));
+  BOOST_CHECK_MESSAGE(validation_result.Is(Error::BLOCK_SIGNATURE_VERIFICATION_FAILED), validation_result.GetRejectionMessage());
 }
 
 BOOST_AUTO_TEST_CASE(invalid_block_time) {
@@ -265,19 +274,19 @@ BOOST_AUTO_TEST_CASE(invalid_block_time) {
   CBlock block = MinimalBlock();
   // corrupt block time by offsetting it by 1
   block.nTime = block.nTime + 1;
-  const auto validation_result = block_validator->CheckBlock(block, nullptr);
+  const staking::BlockValidationResult validation_result = block_validator->CheckBlock(block, nullptr);
 
   BOOST_CHECK(!validation_result);
-  BOOST_CHECK(validation_result.errors.Contains(Error::INVALID_BLOCK_TIME));
+  BOOST_CHECK_MESSAGE(validation_result.Is(Error::INVALID_BLOCK_TIME), validation_result.GetRejectionMessage());
 }
 
 BOOST_AUTO_TEST_CASE(valid_block) {
   staking::BlockValidationInfo block_validation_info;
 
   const auto block_validator = staking::BlockValidator::New(b.get());
-  const auto validation_result = block_validator->CheckBlock(MinimalBlock(), &block_validation_info);
+  const staking::BlockValidationResult validation_result = block_validator->CheckBlock(MinimalBlock(), &block_validation_info);
 
-  BOOST_CHECK(static_cast<bool>(validation_result));
+  BOOST_CHECK_MESSAGE(validation_result, validation_result.GetRejectionMessage());
   BOOST_CHECK(static_cast<bool>(block_validation_info.GetCheckBlockStatus()));
 
   const blockchain::Height expected_height = 4711;
@@ -302,9 +311,9 @@ BOOST_AUTO_TEST_CASE(check_mismatching_height) {
     block_validation_info.MarkContextualCheckBlockHeaderSuccessfull();
     block_validation_info.MarkCheckBlockSuccessfull(1500, uint256());
 
-    const auto validation_result =
+    const staking::BlockValidationResult validation_result =
         block_validator->ContextualCheckBlock(MinimalBlock(), prev_block, std::time(nullptr), &block_validation_info);
-    BOOST_CHECK(static_cast<bool>(validation_result));
+    BOOST_CHECK_MESSAGE(validation_result, validation_result.GetRejectionMessage());
     BOOST_CHECK(block_validation_info.GetContextualCheckBlockStatus().IsTrue());
   }
 
@@ -316,10 +325,10 @@ BOOST_AUTO_TEST_CASE(check_mismatching_height) {
 
     prev_block.nHeight = 1498;
 
-    const auto validation_result =
+    const staking::BlockValidationResult validation_result =
         block_validator->ContextualCheckBlock(MinimalBlock(), prev_block, std::time(nullptr), &block_validation_info);
-    BOOST_CHECK(validation_result.errors.Contains(Error::MISMATCHING_HEIGHT));
-    BOOST_CHECK(!static_cast<bool>(validation_result));
+    BOOST_CHECK(!validation_result);
+    BOOST_CHECK(validation_result.Is(Error::MISMATCHING_HEIGHT));
     BOOST_CHECK(block_validation_info.GetContextualCheckBlockStatus().IsFalse());
   }
 }

--- a/src/test/staking/block_validator_tests.cpp
+++ b/src/test/staking/block_validator_tests.cpp
@@ -6,10 +6,10 @@
 
 #include <blockchain/blockchain_genesis.h>
 #include <blockchain/blockchain_parameters.h>
-#include <test/util/blocktools.h>
 #include <consensus/merkle.h>
 #include <key/mnemonic/mnemonic.h>
 #include <test/test_unite.h>
+#include <test/util/blocktools.h>
 #include <timedata.h>
 
 #include <boost/test/unit_test.hpp>
@@ -25,7 +25,7 @@ struct KeyFixture {
   std::vector<unsigned char> pub_key_data;
 };
 
-KeyFixture MakeKeyFixture(const std::string& seed_words = "cook note face vicious suggest company unit smart lobster tongue dune diamond faculty solid thought") {
+KeyFixture MakeKeyFixture(const std::string &seed_words = "cook note face vicious suggest company unit smart lobster tongue dune diamond faculty solid thought") {
   // a block is signed by the proposer, thus we need some key setup here
   const key::mnemonic::Seed seed(seed_words);
   const CExtKey &ext_key = seed.GetExtKey();
@@ -34,11 +34,10 @@ KeyFixture MakeKeyFixture(const std::string& seed_words = "cook note face viciou
   return {
       ext_key,
       pub_key,
-      std::vector<unsigned char>(pub_key.begin(), pub_key.end())
-  };
+      std::vector<unsigned char>(pub_key.begin(), pub_key.end())};
 }
 
-CTransactionRef MakeCoinbaseTransaction(const KeyFixture& key_fixture = MakeKeyFixture(), const blockchain::Height height = 0) {
+CTransactionRef MakeCoinbaseTransaction(const KeyFixture &key_fixture = MakeKeyFixture(), const blockchain::Height height = 0) {
 
   CMutableTransaction tx;
   tx.SetType(TxType::COINBASE);
@@ -58,7 +57,7 @@ CTransactionRef MakeCoinbaseTransaction(const KeyFixture& key_fixture = MakeKeyF
 }
 
 //! \brief creates a minimal block that passes validation without looking at the chain
-CBlock MinimalBlock(const KeyFixture& key_fixture = MakeKeyFixture()) {
+CBlock MinimalBlock(const KeyFixture &key_fixture = MakeKeyFixture()) {
   // a block is signed by the proposer, thus we need some key setup here
   const key::mnemonic::Seed seed("cook note face vicious suggest company unit smart lobster tongue dune diamond faculty solid thought");
   const CExtKey &ext_key = seed.GetExtKey();
@@ -213,7 +212,6 @@ BOOST_AUTO_TEST_CASE(check_NO_snapshot_hash) {
 
   BOOST_CHECK(!validation_result);
   BOOST_CHECK_MESSAGE(validation_result.Is(Error::NO_SNAPSHOT_HASH), validation_result.GetRejectionMessage());
-
 }
 
 BOOST_AUTO_TEST_CASE(check_empty_coinbase_transaction) {

--- a/src/test/staking/stake_validator_tests.cpp
+++ b/src/test/staking/stake_validator_tests.cpp
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(check_remote_staking_outputs) {
     tx.vout = {out};
     block.vtx = {MakeTransactionRef(tx)};
 
-    const auto r = stake_validator->CheckStake(block, nullptr);
+    const staking::BlockValidationResult r = stake_validator->CheckStake(block, nullptr);
     BOOST_CHECK_MESSAGE(r, r.GetRejectionMessage());
   }
 
@@ -150,9 +150,9 @@ BOOST_AUTO_TEST_CASE(check_remote_staking_outputs) {
     tx.vout = {out};
     block.vtx = {MakeTransactionRef(tx)};
 
-    const auto r = stake_validator->CheckStake(block, nullptr);
+    const staking::BlockValidationResult r = stake_validator->CheckStake(block, nullptr);
     BOOST_CHECK(!r);
-    BOOST_CHECK(r.errors.Contains(staking::BlockValidationError::REMOTE_STAKING_INPUT_BIGGER_THAN_OUTPUT));
+    BOOST_CHECK(r.Is(staking::BlockValidationError::REMOTE_STAKING_INPUT_BIGGER_THAN_OUTPUT));
   }
 
   // Two remote staking outputs with total amount greater than the input amount
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(check_remote_staking_outputs) {
     tx.vout = {out, out2};
     block.vtx = {MakeTransactionRef(tx)};
 
-    const auto r = stake_validator->CheckStake(block, nullptr);
+    const staking::BlockValidationResult r = stake_validator->CheckStake(block, nullptr);
     BOOST_CHECK_MESSAGE(r, r.GetRejectionMessage());
   }
 
@@ -175,9 +175,9 @@ BOOST_AUTO_TEST_CASE(check_remote_staking_outputs) {
     tx.vout = {out};
     block.vtx = {MakeTransactionRef(tx)};
 
-    const auto r = stake_validator->CheckStake(block, nullptr);
+    const staking::BlockValidationResult r = stake_validator->CheckStake(block, nullptr);
     BOOST_CHECK(!r);
-    BOOST_CHECK(r.errors.Contains(staking::BlockValidationError::TRANSACTION_INPUT_NOT_FOUND));
+    BOOST_CHECK(r.Is(staking::BlockValidationError::TRANSACTION_INPUT_NOT_FOUND));
   }
 
   coins.emplace(input2_ref, staking::Coin(&block_index, input2_ref, CTxOut{2 * UNIT, script2}));
@@ -202,9 +202,9 @@ BOOST_AUTO_TEST_CASE(check_remote_staking_outputs) {
     tx.vout = {out, out2};
     block.vtx = {MakeTransactionRef(tx)};
 
-    const auto r = stake_validator->CheckStake(block, nullptr);
+    const staking::BlockValidationResult r = stake_validator->CheckStake(block, nullptr);
     BOOST_CHECK(!r);
-    BOOST_CHECK(r.errors.Contains(staking::BlockValidationError::REMOTE_STAKING_INPUT_BIGGER_THAN_OUTPUT));
+    BOOST_CHECK(r.Is(staking::BlockValidationError::REMOTE_STAKING_INPUT_BIGGER_THAN_OUTPUT));
   }
 }
 

--- a/src/test/test_unite_mocks.h
+++ b/src/test/test_unite_mocks.h
@@ -355,8 +355,8 @@ class BlockValidatorMock : public staking::BlockValidator, public Mock {
   BlockValidationResult ContextualCheckBlockHeader(const CBlockHeader &block_header, const CBlockIndex &block_index, blockchain::Time time, BlockValidationInfo *info) const override {
     return mock_ContextualCheckBlockHeader(block_header, block_index, time, info);
   }
-  BlockValidationResult CheckCoinbaseTransaction(const CTransaction &coinbase_tx) const override {
-    return mock_CheckCoinbaseTransaction(coinbase_tx);
+  BlockValidationResult CheckCoinbaseTransaction(const CBlock &block, const CTransaction &coinbase_tx) const override {
+    return mock_CheckCoinbaseTransaction(block, coinbase_tx);
   }
 };
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1992,7 +1992,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         UTXOViewAdapter utxo_view(GetComponent<staking::ActiveChain>(), view);
         auto validator = GetComponent<staking::StakeValidator>();
         const staking::BlockValidationResult coinbase_validation_result =
-            GetComponent<staking::BlockValidator>()->CheckCoinbaseTransaction(*block.vtx[0]);
+            GetComponent<staking::BlockValidator>()->CheckCoinbaseTransaction(block, *block.vtx[0]);
         if (!staking::CheckResult(coinbase_validation_result, state)) {
             return false;
         }
@@ -2009,7 +2009,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
             validator->CheckStake(block, &state.block_validation_info, check_stake_flags, &utxo_view);
         if (!staking::CheckResult(stake_validation_result, state)) {
             LogPrint(BCLog::VALIDATION, "%s: Invalid stake found for block=%s failure=%s\n",
-                     __func__, block.GetHash().ToString(), stake_validation_result.errors.ToString());
+                     __func__, block.GetHash().ToString(), stake_validation_result.GetRejectionMessage());
             return false;
         }
     }


### PR DESCRIPTION
This changes `BlockValidationResult` from hosting a set of validation errors to just carry one validation error and always short circuit / return early on validation errors.

This was already suggested during the initial review of this by @kostyantyn 

Some things that follow: Some tests had to be set up a bit differently as previously multiple things could fail, now the first thing fails and some fixtures were not mocked accordingly. This fixes that.

Cosmetic changes:
- removes a few `auto` in favor of proper types in tests
- uses a few `BOOST_CHECK_MESSAGE` instead of `BOOST_CHECK` for better debugging

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
