### PR TITLE
Fix lint-include-guards.sh issues

### DIFF
--- a/src/better-enums/enum_set.h
+++ b/src/better-enums/enum_set.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_ENUM_SET_H
-#define UNIT_E_ENUM_SET_H
+#ifndef UNITE_ENUM_SET_H
+#define UNITE_ENUM_SET_H
 
 #include <array>
 #include <sstream>
@@ -234,4 +234,4 @@ class EnumSet {
   }
 };
 
-#endif  //UNIT_E_ENUM_SET_H
+#endif  // UNITE_ENUM_SET_H

--- a/src/blockchain/blockchain_behavior.h
+++ b/src/blockchain/blockchain_behavior.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_BLOCKCHAIN_BEHAVIOR_H
-#define UNIT_E_BLOCKCHAIN_BEHAVIOR_H
+#ifndef UNITE_BLOCKCHAIN_BLOCKCHAIN_BEHAVIOR_H
+#define UNITE_BLOCKCHAIN_BLOCKCHAIN_BEHAVIOR_H
 
 #include <blockchain/blockchain_parameters.h>
 
@@ -110,4 +110,4 @@ class Behavior {
 
 }  // namespace blockchain
 
-#endif  //UNIT_E_BLOCKCHAIN_BEHAVIOR_H
+#endif  // UNITE_BLOCKCHAIN_BLOCKCHAIN_BEHAVIOR_H

--- a/src/blockchain/blockchain_custom_parameters.h
+++ b/src/blockchain/blockchain_custom_parameters.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_BLOCKCHAIN_CUSTOM_PARAMETERS_H
-#define UNIT_E_BLOCKCHAIN_CUSTOM_PARAMETERS_H
+#ifndef UNITE_BLOCKCHAIN_BLOCKCHAIN_CUSTOM_PARAMETERS_H
+#define UNITE_BLOCKCHAIN_BLOCKCHAIN_CUSTOM_PARAMETERS_H
 
 #include <blockchain/blockchain_parameters.h>
 
@@ -40,4 +40,4 @@ blockchain::Parameters ReadCustomParametersFromFile(
 
 }  // namespace blockchain
 
-#endif  //UNIT_E_BLOCKCHAIN_CUSTOM_PARAMETERS_H
+#endif  // UNITE_BLOCKCHAIN_BLOCKCHAIN_CUSTOM_PARAMETERS_H

--- a/src/blockchain/blockchain_genesis.h
+++ b/src/blockchain/blockchain_genesis.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_BLOCKCHAIN_GENESIS_H
-#define UNIT_E_BLOCKCHAIN_GENESIS_H
+#ifndef UNITE_BLOCKCHAIN_BLOCKCHAIN_GENESIS_H
+#define UNITE_BLOCKCHAIN_BLOCKCHAIN_GENESIS_H
 
 #include <amount.h>
 #include <blockchain/blockchain_parameters.h>
@@ -76,4 +76,4 @@ class GenesisBlockBuilder {
 
 }  // namespace blockchain
 
-#endif  //UNIT_E_BLOCKCHAIN_GENESIS_H
+#endif  // UNITE_BLOCKCHAIN_BLOCKCHAIN_GENESIS_H

--- a/src/blockchain/blockchain_interfaces.h
+++ b/src/blockchain/blockchain_interfaces.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_BLOCKCHAIN_INTERFACES_H
-#define UNIT_E_BLOCKCHAIN_INTERFACES_H
+#ifndef UNITE_BLOCKCHAIN_BLOCKCHAIN_INTERFACES_H
+#define UNITE_BLOCKCHAIN_BLOCKCHAIN_INTERFACES_H
 
 #include <blockchain/blockchain_types.h>
 #include <chain.h>
@@ -49,4 +49,4 @@ class UTXOView {
 
 }  // namespace blockchain
 
-#endif  //UNIT_E_BLOCKCHAIN_INTERFACES_H
+#endif  // UNITE_BLOCKCHAIN_BLOCKCHAIN_INTERFACES_H

--- a/src/blockchain/blockchain_parameters.h
+++ b/src/blockchain/blockchain_parameters.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_BLOCKCHAIN_PARAMETERS_H
-#define UNIT_E_BLOCKCHAIN_PARAMETERS_H
+#ifndef UNITE_BLOCKCHAIN_BLOCKCHAIN_PARAMETERS_H
+#define UNITE_BLOCKCHAIN_BLOCKCHAIN_PARAMETERS_H
 
 #include <amount.h>
 #include <blockchain/blockchain_interfaces.h>
@@ -257,4 +257,4 @@ struct Parameters {
 
 }  // namespace blockchain
 
-#endif  //UNIT_E_BLOCKCHAIN_PARAMETERS_H
+#endif  // UNITE_BLOCKCHAIN_BLOCKCHAIN_PARAMETERS_H

--- a/src/blockchain/blockchain_rpc.h
+++ b/src/blockchain/blockchain_rpc.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_BLOCKCHAIN_RPC_H
-#define UNIT_E_BLOCKCHAIN_RPC_H
+#ifndef UNITE_BLOCKCHAIN_BLOCKCHAIN_RPC_H
+#define UNITE_BLOCKCHAIN_BLOCKCHAIN_RPC_H
 
 #include <blockchain/blockchain_behavior.h>
 #include <dependency.h>
@@ -27,4 +27,4 @@ class BlockchainRPC {
 
 }  // namespace blockchain
 
-#endif  //UNIT_E_BLOCKCHAIN_RPC_H
+#endif  // UNITE_BLOCKCHAIN_BLOCKCHAIN_RPC_H

--- a/src/blockchain/blockchain_types.h
+++ b/src/blockchain/blockchain_types.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_BLOCKCHAIN_TYPES_H
-#define UNIT_E_BLOCKCHAIN_TYPES_H
+#ifndef UNITE_BLOCKCHAIN_BLOCKCHAIN_TYPES_H
+#define UNITE_BLOCKCHAIN_BLOCKCHAIN_TYPES_H
 
 #include <amount.h>
 
@@ -45,4 +45,4 @@ BETTER_ENUM(
 
 }  // namespace blockchain
 
