### PR TITLE
Remove duplicate declaration

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -412,9 +412,6 @@ bool RewindBlockIndex(const CChainParams& params);
 /** Update uncommitted block structures (currently: only the witness reserved value). This is safe for submitted blocks. */
 void UpdateUncommittedBlockStructures(CBlock& block, const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams);
 
-/** When there are blocks in the active chain with missing data, rewind the chainstate and remove them from the block index */
-bool RewindBlockIndex(const CChainParams& params);
-
 /** RAII wrapper for VerifyDB: Verify consistency of the block and coin databases */
 class CVerifyDB {
 public:


### PR DESCRIPTION
The parameter was not used, removed; and changed all invocations accordingly.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
