### PR TITLE
Remove arguments that are not required

### DIFF
--- a/src/blockdb.cpp
+++ b/src/blockdb.cpp
@@ -16,7 +16,7 @@ class BlockDiskStorage final : public BlockDB {
 
   boost::optional<CBlock> ReadBlock(const CBlockIndex &index) override {
     boost::optional<CBlock> block((CBlock()));
-    if (!ReadBlockFromDisk(*block, &index, Params().GetConsensus())) {
+    if (!ReadBlockFromDisk(*block, &index)) {
       return boost::none;
     }
     return block;

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -120,7 +120,7 @@ void BaseIndex::ThreadSync()
             }
 
             CBlock block;
-            if (!ReadBlockFromDisk(block, pindex, consensus_params)) {
+            if (!ReadBlockFromDisk(block, pindex)) {
                 FatalError("%s: Failed to read block %s from disk",
                            __func__, pindex->GetBlockHash().ToString());
                 return;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1178,7 +1178,7 @@ void static ProcessGetBlockData(CNode* pfrom, const CChainParams& chainparams, c
         } else {
             // Send block from disk
             std::shared_ptr<CBlock> pblockRead = std::make_shared<CBlock>();
-            if (!ReadBlockFromDisk(*pblockRead, pindex, consensusParams))
+            if (!ReadBlockFromDisk(*pblockRead, pindex))
                 assert(!"cannot load block from disk");
             pblock = pblockRead;
         }
@@ -2129,7 +2129,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         }
 
         CBlock block;
-        bool ret = ReadBlockFromDisk(block, pindex, chainparams.GetConsensus());
+        bool ret = ReadBlockFromDisk(block, pindex);
         assert(ret);
 
         SendBlockTransactions(block, req, pfrom, connman);
@@ -3549,7 +3549,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, size_t node_index, size_t tot
                     }
                     if (!fGotBlockFromCache) {
                         CBlock block;
-                        bool ret = ReadBlockFromDisk(block, pBestIndex, consensusParams);
+                        bool ret = ReadBlockFromDisk(block, pBestIndex);
                         assert(ret);
                         CBlockHeaderAndShortTxIDs cmpctblock(block);
                         connman->PushMessage(pto, msgMaker.Make(nSendFlags, NetMsgType::CMPCTBLOCK, cmpctblock));

--- a/src/p2p/finalizer_commits_handler_impl.cpp
+++ b/src/p2p/finalizer_commits_handler_impl.cpp
@@ -192,7 +192,7 @@ boost::optional<HeaderAndFinalizerCommits> FinalizerCommitsHandlerImpl::FindHead
   }
 
   CBlock block;
-  if (!ReadBlockFromDisk(block, &index, params)) {
+  if (!ReadBlockFromDisk(block, &index)) {
     assert(not("Cannot load block from the disk"));
   }
 

--- a/src/p2p/graphene_sender.cpp
+++ b/src/p2p/graphene_sender.cpp
@@ -179,7 +179,7 @@ void GrapheneSenderImpl::OnGrapheneTxRequestReceived(CNode &from,
 
     CBlock block;
 
-    if (!ReadBlockFromDisk(block, block_index, Params().GetConsensus())) {
+    if (!ReadBlockFromDisk(block, block_index)) {
       LogPrint(BCLog::NET, "Can not read block %s from disk\n", block_hash.GetHex());
       return;
     }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -220,7 +220,7 @@ static bool rest_block(HTTPRequest* req,
         if (IsBlockPruned(pblockindex))
             return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not available (pruned data)");
 
-        if (!ReadBlockFromDisk(block, pblockindex, Params().GetConsensus()))
+        if (!ReadBlockFromDisk(block, pblockindex))
             return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
     }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -773,7 +773,7 @@ static CBlock GetBlockChecked(const CBlockIndex* pblockindex)
         throw JSONRPCError(RPC_MISC_ERROR, "Block not available (pruned data)");
     }
 
-    if (!ReadBlockFromDisk(block, pblockindex, Params().GetConsensus())) {
+    if (!ReadBlockFromDisk(block, pblockindex)) {
         // Block not found on disk. This could be because we have the block
         // header in our index but don't have the block (for example if a
         // non-whitelisted node sends us an unrequested long chain of valid

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -277,7 +277,7 @@ static UniValue gettxoutproof(const JSONRPCRequest& request)
     }
 
     CBlock block;
-    if(!ReadBlockFromDisk(block, pblockindex, Params().GetConsensus()))
+    if(!ReadBlockFromDisk(block, pblockindex))
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");
 
     unsigned int ntxFound = 0;

--- a/src/snapshot/rpc_processing.cpp
+++ b/src/snapshot/rpc_processing.cpp
@@ -120,7 +120,7 @@ UniValue getblocksnapshot(const JSONRPCRequest &request) {
     }
 
     CBlock block;
-    if (!ReadBlockFromDisk(block, parent, ::Params().GetConsensus())) {
+    if (!ReadBlockFromDisk(block, parent)) {
       root_node.push_back(Pair("error", "can't read block from disk"));
       return root_node;
     }

--- a/src/validation.h
+++ b/src/validation.h
@@ -393,8 +393,8 @@ void InitScriptExecutionCache();
 
 
 /** Functions for disk access for blocks */
-bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus::Params& consensusParams);
-bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
+bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos);
+bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex);
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CDiskBlockPos& pos, const CMessageHeader::MessageStartChars& message_start);
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CBlockIndex* pindex, const CMessageHeader::MessageStartChars& message_start);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2275,7 +2275,7 @@ static UniValue listsinceblock(const JSONRPCRequest& request)
     UniValue removed(UniValue::VARR);
     while (include_removed && paltindex && paltindex != pindex) {
         CBlock block;
-        if (!ReadBlockFromDisk(block, paltindex, Params().GetConsensus())) {
+        if (!ReadBlockFromDisk(block, paltindex)) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");
         }
         for (const CTransactionRef& tx : block.vtx) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2006,7 +2006,7 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
             }
 
             CBlock block;
-            if (ReadBlockFromDisk(block, pindex, Params().GetConsensus())) {
+            if (ReadBlockFromDisk(block, pindex)) {
                 LOCK2(cs_main, cs_wallet);
                 if (pindex && !chainActive.Contains(pindex)) {
                     // Abort scan if current block is no longer active, to prevent

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -175,7 +175,7 @@ bool CZMQPublishRawBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
     {
         LOCK(cs_main);
         CBlock block;
-        if(!ReadBlockFromDisk(block, pindex, consensusParams))
+        if(!ReadBlockFromDisk(block, pindex))
         {
             zmqError("Can't read block from disk");
             return false;


### PR DESCRIPTION
The consensus params parameter on `ReadBlockFromDisk` was not used, removed; and changed all invocations accordingly.

Signed-off-by: Julian Fleischer <julian@thirdhash.com>