-#endif  //UNIT_E_BLOCKCHAIN_TYPES_H
+#endif  // UNITE_BLOCKCHAIN_BLOCKCHAIN_TYPES_H

--- a/src/blockchain/regtest_funds.cpp
+++ b/src/blockchain/regtest_funds.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/MIT.
 
-#ifndef UNIT_E_BLOCKCHAIN_REGTEST_FUNDS_H
-#define UNIT_E_BLOCKCHAIN_REGTEST_FUNDS_H
+#ifndef UNITE_BLOCKCHAIN_REGTEST_FUNDS_H
+#define UNITE_BLOCKCHAIN_REGTEST_FUNDS_H
 
 #include <blockchain/blockchain_genesis.h>
 

--- a/src/blockchain/testnet_funds.cpp
+++ b/src/blockchain/testnet_funds.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/MIT.
 
-#ifndef UNIT_E_BLOCKCHAIN_TESTNET_FUNDS_H
-#define UNIT_E_BLOCKCHAIN_TESTNET_FUNDS_H
+#ifndef UNITE_BLOCKCHAIN_TESTNET_FUNDS_H
+#define UNITE_BLOCKCHAIN_TESTNET_FUNDS_H
 
 #include <blockchain/blockchain_genesis.h>
 

--- a/src/blockdb.h
+++ b/src/blockdb.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_BLOCKDB_H
-#define UNIT_E_BLOCKDB_H
+#ifndef UNITE_BLOCKDB_H
+#define UNITE_BLOCKDB_H
 
 #include <chain.h>
 #include <primitives/block.h>
@@ -28,4 +28,4 @@ class BlockDB {
   static std::unique_ptr<BlockDB> New();
 };
 
-#endif  //UNIT_E_BLOCKDB_H
+#endif  // UNITE_BLOCKDB_H

--- a/src/consensus/ltor.h
+++ b/src/consensus/ltor.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNITE_LTOR_H
-#define UNITE_LTOR_H
+#ifndef UNITE_CONSENSUS_LTOR_H
+#define UNITE_CONSENSUS_LTOR_H
 
 #include <vector>
 #include <primitives/transaction.h>
@@ -14,4 +14,4 @@ void SortTransactions(std::vector<CTransactionRef>& transactions);
 
 }
 
-#endif //UNITE_LTOR_H
+#endif  // UNITE_CONSENSUS_LTOR_H

--- a/src/dependency.h
+++ b/src/dependency.h
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_DEPENDENCY_H
-#define UNIT_E_DEPENDENCY_H
+#ifndef UNITE_DEPENDENCY_H
+#define UNITE_DEPENDENCY_H
 
 template <typename T>
 using Dependency = T *;
 
-#endif  //UNIT_E_DEPENDENCY_H
+#endif  // UNITE_DEPENDENCY_H

--- a/src/dependency_injector.h
+++ b/src/dependency_injector.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_DEPENDENCY_INJECTOR_H
-#define UNIT_E_DEPENDENCY_INJECTOR_H
+#ifndef UNITE_DEPENDENCY_INJECTOR_H
+#define UNITE_DEPENDENCY_INJECTOR_H
 
 #include <dependency.h>
 
@@ -454,4 +454,4 @@ class Injector {
   };
 };
 
-#endif  // UNIT_E_DEPENDENCY_INJECTOR_H
+#endif  // UNITE_DEPENDENCY_INJECTOR_H

--- a/src/esperanza/init.h
+++ b/src/esperanza/init.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNITE_ESPERANZA_WALLETEXT_INIT_H
-#define UNITE_ESPERANZA_WALLETEXT_INIT_H
+#ifndef UNITE_ESPERANZA_INIT_H
+#define UNITE_ESPERANZA_INIT_H
 
 #include <string>
 
@@ -15,4 +15,4 @@ void AddOptions(ArgsManager &args);
 
 }  // namespace esperanza
 
-#endif  // UNITE_ESPERANZA_WALLETEXT_INIT_H
+#endif  // UNITE_ESPERANZA_INIT_H

--- a/src/esperanza/script.h
+++ b/src/esperanza/script.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef ESPERANZA_SCRIPT_H
-#define ESPERANZA_SCRIPT_H
+#ifndef UNITE_ESPERANZA_SCRIPT_H
+#define UNITE_ESPERANZA_SCRIPT_H
 
 class CTransaction;
 class uint160;
@@ -30,4 +30,4 @@ bool ExtractValidatorPubkey(const CTransaction &tx,
                             CPubKey &pubkeyOut);
 }  // namespace esperanza
 
-#endif
+#endif  // UNITE_ESPERANZA_SCRIPT_H

--- a/src/esperanza/walletextension_deps.h
+++ b/src/esperanza/walletextension_deps.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_ESPERANZA_WALLETEXTENSION_DEPS_H
-#define UNIT_E_ESPERANZA_WALLETEXTENSION_DEPS_H
+#ifndef UNITE_ESPERANZA_WALLETEXTENSION_DEPS_H
+#define UNITE_ESPERANZA_WALLETEXTENSION_DEPS_H
 
 #include <dependency.h>
 #include <finalization/state_repository.h>
@@ -79,4 +79,4 @@ class WalletExtensionDeps {
 
 }  // namespace esperanza
 
-#endif  //UNIT_E_WALLETEXTENSION_DEPS_H
+#endif  // UNITE_WALLETEXTENSION_DEPS_H

--- a/src/finalization/state_db.h
+++ b/src/finalization/state_db.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef FINALIZATION_STATE_DB_H
-#define FINALIZATION_STATE_DB_H
+#ifndef UNITE_FINALIZATION_STATE_DB_H
+#define UNITE_FINALIZATION_STATE_DB_H
 
 #include <blockchain/blockchain_types.h>
 #include <dependency.h>
@@ -79,4 +79,4 @@ class StateDB {
 
 }  // namespace finalization
 
-#endif
+#endif  // UNITE_FINALIZATION_STATE_DB_H

--- a/src/finalization/state_processor.h
+++ b/src/finalization/state_processor.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNITE_FINALIZATION_STATE_PROCESSOR
-#define UNITE_FINALIZATION_STATE_PROCESSOR
+#ifndef UNITE_FINALIZATION_STATE_PROCESSOR_H
+#define UNITE_FINALIZATION_STATE_PROCESSOR_H
 
 #include <dependency.h>
 #include <primitives/transaction.h>
