### PR TITLE
Fix compilation warning

### DIFF
--- a/src/test/staking/block_reward_validator_tests.cpp
+++ b/src/test/staking/block_reward_validator_tests.cpp
@@ -25,7 +25,7 @@ struct Fixture {
   std::unique_ptr<blockchain::Behavior> b =
       blockchain::Behavior::NewFromParameters(parameters);
 
-  CBlockIndex prev_block = [this]() {
+  CBlockIndex prev_block = []() {
     CBlockIndex b;
     b.nHeight = 100;
     return b;


### PR DESCRIPTION
test/staking/block_reward_validator_tests.cpp:28:29: warning: lambda capture 'this' is not used
