### PR TITLE
Check stake before relaying high perf compact block

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -104,6 +104,7 @@ UNITE_TESTS =\
   test/multisig_tests.cpp \
   test/net_tests.cpp \
   test/netbase_tests.cpp \
+  test/new_pos_valid_block_tests.cpp \
   test/pmt_tests.cpp \
   test/p2p/grapheneblock_tests.cpp \
   test/policyestimator_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -104,7 +104,6 @@ UNITE_TESTS =\
   test/multisig_tests.cpp \
   test/net_tests.cpp \
   test/netbase_tests.cpp \
-  test/new_pos_valid_block_tests.cpp \
   test/pmt_tests.cpp \
   test/p2p/grapheneblock_tests.cpp \
   test/policyestimator_tests.cpp \
@@ -157,6 +156,7 @@ UNITE_TESTS += \
   test/esperanza/walletextension_tests.cpp \
   test/injector_tests.cpp \
   test/mnemonic_tests.cpp \
+  test/new_pos_valid_block_tests.cpp \
   test/proposer/blockassembleradapter_tests.cpp \
   test/proposer/block_builder_tests.cpp \
   test/proposer/proposer_logic_tests.cpp \

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -897,7 +897,7 @@ static uint256 most_recent_block_hash GUARDED_BY(cs_most_recent_block);
  * Maintain state about the best-seen block and fast-announce a compact block
  * to compatible peers.
  */