@@ -86,4 +86,4 @@ class StateProcessor {
 
 }  // namespace finalization
 
-#endif
+#endif  // UNITE_FINALIZATION_STATE_PROCESSOR_H

--- a/src/finalization/state_repository.h
+++ b/src/finalization/state_repository.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNITE_FINALIZATION_STATE_REPOSITORY
-#define UNITE_FINALIZATION_STATE_REPOSITORY
+#ifndef UNITE_FINALIZATION_STATE_REPOSITORY_H
+#define UNITE_FINALIZATION_STATE_REPOSITORY_H
 
 #include <chain.h>
 #include <dependency.h>
@@ -107,4 +107,4 @@ class StateRepository {
 
 }  // namespace finalization
 
-#endif
+#endif  // UNITE_FINALIZATION_STATE_REPOSITORY_H

--- a/src/finalization/vote_recorder.h
+++ b/src/finalization/vote_recorder.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_FINALIZATION_VOTE_RECORDER_H
-#define UNIT_E_FINALIZATION_VOTE_RECORDER_H
+#ifndef UNITE_FINALIZATION_VOTE_RECORDER_H
+#define UNITE_FINALIZATION_VOTE_RECORDER_H
 
 #include <dbwrapper.h>
 #include <esperanza/vote.h>
@@ -99,4 +99,4 @@ bool RecordVote(const CTransaction &tx,
 
 }  // namespace finalization
 
-#endif  // UNIT_E_FINALIZATION_VOTE_RECORDER_H
+#endif  // UNITE_FINALIZATION_VOTE_RECORDER_H

--- a/src/injector.h
+++ b/src/injector.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_INJECTOR_H
-#define UNIT_E_INJECTOR_H
+#ifndef UNITE_INJECTOR_H
+#define UNITE_INJECTOR_H
 
 #include <dependency_injector.h>
 
@@ -189,4 +189,4 @@ Dependency<T> GetComponent() {
   return GetInjector().Get<T>();
 }
 
-#endif  // UNIT_E_INJECTOR_H
+#endif  // UNITE_INJECTOR_H

--- a/src/injector_config.h
+++ b/src/injector_config.h
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_INJECTOR_CONFIG_H
-#define UNIT_E_INJECTOR_CONFIG_H
+#ifndef UNITE_INJECTOR_CONFIG_H
+#define UNITE_INJECTOR_CONFIG_H
 
 struct UnitEInjectorConfiguration {
   bool use_in_memory_databases = false;
   bool disable_finalization = false;
 };
 
-#endif //UNIT_E_INJECTOR_CONFIG_H
+#endif // UNITE_INJECTOR_CONFIG_H

--- a/src/proposer/block_builder.h
+++ b/src/proposer/block_builder.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_PROPOSER_BLOCK_BUILDER_H
-#define UNIT_E_PROPOSER_BLOCK_BUILDER_H
+#ifndef UNITE_PROPOSER_BLOCK_BUILDER_H
+#define UNITE_PROPOSER_BLOCK_BUILDER_H
 
 #include <blockchain/blockchain_behavior.h>
 #include <dependency.h>
@@ -51,4 +51,4 @@ class BlockBuilder {
 
 }  // namespace proposer
 
-#endif  //UNIT_E_BLOCK_BUILDER_H
+#endif  // UNITE_BLOCK_BUILDER_H

--- a/src/proposer/eligible_coin.h
+++ b/src/proposer/eligible_coin.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_PROPOSER_ELIGIBLE_COIN_H
-#define UNIT_E_PROPOSER_ELIGIBLE_COIN_H
+#ifndef UNITE_PROPOSER_ELIGIBLE_COIN_H
+#define UNITE_PROPOSER_ELIGIBLE_COIN_H
 
 #include <amount.h>
 #include <blockchain/blockchain_types.h>
@@ -43,4 +43,4 @@ struct EligibleCoin {
 
 }  // namespace proposer
 
-#endif  //UNIT_E_PROPOSER_ELIGIBLE_COIN_H
+#endif  // UNITE_PROPOSER_ELIGIBLE_COIN_H

--- a/src/proposer/multiwallet.h
+++ b/src/proposer/multiwallet.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_PROPOSER_MULTIWALLET_H
-#define UNIT_E_PROPOSER_MULTIWALLET_H
+#ifndef UNITE_PROPOSER_MULTIWALLET_H
+#define UNITE_PROPOSER_MULTIWALLET_H
 
 #include <memory>
 #include <vector>
@@ -24,4 +24,4 @@ class MultiWallet {
 
 }  // namespace proposer
 
-#endif  // UNIT_E_PROPOSER_MULTIWALLET_H
+#endif  // UNITE_PROPOSER_MULTIWALLET_H

--- a/src/proposer/proposer_logic.h
+++ b/src/proposer/proposer_logic.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_PROPOSER_LOGIC_H
-#define UNIT_E_PROPOSER_LOGIC_H
+#ifndef UNITE_PROPOSER_PROPOSER_LOGIC_H
+#define UNITE_PROPOSER_PROPOSER_LOGIC_H
 
 #include <amount.h>
 #include <blockchain/blockchain_types.h>
@@ -43,4 +43,4 @@ class Logic {
 
 }  // namespace proposer
 
-#endif  //UNIT_E_PROPOSER_LOGIC_H
+#endif  // UNITE_PROPOSER_PROPOSER_LOGIC_H

--- a/src/proposer/proposer_rpc.h
+++ b/src/proposer/proposer_rpc.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_PROPOSER_RPC_H
-#define UNIT_E_PROPOSER_RPC_H
+#ifndef UNITE_PROPOSER_PROPOSER_RPC_H
+#define UNITE_PROPOSER_PROPOSER_RPC_H
 
 #include <dependency.h>
 #include <settings.h>
@@ -57,4 +57,4 @@ class ProposerRPC {
 
 }  // namespace proposer
 
-#endif  //UNIT_E_PROPOSER_RPC_H
+#endif  // UNITE_PROPOSER_PROPOSER_RPC_H

