### PR TITLE
Remove unused code

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -403,15 +403,6 @@ bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CBlockIndex* pindex
 /** Check a block is completely valid from start to finish (only works on top of our current best block) */
 bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev, TestBlockValidityFlags::Type flags = TestBlockValidityFlags::NONE) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-/** Check whether NULLDUMMY (BIP 147) has activated. */
-bool IsNullDummyEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& params);
-
-/** When there are blocks in the active chain with missing data, rewind the chainstate and remove them from the block index */
-bool RewindBlockIndex(const CChainParams& params);
-
-/** Update uncommitted block structures (currently: only the witness reserved value). This is safe for submitted blocks. */
-void UpdateUncommittedBlockStructures(CBlock& block, const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams);
-
 /** When there are blocks in the active chain with missing data, rewind the chainstate and remove them from the block index */
 bool RewindBlockIndex(const CChainParams& params);
 


### PR DESCRIPTION
Unused declarations:

- `RewindBlockIndex` is duplicated (see lines 410 and 416)
- `IsNullDummyEnabled` is not used and lacks a definition in `*.cpp`
- same with `UpdateUncommittedBlockStructures`

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