-void PeerLogicValidation::NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& pblock) {
+void PeerLogicValidation::NewPoSValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& pblock) {
     std::shared_ptr<const CBlockHeaderAndShortTxIDs> pcmpctblock = std::make_shared<const CBlockHeaderAndShortTxIDs>(*pblock);
     const CNetMsgMaker msgMaker(PROTOCOL_VERSION);
 
@@ -927,7 +927,7 @@ void PeerLogicValidation::NewPoWValidBlock(const CBlockIndex *pindex, const std:
         // If the peer has, or we announced to them the previous block already,
         // but we don't think they have this one, go ahead and announce it
         if (state.fPreferHeaderAndIDs && !PeerHasHeader(&state, pindex) && PeerHasHeader(&state, pindex->pprev)) {
-            LogPrint(BCLog::NET, "%s sending header-and-ids %s to peer=%d\n", "PeerLogicValidation::NewPoWValidBlock",
+            LogPrint(BCLog::NET, "%s sending header-and-ids %s to peer=%d\n", "PeerLogicValidation::NewPoSValidBlock",
                     hashBlock.ToString(), pnode->GetId());
             connman->PushMessage(pnode, msgMaker.Make(NetMsgType::CMPCTBLOCK, *pcmpctblock));
             state.pindexBestHeaderSent = pindex;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -40,7 +40,7 @@ public:
     /**
      * Overridden from CValidationInterface.
      */
-    void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& pblock) override;
+    void NewPoSValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& pblock) override;
 
     /** Initialize a peer by adding it to mapNodeState and pushing a message requesting its version */
     void InitializeNode(CNode* pnode) override;

--- a/src/test/esperanza/walletextension_tests.cpp
+++ b/src/test/esperanza/walletextension_tests.cpp
@@ -290,7 +290,7 @@ BOOST_FIXTURE_TEST_CASE(get_stakeable_coins, TestChain100Setup) {
   // Make the first coinbase mature
   CScript coinbase_script = GetScriptForDestination(coinbaseKey.GetPubKey().GetID());
   bool processed;
-  CreateAndProcessBlock({}, coinbase_script, &processed);
+  CreateAndProcessBlock({}, coinbase_script, boost::none, &processed);
   BOOST_CHECK(processed);
 
   CTransaction &stakeable = m_coinbase_txns.front();

--- a/src/test/new_pos_valid_block_tests.cpp
+++ b/src/test/new_pos_valid_block_tests.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 The Unit-e developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <staking/coin.h>
+#include <test/test_unite.h>
+#include <validationinterface.h>
+#include <wallet/test/wallet_test_fixture.h>
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(new_pos_valid_block_tests, TestChain100Setup)
+
+struct NewPoSValidBlockListener : CValidationInterface {
+  NewPoSValidBlockListener() {
+    RegisterValidationInterface(this);
+  }
+
+  ~NewPoSValidBlockListener() {
+    UnregisterValidationInterface(this);
+  }
+
+  std::set<uint256> new_pos_valid_blocks;
+
+ protected:
+  void NewPoSValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock> &block) override {
+    new_pos_valid_blocks.emplace(block->GetHash());
+  }
+};
+
+staking::Coin GetStake(CWallet &wallet) {
+  LOCK2(cs_main, wallet.cs_wallet);
+  const esperanza::WalletExtension &wallet_ext = wallet.GetWalletExtension();
+  return *wallet_ext.GetStakeableCoins().begin();
+}
+
+BOOST_AUTO_TEST_CASE(spent_stake) {
+  const staking::Coin stake = GetStake(*m_wallet);
+
+  const CScript coinbase_script = CScript() << OP_1;
+
+  bool processed;
+  NewPoSValidBlockListener listener;
+  const CBlock valid_block = CreateAndProcessBlock({}, coinbase_script, stake, &processed);
+  BOOST_CHECK(processed);
+  BOOST_CHECK_EQUAL(1, listener.new_pos_valid_blocks.count(valid_block.GetHash()));
+
+  const CBlock invalid_block = CreateAndProcessBlock({}, coinbase_script, stake, &processed);
+  BOOST_CHECK(!processed);
+  BOOST_CHECK_EQUAL(0, listener.new_pos_valid_blocks.count(invalid_block.GetHash()));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/new_pos_valid_block_tests.cpp
+++ b/src/test/new_pos_valid_block_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <consensus/validation.h>
 #include <staking/coin.h>
 #include <test/test_unite.h>
 #include <validationinterface.h>
@@ -20,10 +21,15 @@ struct NewPoSValidBlockListener : CValidationInterface {
   }
 
   std::set<uint256> new_pos_valid_blocks;
+  std::map<uint256, CValidationState> checked_blocks;
 
  protected:
   void NewPoSValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock> &block) override {
     new_pos_valid_blocks.emplace(block->GetHash());
+  }
+
+  void BlockChecked(const CBlock &block, const CValidationState &state) override {
+    checked_blocks[block.GetHash()] = state;
   }
 };
 
@@ -44,9 +50,38 @@ BOOST_AUTO_TEST_CASE(spent_stake) {
   BOOST_CHECK(processed);
   BOOST_CHECK_EQUAL(1, listener.new_pos_valid_blocks.count(valid_block.GetHash()));
 
+  // Using the same stake again => spent stake
   const CBlock invalid_block = CreateAndProcessBlock({}, coinbase_script, stake, &processed);
   BOOST_CHECK(!processed);
   BOOST_CHECK_EQUAL(0, listener.new_pos_valid_blocks.count(invalid_block.GetHash()));
+}
+
+BOOST_AUTO_TEST_CASE(invalid_stake_script) {
+  const CScript coinbase_script = CScript() << OP_1;
+  std::shared_ptr<const CBlock> valid_block = CreateBlock({}, coinbase_script);
+
+  // We are going to alter some coinbase scripts to make this block invalid
+  auto invalid_block = std::make_shared<CBlock>(*valid_block);
+  auto coinbase = CMutableTransaction(*invalid_block->vtx[0]);
+  coinbase.vin[1].scriptSig = CScript() << OP_1;
+  invalid_block->vtx[0] = MakeTransactionRef(std::move(coinbase));
+
+  // Because we changed a transaction
+  invalid_block->ComputeMerkleTrees();
+
+  NewPoSValidBlockListener listener;
+
+  BOOST_CHECK(!ProcessBlock(invalid_block));
+  const auto it = listener.checked_blocks.find(invalid_block->GetHash());
+  BOOST_REQUIRE(it != listener.checked_blocks.end());
+  CValidationState vs = it->second;
+  BOOST_CHECK_EQUAL(vs.GetRejectCode(), 64);
+  BOOST_CHECK_EQUAL(vs.GetRejectReason(), "non-mandatory-script-verify-flag (Witness requires empty scriptSig)");
+  BOOST_CHECK_EQUAL(0, listener.new_pos_valid_blocks.count(invalid_block->GetHash()));
+
+  // Now submit valid block to ensure that it actually was valid before we tampered it
+  BOOST_CHECK(ProcessBlock(valid_block));
+  BOOST_CHECK_EQUAL(1, listener.new_pos_valid_blocks.count(valid_block->GetHash()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -64,18 +64,18 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
     bool processed;
 
     // Test 1: block with both of those transactions should be rejected.
-    block = CreateAndProcessBlock(spends, scriptPubKey, &processed);
+    block = CreateAndProcessBlock(spends, scriptPubKey, boost::none, &processed);
     BOOST_CHECK(chainActive.Tip()->GetBlockHash() != block.GetHash());
 
     // Test 2: ... and should be rejected if spend1 is in the memory pool
     BOOST_CHECK(ToMemPool(spends[0]));
-    block = CreateAndProcessBlock(spends, scriptPubKey, &processed);
+    block = CreateAndProcessBlock(spends, scriptPubKey, boost::none, &processed);
     BOOST_CHECK(chainActive.Tip()->GetBlockHash() != block.GetHash());
     mempool.clear();
 
     // Test 3: ... and should be rejected if spend2 is in the memory pool
     BOOST_CHECK(ToMemPool(spends[1]));
-    block = CreateAndProcessBlock(spends, scriptPubKey, &processed);
+    block = CreateAndProcessBlock(spends, scriptPubKey, boost::none, &processed);
     BOOST_CHECK(chainActive.Tip()->GetBlockHash() != block.GetHash());
     mempool.clear();
 
@@ -154,7 +154,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup)
     CScript p2wpkh_scriptPubKey = GetScriptForWitness(p2pkh_scriptPubKey);
 
     bool processed;
-    const CTransactionRef p2pkh_coinbase = CreateAndProcessBlock({}, p2pkh_scriptPubKey, &processed).vtx[0];
+    const CTransactionRef p2pkh_coinbase = CreateAndProcessBlock({}, p2pkh_scriptPubKey, boost::none, &processed).vtx[0];
     BOOST_CHECK(processed);
 
     // Make the reward with p2pkh_scriptPubKey mature

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3424,7 +3424,7 @@ bool AcceptStake(CBlockIndex &index, const CBlock &block, CValidationState &stat
     constexpr unsigned int standard_flags = STANDARD_SCRIPT_VERIFY_FLAGS;
     if (!CheckInputs(*coinbase, state, coins_cache, true, standard_flags, true, true, txdata)) {
         LogPrint(BCLog::VALIDATION, "%s: Invalid stake found for block=%s failure=%s\n",
-                 __func__, block.GetHash().ToString(), state.GetDebugMessage());
+                 __func__, block.GetHash().ToString(), state.GetRejectReason());
         return false;
     }
 
@@ -3489,7 +3489,7 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
     }
 
     if (chainActive.Tip() == pindex->pprev) {
-        if (!AcceptStake(*pindex, block, state, *pcoinsTip)){
+        if (!AcceptStake(*pindex, block, state, *pcoinsTip)) {
             return false;
         }
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -27,7 +27,7 @@ struct MainSignalsInstance {
     boost::signals2::signal<void (const CBlockLocator &)> ChainStateFlushed;
     boost::signals2::signal<void (int64_t nBestBlockTime, CConnman* connman)> Broadcast;
     boost::signals2::signal<void (const CBlock&, const CValidationState&)> BlockChecked;
-    boost::signals2::signal<void (const CBlockIndex *, const std::shared_ptr<const CBlock>&)> NewPoWValidBlock;
+    boost::signals2::signal<void (const CBlockIndex *, const std::shared_ptr<const CBlock>&)> NewPoSValidBlock;
     boost::signals2::signal<void (const finalization::VoteRecord &, const finalization::VoteRecord &)> SlashingConditionDetected;
 
     // We are not allowed to assume the scheduler only runs in one thread,
@@ -82,7 +82,7 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.m_internals->ChainStateFlushed.connect(boost::bind(&CValidationInterface::ChainStateFlushed, pwalletIn, _1));
     g_signals.m_internals->Broadcast.connect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1, _2));
     g_signals.m_internals->BlockChecked.connect(boost::bind(&CValidationInterface::BlockChecked, pwalletIn, _1, _2));
-    g_signals.m_internals->NewPoWValidBlock.connect(boost::bind(&CValidationInterface::NewPoWValidBlock, pwalletIn, _1, _2));
+    g_signals.m_internals->NewPoSValidBlock.connect(boost::bind(&CValidationInterface::NewPoSValidBlock, pwalletIn, _1, _2));
     g_signals.m_internals->SlashingConditionDetected.connect(boost::bind(&CValidationInterface::SlashingConditionDetected, pwalletIn, _1, _2));
 }
 
@@ -95,7 +95,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.m_internals->BlockDisconnected.disconnect(boost::bind(&CValidationInterface::BlockDisconnected, pwalletIn, _1));
     g_signals.m_internals->TransactionRemovedFromMempool.disconnect(boost::bind(&CValidationInterface::TransactionRemovedFromMempool, pwalletIn, _1));
     g_signals.m_internals->UpdatedBlockTip.disconnect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
-    g_signals.m_internals->NewPoWValidBlock.disconnect(boost::bind(&CValidationInterface::NewPoWValidBlock, pwalletIn, _1, _2));
+    g_signals.m_internals->NewPoSValidBlock.disconnect(boost::bind(&CValidationInterface::NewPoSValidBlock, pwalletIn, _1, _2));
     g_signals.m_internals->SlashingConditionDetected.connect(boost::bind(&CValidationInterface::SlashingConditionDetected, pwalletIn, _1, _2));
 }
 
@@ -111,7 +111,7 @@ void UnregisterAllValidationInterfaces() {
     g_signals.m_internals->BlockDisconnected.disconnect_all_slots();
     g_signals.m_internals->TransactionRemovedFromMempool.disconnect_all_slots();
     g_signals.m_internals->UpdatedBlockTip.disconnect_all_slots();
-    g_signals.m_internals->NewPoWValidBlock.disconnect_all_slots();
+    g_signals.m_internals->NewPoSValidBlock.disconnect_all_slots();
     g_signals.m_internals->SlashingConditionDetected.disconnect_all_slots();
 }
 
@@ -179,8 +179,8 @@ void CMainSignals::BlockChecked(const CBlock& block, const CValidationState& sta
     m_internals->BlockChecked(block, state);
 }
 
-void CMainSignals::NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock> &block) {
-    m_internals->NewPoWValidBlock(pindex, block);
+void CMainSignals::NewPoSValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock> &block) {
+    m_internals->NewPoSValidBlock(pindex, block);
 }
 
 void CMainSignals::SlashingConditionDetected(const finalization::VoteRecord &vote1, const finalization::VoteRecord &vote2) {

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -148,7 +148,7 @@ protected:
     /**
      * Notifies listeners that a block which builds directly on our current tip
      * has been received and connected to the headers tree, though not validated yet */
-    virtual void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) {};
+    virtual void NewPoSValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) {};
 
     /**
      * Notifies listeners that a slashable event has be detected
@@ -194,7 +194,7 @@ public:
     void ChainStateFlushed(const CBlockLocator &);
     void Broadcast(int64_t nBestBlockTime, CConnman* connman);
     void BlockChecked(const CBlock&, const CValidationState&);
-    void NewPoWValidBlock(const CBlockIndex *, const std::shared_ptr<const CBlock>&);
+    void NewPoSValidBlock(const CBlockIndex *, const std::shared_ptr<const CBlock>&);
     void SlashingConditionDetected(const finalization::VoteRecord &, const finalization::VoteRecord &);
 };
 

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -45,6 +45,7 @@ struct TestChain100Setup : public WalletTestingSetup {
   // a pointer to a bool can be passed in which the result will be stored in.
   CBlock CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns,
                                const CScript& scriptPubKey,
+                               boost::optional<staking::Coin> stake = boost::none,
                                bool *processed = nullptr);
 
   ~TestChain100Setup();

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -38,13 +38,17 @@ struct WalletTestingSetup : public TestingSetup {
 struct TestChain100Setup : public WalletTestingSetup {
   TestChain100Setup(UnitEInjectorConfiguration config = UnitEInjectorConfiguration());
 
-  // Create a new block with just given transactions, coinbase paying to
-  // scriptPubKey, and try to add it to the current chain.
-  //
-  // Asserts that the a new block was successfully created. Alternatively
-  // a pointer to a bool can be passed in which the result will be stored in.
+  //! \brief Create a new block with given transactions
+  std::shared_ptr<const CBlock> CreateBlock(const std::vector<CMutableTransaction>& txns,
+                                            const CScript& coinbase_script,
+                                            boost::optional<staking::Coin> stake = boost::none);
+
+  //! \brief Add given block to the current chain
+  bool ProcessBlock(std::shared_ptr<const CBlock> block);
+
+  //! \brief Create new block and add it to the current chain
   CBlock CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns,
-                               const CScript& scriptPubKey,
+                               const CScript& coinbase_script,
                                boost::optional<staking::Coin> stake = boost::none,
                                bool *processed = nullptr);
 

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -1351,6 +1351,7 @@ class FullBlockTest(UnitETestFramework):
         height = self.block_heights[self.tip.sha256] + 1
         snapshot_hash = self.block_snapshot_meta[self.tip.hashPrevBlock].hash
         coinbase = create_coinbase(height, self.get_staking_coin(), snapshot_hash, self.coinbase_pubkey)
+        coinbase = sign_coinbase(self.nodes[0], coinbase)
         chain1b3 = self.next_block(chain1_tip + 1, self.get_staking_coin())
         chain1b3.vtx[0] = coinbase
         block = self.update_block(chain1_tip + 1, [])


### PR DESCRIPTION
Fixes #903 

High-bandwidth compact block relay can sometimes relay invalid blocks, however PoW check ensures that it is hard to create many of such blocks to cause any issues. After removing PoW we have lost this protection.

This PR introduces new `AcceptStake` function, which performs full stake validation as a part of `AcceptBlock`. At the moment this validation is only performed when new block extends active chain. 
Behaviour in case of fork is unchanged and subject to a separate feature/PR(which I am working on in parallel).

Signed-off-by: Aleksandr Mikhailov <aleksandr@thirdhash.com>