--- a/src/proposer/proposer_state.h
+++ b/src/proposer/proposer_state.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_PROPOSER_PROPOSER_STATE_H
-#define UNIT_E_PROPOSER_PROPOSER_STATE_H
+#ifndef UNITE_PROPOSER_PROPOSER_STATE_H
+#define UNITE_PROPOSER_PROPOSER_STATE_H
 
 #include <proposer/proposer_status.h>
 
@@ -31,4 +31,4 @@ struct State {
 
 }  // namespace proposer
 
-#endif  // UNIT_E_PROPOSER_STATE_H
+#endif  // UNITE_PROPOSER_STATE_H

--- a/src/proposer/proposer_status.h
+++ b/src/proposer/proposer_status.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_PROPOSER_PROPOSER_STATUS_H
-#define UNIT_E_PROPOSER_PROPOSER_STATUS_H
+#ifndef UNITE_PROPOSER_PROPOSER_STATUS_H
+#define UNITE_PROPOSER_PROPOSER_STATUS_H
 
 #include <better-enums/enum.h>
 
@@ -24,4 +24,4 @@ BETTER_ENUM(
 
 }  // namespace proposer
 
-#endif  // UNIT_E_PROPOSER_STATUS_H
+#endif  // UNITE_PROPOSER_STATUS_H

--- a/src/proposer/sync.h
+++ b/src/proposer/sync.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_PROPOSER_SYNC_H
-#define UNIT_E_PROPOSER_SYNC_H
+#ifndef UNITE_PROPOSER_SYNC_H
+#define UNITE_PROPOSER_SYNC_H
 
 #include <stdint.h>
 #include <condition_variable>
@@ -68,4 +68,4 @@ class CountingSemaphore {
 
 }  // namespace proposer
 
-#endif  // UNIT_E_SYNC_H
+#endif  // UNITE_SYNC_H

--- a/src/proposer/waiter.h
+++ b/src/proposer/waiter.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_PROPOSER_WAITER_H
-#define UNIT_E_PROPOSER_WAITER_H
+#ifndef UNITE_PROPOSER_WAITER_H
+#define UNITE_PROPOSER_WAITER_H
 
 #include <atomic>
 #include <chrono>
@@ -30,4 +30,4 @@ class Waiter {
 
 }  // namespace proposer
 
-#endif  // UNIT_E_PROPOSER_WAITER_H
+#endif  // UNITE_PROPOSER_WAITER_H

--- a/src/rpc/finalization.h
+++ b/src/rpc/finalization.h
@@ -4,11 +4,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 
-#ifndef UNITE_RPC_ESPERANZA_H
-#define UNITE_RPC_ESPERANZA_H
+#ifndef UNITE_RPC_FINALIZATION_H
+#define UNITE_RPC_FINALIZATION_H
 
 class CRPCTable;
 
 void RegisterFinalizationRPCCommands(CRPCTable &t);
 
-#endif // UNITE_RPC_ESPERANZA_H
+#endif // UNITE_RPC_FINALIZATION_H

--- a/src/rpc/parameter_conversion.h
+++ b/src/rpc/parameter_conversion.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNITE_RPC_CLIENT_H
-#define UNITE_RPC_CLIENT_H
+#ifndef UNITE_RPC_PARAMETER_CONVERSION_H
+#define UNITE_RPC_PARAMETER_CONVERSION_H
 
 #include <univalue.h>
 
@@ -19,4 +19,4 @@ UniValue RPCConvertNamedValues(const std::string& strMethod, const std::vector<s
  */
 UniValue ParseNonRFCJSONValue(const std::string& strVal);
 
-#endif // UNITE_RPC_CLIENT_H
+#endif // UNITE_RPC_PARAMETER_CONVERSION_H

--- a/src/rpc/proposing.h
+++ b/src/rpc/proposing.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_RPC_PROPOSING_H
-#define UNIT_E_RPC_PROPOSING_H
+#ifndef UNITE_RPC_PROPOSING_H
+#define UNITE_RPC_PROPOSING_H
 
 #include <proposer/proposer_rpc.h>
 
@@ -11,4 +11,4 @@ class CRPCTable;
 
 void RegisterProposerRPCCommands(CRPCTable &t);
 
-#endif  // UNIT_E_RPC_PROPOSING_H
+#endif  // UNITE_RPC_PROPOSING_H

--- a/src/rpc/staking.h
+++ b/src/rpc/staking.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_RPC_STAKING_H
-#define UNIT_E_RPC_STAKING_H
+#ifndef UNITE_RPC_STAKING_H
+#define UNITE_RPC_STAKING_H
 
 #include <staking/staking_rpc.h>
 
@@ -11,4 +11,4 @@ class CRPCTable;
 
 void RegisterStakingRPCCommands(CRPCTable &t);
 
-#endif  // UNIT_E_RPC_STAKING_H
+#endif  // UNITE_RPC_STAKING_H

--- a/src/settings.h
+++ b/src/settings.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_SETTINGS_H
-#define UNIT_E_SETTINGS_H
+#ifndef UNITE_SETTINGS_H
+#define UNITE_SETTINGS_H
 
 #include <amount.h>
 #include <dependency.h>
@@ -71,4 +71,4 @@ struct Settings {
       Dependency<blockchain::Behavior>);
 };
 
-#endif  // UNIT_E_SETTINGS_H
+#endif  // UNITE_SETTINGS_H

--- a/src/snapshot/chainstate_iterator.h
+++ b/src/snapshot/chainstate_iterator.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNITE_CHAINSTATE_ITERATOR_H
-#define UNITE_CHAINSTATE_ITERATOR_H
+#ifndef UNITE_SNAPSHOT_CHAINSTATE_ITERATOR_H
+#define UNITE_SNAPSHOT_CHAINSTATE_ITERATOR_H
 
 #include <stdint.h>
 #include <map>
@@ -38,4 +38,4 @@ class ChainstateIterator {
 
 }  // namespace snapshot
 
-#endif  // UNITE_CHAINSTATE_ITERATOR_H
+#endif  // UNITE_SNAPSHOT_CHAINSTATE_ITERATOR_H

