### PR TITLE
Delete old finalization states from disk

### DIFF
--- a/src/finalization/state_db.h
+++ b/src/finalization/state_db.h
@@ -47,6 +47,8 @@ class StateDB {
   virtual bool Load(const CBlockIndex &index,
                     std::map<const CBlockIndex *, FinalizationState> *states) const = 0;
 
+  virtual bool Erase(const CBlockIndex &index) = 0;
+
   //! \brief Returns last finalized epoch accoring to active chain's tip.
   virtual boost::optional<uint32_t> FindLastFinalizedEpoch() const = 0;
 

--- a/src/finalization/state_repository.cpp
+++ b/src/finalization/state_repository.cpp
@@ -129,6 +129,7 @@ void RepositoryImpl::TrimUntilHeight(blockchain::Height height) {
       assert(index != nullptr);
     }
     if (static_cast<blockchain::Height>(index->nHeight) < height) {
+      m_state_db->Erase(*it->first);
       it = m_states.erase(it);
     } else {
       ++it;

--- a/src/test/esperanza/finalizationstate_utils.cpp
+++ b/src/test/esperanza/finalizationstate_utils.cpp
@@ -26,6 +26,11 @@ T Rand() {
   return static_cast<T>(GetRand(std::numeric_limits<T>::max()));
 }
 
+template <>
+bool Rand<bool>() {
+  return static_cast<bool>(GetRand(2));
+}
+
 #define ConstRand(N) [] { static size_t r = GetRand(N); return r; }()
 
 void FinalizationStateSpy::shuffle() {

--- a/src/test/test_unite_mocks.h
+++ b/src/test/test_unite_mocks.h
@@ -300,9 +300,9 @@ class StateDBMock : public finalization::StateDB, public Mock {
   MethodMock<decltype(&finalization::StateDB::Save)> mock_Save{this, false};
   MethodMock<bool (finalization::StateDB::*)(std::map<const CBlockIndex *, FinalizationState> *)> mock_Load{this, false};
   MethodMock<bool (finalization::StateDB::*)(const CBlockIndex &, std::map<const CBlockIndex *, FinalizationState> *)> mock_LoadParticular{this, false};
+  MethodMock<decltype(&finalization::StateDB::Erase)> mock_Erase{this, false};
   MethodMock<decltype(&finalization::StateDB::FindLastFinalizedEpoch)> mock_FindLastFinalizedEpoch{this, boost::none};
   MethodMock<decltype(&finalization::StateDB::LoadStatesHigherThan)> mock_LoadStatesHigherThan{this};
-
   bool Save(const std::map<const CBlockIndex *, FinalizationState> &states) override {
     return mock_Save(states);
   }
@@ -312,6 +312,9 @@ class StateDBMock : public finalization::StateDB, public Mock {
   bool Load(const CBlockIndex &index,
             std::map<const CBlockIndex *, FinalizationState> *states) const override {
     return mock_LoadParticular(index, states);
+  }
+  bool Erase(const CBlockIndex &index) override {
+    return mock_Erase(index);
   }
   boost::optional<uint32_t> FindLastFinalizedEpoch() const override {
     return mock_FindLastFinalizedEpoch();


### PR DESCRIPTION
We've noticed that finalization state storage aggressively consumes disk space that leads
to the out-of-disk condition. This commit fixes that by deleting old states from disk the
same way as we trim repository in memory.

Besides that:
* Fix `Rand<bool>` from finalizationstate_utils.cpp;
* For DBWrapper, use composition instead of inheritance in StateDBImpl.
