### PR TITLE
Print full command when running node

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -335,7 +335,6 @@ class UnitETestFramework(metaclass=UnitETestMetaClass):
         assert_equal(len(extra_args), num_nodes)
         assert_equal(len(binary), num_nodes)
         for i in range(num_nodes):
-            print("Starting node " + str(i) + " with args: " + ' '.join(str(e) for e in extra_args[i]))
             self.nodes.append(TestNode(i, get_datadir_path(self.options.tmpdir, i), rpchost=rpchost, timewait=self.rpc_timewait, unit_e=binary[i], unit_e_cli=self.options.unit_e_cli, mocktime=self.mocktime, coverage_dir=self.options.coveragedir, extra_conf=extra_confs[i], extra_args=extra_args[i], use_cli=self.options.usecli))
 
     def start_node(self, i, *args, **kwargs):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -84,6 +84,9 @@ class TestNode():
             "-mocktime=" + str(mocktime),
             "-uacomment=testnode%d" % i
         ]
+        print("Starting node " + str(i) + " with command: "
+              + ' '.join(str(e) for e in self.args)
+              + ' '.join(str(e) for e in extra_args))
 
         self.cli = TestNodeCLI(unit_e_cli, self.datadir)
         self.use_cli = use_cli

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -84,7 +84,7 @@ class TestNode():
             "-mocktime=" + str(mocktime),
             "-uacomment=testnode%d" % i
         ]
-        print("Starting node " + str(i) + " with command: "
+        print("Initiating node " + str(i) + " with command: "
               + ' '.join(str(e) for e in self.args)
               + ' '.join(str(e) for e in extra_args))
 


### PR DESCRIPTION
This PR makes the logs from the functional tests print the full command used to run the node and not just the `extra_args`.