--- a/src/snapshot/params.h
+++ b/src/snapshot/params.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_SNAPSHOT_PARAMS_H
-#define UNIT_E_SNAPSHOT_PARAMS_H
+#ifndef UNITE_SNAPSHOT_PARAMS_H
+#define UNITE_SNAPSHOT_PARAMS_H
 
 #include <cstdint>
 
@@ -24,4 +24,4 @@ struct Params {
 
 }  // namespace snapshot
 
-#endif  //UNIT_E_SNAPSHOT_PARAMS_H
+#endif  // UNITE_SNAPSHOT_PARAMS_H

--- a/src/snapshot/rpc_processing.h
+++ b/src/snapshot/rpc_processing.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_SNAPSHOT_RPC_PROCESSING_H
-#define UNIT_E_SNAPSHOT_RPC_PROCESSING_H
+#ifndef UNITE_SNAPSHOT_RPC_PROCESSING_H
+#define UNITE_SNAPSHOT_RPC_PROCESSING_H
 
 class CRPCTable;
 
@@ -13,4 +13,4 @@ void RegisterRPCCommands(CRPCTable &t);
 
 }  // namespace snapshot
 
-#endif  //UNIT_E_SNAPSHOT_RPC_PROCESSING_H
+#endif  // UNITE_SNAPSHOT_RPC_PROCESSING_H

--- a/src/snapshot/snapshot_index.h
+++ b/src/snapshot/snapshot_index.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_CURRENT_SNAPSHOTS_H
-#define UNIT_E_CURRENT_SNAPSHOTS_H
+#ifndef UNITE_SNAPSHOT_SNAPSHOT_INDEX_H
+#define UNITE_SNAPSHOT_SNAPSHOT_INDEX_H
 
 #include <chain.h>
 #include <serialize.h>
@@ -188,4 +188,4 @@ void FinalizeSnapshots(const CBlockIndex *block_index);
 
 }  // namespace snapshot
 
-#endif  //UNIT_E_CURRENT_SNAPSHOTS_H
+#endif  // UNITE_SNAPSHOT_SNAPSHOT_INDEX_H

--- a/src/snapshot/snapshot_validation.h
+++ b/src/snapshot/snapshot_validation.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_SNAPSHOT_VALIDATION_H
-#define UNIT_E_SNAPSHOT_VALIDATION_H
+#ifndef UNITE_SNAPSHOT_SNAPSHOT_VALIDATION_H
+#define UNITE_SNAPSHOT_SNAPSHOT_VALIDATION_H
 
 #include <chain.h>
 #include <primitives/transaction.h>
@@ -26,4 +26,4 @@ bool ReadSnapshotHashFromTx(const CTransaction &tx,
 
 }  // namespace snapshot
 
-#endif  // UNIT_E_SNAPSHOT_VALIDATION_H
+#endif  // UNITE_SNAPSHOT_SNAPSHOT_VALIDATION_H

--- a/src/staking/active_chain.h
+++ b/src/staking/active_chain.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_STAKING_ACTIVE_CHAIN_H
-#define UNIT_E_STAKING_ACTIVE_CHAIN_H
+#ifndef UNITE_STAKING_ACTIVE_CHAIN_H
+#define UNITE_STAKING_ACTIVE_CHAIN_H
 
 #include <blockchain/blockchain_behavior.h>
 #include <blockchain/blockchain_interfaces.h>
@@ -141,4 +141,4 @@ class ActiveChain : public blockchain::ChainAccess, public blockchain::UTXOView 
 
 }  // namespace staking
 
-#endif  // UNIT_E_STAKING_ACTIVE_CHAIN_H
+#endif  // UNITE_STAKING_ACTIVE_CHAIN_H

--- a/src/staking/block_index_map.h
+++ b/src/staking/block_index_map.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNITE_STAKING_BLOCK_INDEX_MAP
-#define UNITE_STAKING_BLOCK_INDEX_MAP
+#ifndef UNITE_STAKING_BLOCK_INDEX_MAP_H
+#define UNITE_STAKING_BLOCK_INDEX_MAP_H
 
 #include <sync.h>
 #include <functional>
@@ -34,4 +34,4 @@ class BlockIndexMap {
 
 }  // namespace staking
 
-#endif
+#endif  // UNITE_STAKING_BLOCK_INDEX_MAP_H

--- a/src/staking/block_reward_validator.h
+++ b/src/staking/block_reward_validator.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/MIT.
 
-#ifndef UNIT_E_STAKING_BLOCK_REWARD_VALIDATOR_H
-#define UNIT_E_STAKING_BLOCK_REWARD_VALIDATOR_H
+#ifndef UNITE_STAKING_BLOCK_REWARD_VALIDATOR_H
+#define UNITE_STAKING_BLOCK_REWARD_VALIDATOR_H
 
 #include <amount.h>
 #include <blockchain/blockchain_behavior.h>
@@ -34,4 +34,4 @@ class BlockRewardValidator {
 
 }  // namespace staking
 
-#endif  //UNIT_E_STAKING_BLOCK_REWARD_VALIDATOR_H
+#endif  // UNITE_STAKING_BLOCK_REWARD_VALIDATOR_H

--- a/src/staking/block_validation_info.h
+++ b/src/staking/block_validation_info.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/MIT.
 
-#ifndef UNIT_E_STAKING_BLOCK_INFO_H
-#define UNIT_E_STAKING_BLOCK_INFO_H
+#ifndef UNITE_STAKING_BLOCK_VALIDATION_INFO_H
+#define UNITE_STAKING_BLOCK_VALIDATION_INFO_H
 
 #include <trit.h>
 
@@ -178,4 +178,4 @@ class BlockValidationInfo {
 
 }  // namespace staking
 
-#endif  //UNIT_E_STAKING_BLOCK_INFO_H
+#endif  // UNITE_STAKING_BLOCK_VALIDATION_INFO_H

--- a/src/staking/block_validator.h
+++ b/src/staking/block_validator.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_STAKING_BLOCK_VALIDATOR_H
-#define UNIT_E_STAKING_BLOCK_VALIDATOR_H
+#ifndef UNITE_STAKING_BLOCK_VALIDATOR_H
+#define UNITE_STAKING_BLOCK_VALIDATOR_H
 
 #include <better-enums/enum.h>
 #include <better-enums/enum_set.h>
