### PR TITLE
Fix pre-commit hook

### DIFF
--- a/contrib/githooks/pre-commit
+++ b/contrib/githooks/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Using: contrib/devtools/lint-clang-format.py [--check-commit] [--replace [--git-add]]
+# Using: test/lint/lint-clang-format.py [--check-commit] [--replace [--git-add]]
 
 # Checking unit-e sources follow style guide.
 # With no options, just check all the project files.
@@ -10,4 +10,4 @@
 # --git-add        add formated files back into your commit
 
 unset GIT_DIR
-./contrib/devtools/lint-clang-format.py --check-commit --replace --git-add
+./test/lint/lint-clang-format.py --check-commit --replace --git-add


### PR DESCRIPTION
The #1101 broke pre-commit git hook by moving linter from `contrib/devtools` to`test/lint`
directory. This commit fixes that.
