### PR TITLE
Move security policy to own file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -366,8 +366,7 @@ GitHub](https://github.com/dtr-org/unit-e/issues). There is some more
 information in the [developer
 notes](https://github.com/dtr-org/unit-e/blob/master/doc/developer-notes.md#github-issues).
 
-Contact security@dtr.org to report security vulnerabilities or discuss sensitive
-security related matters.
+See [SECURITY.md](SECURITY.md) for information how to deal with security issues.
 
 
 Release Policy

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+Unit-e is currently run as [alpha
+testnet](https://github.com/dtr-org/unit-e#alpha-testnet).
+[Releases](https://github.com/dtr-org/unit-e/releases) of the unit-e client are
+done as [source code
+only](https://github.com/dtr-org/unit-e#running-from-source) releases. We are
+committed to fix any security issues in the code base in a timely manner.
+
+Contact security@dtr.org to report security vulnerabilities or discuss sensitive
+security related matters.


### PR DESCRIPTION
Move security policy to SECURITY.md so it shows up on the new Security tab on GitHub.