@@ -174,4 +174,4 @@ class AbstractBlockValidator : public BlockValidator {
 
 }  // namespace staking
 
-#endif  //UNIT_E_STAKE_VALIDATOR_H
+#endif  // UNITE_STAKE_VALIDATOR_H

--- a/src/staking/coin.h
+++ b/src/staking/coin.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_STAKING_COIN_H
-#define UNIT_E_STAKING_COIN_H
+#ifndef UNITE_STAKING_COIN_H
+#define UNITE_STAKING_COIN_H
 
 #include <amount.h>
 #include <blockchain/blockchain_types.h>
@@ -119,4 +119,4 @@ using CoinSet = std::set<Coin, CoinByAmountComparator>;
 
 }  // namespace staking
 
-#endif  //UNIT_E_STAKING_COIN_H
+#endif  // UNITE_STAKING_COIN_H

--- a/src/staking/legacy_validation_interface.h
+++ b/src/staking/legacy_validation_interface.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_LEGACY_VALIDATION_INTERFACE_H
-#define UNIT_E_LEGACY_VALIDATION_INTERFACE_H
+#ifndef UNITE_STAKING_LEGACY_VALIDATION_INTERFACE_H
+#define UNITE_STAKING_LEGACY_VALIDATION_INTERFACE_H
 
 #include <dependency.h>
 
@@ -106,4 +106,4 @@ class LegacyValidationInterface {
 
 }  // namespace staking
 
-#endif  //UNIT_E_LEGACY_VALIDATION_INTERFACE_H
+#endif  // UNITE_STAKING_LEGACY_VALIDATION_INTERFACE_H

--- a/src/staking/network.h
+++ b/src/staking/network.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_STAKING_NETWORK_H
-#define UNIT_E_STAKING_NETWORK_H
+#ifndef UNITE_STAKING_NETWORK_H
+#define UNITE_STAKING_NETWORK_H
 
 #include <stdint.h>
 
@@ -35,4 +35,4 @@ class Network {
 
 }  // namespace staking
 
-#endif  // UNIT_E_STAKING_NETWORK_H
+#endif  // UNITE_STAKING_NETWORK_H

--- a/src/staking/proof_of_stake.h
+++ b/src/staking/proof_of_stake.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_STAKING_PROOF_OF_STAKE_H
-#define UNIT_E_STAKING_PROOF_OF_STAKE_H
+#ifndef UNITE_STAKING_PROOF_OF_STAKE_H
+#define UNITE_STAKING_PROOF_OF_STAKE_H
 
 #include <blockchain/blockchain_types.h>
 #include <primitives/block.h>
@@ -87,4 +87,4 @@ uint256 ComputeStakeModifier(const uint256 &stake_transaction_hash,
 
 }  // namespace staking
 
-#endif  //UNIT_E_STAKING_PROOF_OF_STAKE_H
+#endif  // UNITE_STAKING_PROOF_OF_STAKE_H

--- a/src/staking/stake_validator.h
+++ b/src/staking/stake_validator.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_STAKING_STAKE_VALIDATOR_H
-#define UNIT_E_STAKING_STAKE_VALIDATOR_H
+#ifndef UNITE_STAKING_STAKE_VALIDATOR_H
+#define UNITE_STAKING_STAKE_VALIDATOR_H
 
 #include <amount.h>
 #include <blockchain/blockchain_behavior.h>
@@ -128,4 +128,4 @@ class StakeValidator {
 
 }  // namespace staking
 
-#endif  //UNIT_E_STAKING_STAKE_VALIDATOR_H
+#endif  // UNITE_STAKING_STAKE_VALIDATOR_H

--- a/src/staking/staking_rpc.h
+++ b/src/staking/staking_rpc.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_STAKING_RPC_H
-#define UNIT_E_STAKING_RPC_H
+#ifndef UNITE_STAKING_STAKING_RPC_H
+#define UNITE_STAKING_STAKING_RPC_H
 
 #include <dependency.h>
 #include <rpc/server.h>
@@ -43,4 +43,4 @@ class StakingRPC {
 
 }  // namespace staking
 
-#endif  //UNIT_E_PROPOSER_RPC_H
+#endif  // UNITE_STAKING_STAKING_RPC_H

--- a/src/staking/stakingwallet.h
+++ b/src/staking/stakingwallet.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_STAKING_STAKINGWALLET_H
-#define UNIT_E_STAKING_STAKINGWALLET_H
+#ifndef UNITE_STAKING_STAKINGWALLET_H
+#define UNITE_STAKING_STAKINGWALLET_H
 
 #include <amount.h>
 #include <key.h>
@@ -68,4 +68,4 @@ class StakingWallet {
 
 }  // namespace staking
 
-#endif  // UNIT_E_STAKINGWALLET_H
+#endif  // UNITE_STAKINGWALLET_H

--- a/src/staking/transactionpicker.h
+++ b/src/staking/transactionpicker.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_STAKING_TRANSACTION_PICKER_H
-#define UNIT_E_STAKING_TRANSACTION_PICKER_H
+#ifndef UNITE_STAKING_TRANSACTIONPICKER_H
+#define UNITE_STAKING_TRANSACTIONPICKER_H
 
 #include <vector>
 
@@ -78,4 +78,4 @@ class TransactionPicker {
 
 }  // namespace staking
 
-#endif  // UNIT_E_STAKING_TRANSACTION_PICKER_H
+#endif  // UNITE_STAKING_TRANSACTIONPICKER_H

--- a/src/staking/validation_error.h
+++ b/src/staking/validation_error.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/MIT.
 
-#ifndef UNIT_E_STAKING_VALIDATION_ERROR_H
-#define UNIT_E_STAKING_VALIDATION_ERROR_H
+#ifndef UNITE_STAKING_VALIDATION_ERROR_H
+#define UNITE_STAKING_VALIDATION_ERROR_H
 
 #include <better-enums/enum.h>
 
@@ -72,4 +72,4 @@ bool CheckResult(const BlockValidationResult &result, CValidationState &state);
 
 }  // namespace staking
 
-#endif  //UNIT_E_VALIDATION_ERROR_H
+#endif  // UNITE_VALIDATION_ERROR_H

--- a/src/staking/validation_result.h
+++ b/src/staking/validation_result.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/MIT.
 
-#ifndef UNIT_E_STAKING_VALIDATION_RESULT_H
-#define UNIT_E_STAKING_VALIDATION_RESULT_H
+#ifndef UNITE_STAKING_VALIDATION_RESULT_H
+#define UNITE_STAKING_VALIDATION_RESULT_H
 
 #include <better-enums/enum_set.h>
 #include <blockchain/blockchain_types.h>
@@ -40,4 +40,4 @@ class BlockValidationResult {
 
 }  // namespace staking
 
-#endif  //UNIT_E_VALIDATION_RESULT_H
+#endif  // UNITE_VALIDATION_RESULT_H

--- a/src/sync_status.h
+++ b/src/sync_status.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_STATUS_H
-#define UNIT_E_STATUS_H
+#ifndef UNITE_SYNC_STATUS_H
+#define UNITE_SYNC_STATUS_H
 
 #include <better-enums/enum.h>
 
@@ -20,4 +20,4 @@ BETTER_ENUM(
 )
 // clang-format on
 
-#endif  // UNIT_E_STATUS_H
+#endif  // UNITE_SYNC_STATUS_H

--- a/src/test/esperanza/finalization_utils.h
+++ b/src/test/esperanza/finalization_utils.h
@@ -6,8 +6,8 @@
 #include <key.h>
 #include <primitives/transaction.h>
 
-#ifndef UNIT_E_TESTS_ESPERANZA_FINALIZATION_UTILS_H
-#define UNIT_E_TESTS_ESPERANZA_FINALIZATION_UTILS_H
+#ifndef UNITE_TEST_ESPERANZA_FINALIZATION_UTILS_H
+#define UNITE_TEST_ESPERANZA_FINALIZATION_UTILS_H
 
 CTransaction CreateVoteTx(const esperanza::Vote &vote, const CKey &spendable_key);
 
@@ -28,4 +28,4 @@ CTransaction CreateWithdrawTx(const CTransaction &spendable_tx,
 CTransaction CreateP2PKHTx(const CTransaction &spendable_tx,
                            const CKey &spendable_key, CAmount amount);
 
-#endif  // UNIT_E_TESTS_ESPERANZA_FINALIZATION_UTILS_H
+#endif  // UNITE_TEST_ESPERANZA_FINALIZATION_UTILS_H

--- a/src/test/esperanza/finalizationstate_utils.h
+++ b/src/test/esperanza/finalizationstate_utils.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_TESTS_FINALIZATIONSTATE_UTILS_H
-#define UNIT_E_TESTS_FINALIZATIONSTATE_UTILS_H
+#ifndef UNITE_TEST_ESPERANZA_FINALIZATIONSTATE_UTILS_H
+#define UNITE_TEST_ESPERANZA_FINALIZATIONSTATE_UTILS_H
 
 #include <esperanza/finalizationstate.h>
 #include <finalization/params.h>
@@ -70,4 +70,4 @@ uint160 RandValidatorAddr();
 CPubKey MakePubKey();
 esperanza::AdminKeySet MakeKeySet();
 
-#endif  //UNIT_E_TESTS_FINALIZATIONSTATE_UTILS_H
+#endif  // UNITE_TEST_ESPERANZA_FINALIZATIONSTATE_UTILS_H

--- a/src/test/rpc_test_utils.h
+++ b/src/test/rpc_test_utils.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_TEST_RPC_TEST_UTILS_H
-#define UNIT_E_TEST_RPC_TEST_UTILS_H
+#ifndef UNITE_TEST_RPC_TEST_UTILS_H
+#define UNITE_TEST_RPC_TEST_UTILS_H
 
 #include <rpc/protocol.h>
 #include <univalue.h>
@@ -21,4 +21,4 @@ UniValue CallRPC(std::string args);
 void AssertRPCError(std::string call, RPCErrorCode error,
                     const std::string &message = "");
 
-#endif // UNIT_E_TEST_RPC_TEST_UTILS_H
+#endif // UNITE_TEST_RPC_TEST_UTILS_H

--- a/src/test/test_unite_block_fixture.h
+++ b/src/test/test_unite_block_fixture.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_TEST_UNITE_BLOCK_FIXTURE_H
-#define UNIT_E_TEST_UNITE_BLOCK_FIXTURE_H
+#ifndef UNITE_TEST_TEST_UNITE_BLOCK_FIXTURE_H
+#define UNITE_TEST_TEST_UNITE_BLOCK_FIXTURE_H
 
 #include <primitives/block.h>
 
@@ -14,4 +14,4 @@ struct RealBlockFixture {
   RealBlockFixture();
 };
 
-#endif  //UNIT_E_TEST_UNITE_BLOCK_FIXTURE_H
+#endif  // UNITE_TEST_TEST_UNITE_BLOCK_FIXTURE_H

--- a/src/test/test_unite_mocks.h
+++ b/src/test/test_unite_mocks.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_TEST_UNITE_MOCKS_H
-#define UNIT_E_TEST_UNITE_MOCKS_H
+#ifndef UNITE_TEST_TEST_UNITE_MOCKS_H
+#define UNITE_TEST_TEST_UNITE_MOCKS_H
 
 #include <blockdb.h>
 #include <coins.h>
@@ -412,4 +412,4 @@ class BlockBuilderMock : public proposer::BlockBuilder, public Mock {
 
 }  // namespace mocks
 
-#endif  //UNIT_E_TEST_UNITE_MOCKS_H
+#endif  // UNITE_TEST_TEST_UNITE_MOCKS_H

--- a/src/test/util/blocktools.h
+++ b/src/test/util/blocktools.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_TEST_UTIL_BLOCKTOOLS_H
-#define UNIT_E_TEST_UTIL_BLOCKTOOLS_H
+#ifndef UNITE_TEST_UTIL_BLOCKTOOLS_H
+#define UNITE_TEST_UTIL_BLOCKTOOLS_H
 
 #include <test/test_unite_mocks.h>
 
@@ -70,4 +70,4 @@ struct BlockIndexFake {
 
 }  // namespace blocktools
 
-#endif  //UNIT_E_TEST_UTIL_BLOCKTOOLS_H
+#endif  // UNITE_TEST_UTIL_BLOCKTOOLS_H

--- a/src/test/util/mocks.h
+++ b/src/test/util/mocks.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_TEST_UTIL_MOCKS_H
-#define UNIT_E_TEST_UTIL_MOCKS_H
+#ifndef UNITE_TEST_UTIL_MOCKS_H
+#define UNITE_TEST_UTIL_MOCKS_H
 
 #include <sync.h>
 
@@ -206,4 +206,4 @@ class MethodMock<R (C::*)(Args...)> : public MethodMockImpl<R, Args...> {
 
 };  // namespace mocks
 
-#endif  //UNIT_E_TEST_UTIL_MOCKS_H
+#endif  // UNITE_TEST_UTIL_MOCKS_H

--- a/src/test/util/txtools.h
+++ b/src/test/util/txtools.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_TEST_UTIL_TXTOOLS_H
-#define UNIT_E_TEST_UTIL_TXTOOLS_H
+#ifndef UNITE_TEST_UTIL_TXTOOLS_H
+#define UNITE_TEST_UTIL_TXTOOLS_H
 
 #include <key.h>
 #include <keystore.h>
@@ -28,4 +28,4 @@ class TxTool {
 
 };
 
-#endif //UNIT_E_TEST_UTIL_TXTOOLS_H
+#endif // UNITE_TEST_UTIL_TXTOOLS_H

--- a/src/test/util/util.h
+++ b/src/test/util/util.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_TEST_UTIL_H
-#define UNIT_E_TEST_UTIL_H
+#ifndef UNITE_TEST_UTIL_UTIL_H
+#define UNITE_TEST_UTIL_UTIL_H
 
 #include <blockchain/blockchain_behavior.h>
 #include <blockchain/blockchain_types.h>
@@ -35,4 +35,4 @@ CBlock MinimalBlock(const KeyFixture &key_fixture = MakeKeyFixture());
 CBlock MinimalBlock(const std::function<void(CBlock &)>,
                     const KeyFixture &key_fixture = MakeKeyFixture());
 
-#endif  //UNIT_E_TEST_UTIL_H
+#endif  // UNITE_TEST_UTIL_UTIL_H

--- a/src/trit.h
+++ b/src/trit.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_TRIT_H
-#define UNIT_E_TRIT_H
+#ifndef UNITE_TRIT_H
+#define UNITE_TRIT_H
 
 #include <cstdint>
 
@@ -106,4 +106,4 @@ class Trit final {
 
 };
 
-#endif  //UNIT_E_TRIT_H
+#endif  // UNITE_TRIT_H

--- a/src/ufp64.h
+++ b/src/ufp64.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_UFP32_H
-#define UNIT_E_UFP32_H
+#ifndef UNITE_UFP64_H
+#define UNITE_UFP64_H
 
 #include <arith_uint256.h>
 #include <stdint.h>
@@ -48,4 +48,4 @@ ufp64_t to_ufp64(uint64_t x);
 std::string to_str(uint64_t x);
 } // namespace ufp64
 
-#endif //UNIT_E_UFP32_H
+#endif // UNITE_UFP64_H

--- a/src/utiltypetags.h
+++ b/src/utiltypetags.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_TYPETAGS_H
-#define UNIT_E_TYPETAGS_H
+#ifndef UNITE_UTILTYPETAGS_H
+#define UNITE_UTILTYPETAGS_H
 
 /*! \brief zero cost tagged types like Haskell's newtype
  *
@@ -28,4 +28,4 @@ private:
     impl m_value;
 };
 
-#endif //UNIT_E_TYPETAGS_H
+#endif // UNITE_UTILTYPETAGS_H

--- a/src/validation_flags.h
+++ b/src/validation_flags.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef UNIT_E_VALIDATION_FLAGS_H
-#define UNIT_E_VALIDATION_FLAGS_H
+#ifndef UNITE_VALIDATION_FLAGS_H
+#define UNITE_VALIDATION_FLAGS_H
 
 #include <utiltypetags.h>
 
@@ -97,4 +97,4 @@ static const Type SKIP_ELIGIBILITY_CHECK = Type(1 << 1);
 
 }  // namespace TestBlockValidityFlags
 
-#endif  //UNIT_E_VALIDATION_FLAGS_H
+#endif  // UNITE_VALIDATION_FLAGS_H

--- a/test/lint/lint-all.sh
+++ b/test/lint/lint-all.sh
@@ -21,6 +21,7 @@ SHELL_SCRIPTS=(
   lint-clang-format.py
   lint-filenames.sh
   lint-format-strings.sh
+  lint-include-guards.sh
   lint-includes.sh
   lint-locale-dependence.sh
   lint-logs.sh

--- a/test/lint/lint-include-guards.sh
+++ b/test/lint/lint-include-guards.sh
@@ -10,7 +10,16 @@ export LC_ALL=C
 HEADER_ID_PREFIX="UNITE_"
 HEADER_ID_SUFFIX="_H"
 
-REGEXP_EXCLUDE_FILES_WITH_PREFIX="src/(crypto/ctaes/|leveldb/|secp256k1/|tinyformat.h|univalue|usbdevice/)"
+REGEXP_EXCLUDE_FILES_WITH_PREFIX="src/(\
+better-enums/|\
+crypto/ctaes/|\
+key/mnemonic/|\
+leveldb/|\
+secp256k1/|\
+tinyformat.h|\
+unilib/|\
+univalue|\
+usbdevice/)"
 
 EXIT_CODE=0
 for HEADER_FILE in $(git ls-files -- "*.h" | grep -vE "^${REGEXP_EXCLUDE_FILES_WITH_PREFIX}")


### PR DESCRIPTION
* Make lint-include-guards.sh pass.
* Consistently use the `UNITE_` prefix everywhere as this is the
  dominant form and what clonemachine creates right now.
* Add lint-include-guards.sh to lint-all.sh

Signed-off-by: Cornelius Schumacher <cornelius@thirdhash.com>
